### PR TITLE
fs: add host-backed compatibility adapter

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -455,6 +455,7 @@ Important properties:
 - the default backend is in-memory
 - the default backend exposes a Unix-like virtual layout rooted at `/`
 - host-backed filesystems, if ever added, must still satisfy policy checks and must never imply host command execution
+- developer-only test harnesses may use a host-backed filesystem adapter, but that adapter is not the default runtime backend and does not change the no-host-command-execution rule
 - shell redirects and command file access share the same filesystem view
 - symlink support is optional and must default to the safer behavior when policy is ambiguous
 - for backends without symlink creation/traversal support, `Lstat` behaves like `Stat`, `Readlink` fails for non-symlinks, and `Realpath` resolves only existing virtual paths

--- a/internal/compatfs/hostfs_posix.go
+++ b/internal/compatfs/hostfs_posix.go
@@ -1,0 +1,131 @@
+//go:build !windows
+
+package compatfs
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	jbfs "github.com/ewhauser/jbgo/fs"
+)
+
+type HostFS struct {
+	mu  sync.RWMutex
+	cwd string
+}
+
+func New() (*HostFS, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	return &HostFS{cwd: filepath.Clean(cwd)}, nil
+}
+
+func (h *HostFS) Open(_ context.Context, name string) (jbfs.File, error) {
+	return h.OpenFile(context.Background(), name, os.O_RDONLY, 0)
+}
+
+func (h *HostFS) OpenFile(_ context.Context, name string, flag int, perm fs.FileMode) (jbfs.File, error) {
+	return os.OpenFile(h.resolve(name), flag, perm)
+}
+
+func (h *HostFS) Stat(_ context.Context, name string) (fs.FileInfo, error) {
+	return os.Stat(h.resolve(name))
+}
+
+func (h *HostFS) Lstat(_ context.Context, name string) (fs.FileInfo, error) {
+	return os.Lstat(h.resolve(name))
+}
+
+func (h *HostFS) ReadDir(_ context.Context, name string) ([]fs.DirEntry, error) {
+	return os.ReadDir(h.resolve(name))
+}
+
+func (h *HostFS) Readlink(_ context.Context, name string) (string, error) {
+	target, err := os.Readlink(h.resolve(name))
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(target), nil
+}
+
+func (h *HostFS) Realpath(_ context.Context, name string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(h.resolve(name))
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(resolved), nil
+}
+
+func (h *HostFS) Symlink(_ context.Context, target, linkName string) error {
+	return os.Symlink(target, h.resolve(linkName))
+}
+
+func (h *HostFS) Link(_ context.Context, oldName, newName string) error {
+	return os.Link(h.resolve(oldName), h.resolve(newName))
+}
+
+func (h *HostFS) Chmod(_ context.Context, name string, mode fs.FileMode) error {
+	return os.Chmod(h.resolve(name), mode)
+}
+
+func (h *HostFS) Chtimes(_ context.Context, name string, atime, mtime time.Time) error {
+	return os.Chtimes(h.resolve(name), atime, mtime)
+}
+
+func (h *HostFS) MkdirAll(_ context.Context, name string, perm fs.FileMode) error {
+	return os.MkdirAll(h.resolve(name), perm)
+}
+
+func (h *HostFS) Remove(_ context.Context, name string, recursive bool) error {
+	resolved := h.resolve(name)
+	if recursive {
+		return os.RemoveAll(resolved)
+	}
+	return os.Remove(resolved)
+}
+
+func (h *HostFS) Rename(_ context.Context, oldName, newName string) error {
+	return os.Rename(h.resolve(oldName), h.resolve(newName))
+}
+
+func (h *HostFS) Getwd() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return filepath.ToSlash(h.cwd)
+}
+
+func (h *HostFS) Chdir(name string) error {
+	resolved := h.resolve(name)
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return &os.PathError{Op: "chdir", Path: resolved, Err: fs.ErrInvalid}
+	}
+	h.mu.Lock()
+	h.cwd = filepath.Clean(resolved)
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *HostFS) resolve(name string) string {
+	converted := filepath.FromSlash(name)
+	if filepath.IsAbs(converted) {
+		return filepath.Clean(converted)
+	}
+
+	h.mu.RLock()
+	cwd := h.cwd
+	h.mu.RUnlock()
+	if cwd == "" {
+		cwd = string(os.PathSeparator)
+	}
+	return filepath.Clean(filepath.Join(cwd, converted))
+}

--- a/internal/compatfs/hostfs_posix_test.go
+++ b/internal/compatfs/hostfs_posix_test.go
@@ -1,0 +1,90 @@
+//go:build !windows
+
+package compatfs
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHostFSReadsWritesAndResolvesSymlinks(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	fsys, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	file, err := fsys.OpenFile(context.Background(), "note.txt", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	if _, err := io.WriteString(file, "hello\n"); err != nil {
+		t.Fatalf("WriteString() error = %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	if err := fsys.MkdirAll(context.Background(), "sub", 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := fsys.Rename(context.Background(), "note.txt", "sub/note.txt"); err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+	if err := fsys.Symlink(context.Background(), "sub/note.txt", "link.txt"); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	entries, err := fsys.ReadDir(context.Background(), "sub")
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "note.txt" {
+		t.Fatalf("ReadDir() = %#v, want single note.txt entry", entries)
+	}
+
+	target, err := fsys.Readlink(context.Background(), "link.txt")
+	if err != nil {
+		t.Fatalf("Readlink() error = %v", err)
+	}
+	if got, want := target, "sub/note.txt"; got != want {
+		t.Fatalf("Readlink() = %q, want %q", got, want)
+	}
+
+	resolved, err := fsys.Realpath(context.Background(), "link.txt")
+	if err != nil {
+		t.Fatalf("Realpath() error = %v", err)
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(tmpDirFromFS(t, fsys))
+	if err != nil {
+		t.Fatalf("EvalSymlinks() error = %v", err)
+	}
+	wantResolved := filepath.ToSlash(filepath.Join(canonicalRoot, "sub", "note.txt"))
+	if resolved != wantResolved {
+		t.Fatalf("Realpath() = %q, want %q", resolved, wantResolved)
+	}
+
+	reader, err := fsys.Open(context.Background(), "sub/note.txt")
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("Close(reader) error = %v", err)
+	}
+	if got, want := string(data), "hello\n"; got != want {
+		t.Fatalf("contents = %q, want %q", got, want)
+	}
+}
+
+func tmpDirFromFS(t *testing.T, fsys *HostFS) string {
+	t.Helper()
+	return filepath.FromSlash(fsys.Getwd())
+}

--- a/internal/compatfs/hostfs_windows.go
+++ b/internal/compatfs/hostfs_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package compatfs
+
+import "errors"
+
+var errUnsupported = errors.New("host compatibility filesystem is unsupported on Windows")
+
+type HostFS struct{}
+
+func New() (*HostFS, error) {
+	return nil, errUnsupported
+}


### PR DESCRIPTION
## Summary
- add an internal host-backed filesystem adapter for developer-only compatibility/test harnesses
- keep the default runtime backend unchanged
- document the narrow SPEC allowance for opt-in host-backed adapters

## Testing
- go test ./internal/compatfs