### PR TITLE
Add dirty parity followups for command compatibility

### DIFF
--- a/commands/head.go
+++ b/commands/head.go
@@ -20,19 +20,26 @@ func (c *Head) Run(ctx context.Context, inv *Invocation) error {
 	if err != nil {
 		return err
 	}
+	process := func(data []byte) []byte {
+		if opts.hasBytes {
+			return firstBytes(data, opts.bytes)
+		}
+		return firstLines(data, opts.lines)
+	}
 
 	if len(opts.files) == 0 {
 		data, err := readAllStdin(inv)
 		if err != nil {
 			return err
 		}
-		_, err = inv.Stdout.Write(firstLines(data, opts.lines))
+		_, err = inv.Stdout.Write(process(data))
 		if err != nil {
 			return &ExitError{Code: 1, Err: err}
 		}
 		return nil
 	}
 
+	showHeaders := opts.verbose || (!opts.quiet && len(opts.files) > 1)
 	exitCode := 0
 	for i, file := range opts.files {
 		data, _, err := readAllFile(ctx, inv, file)
@@ -41,7 +48,7 @@ func (c *Head) Run(ctx context.Context, inv *Invocation) error {
 			exitCode = 1
 			continue
 		}
-		if len(opts.files) > 1 {
+		if showHeaders {
 			if i > 0 {
 				_, _ = fmt.Fprintln(inv.Stdout)
 			}
@@ -49,7 +56,7 @@ func (c *Head) Run(ctx context.Context, inv *Invocation) error {
 				return &ExitError{Code: 1, Err: err}
 			}
 		}
-		if _, err := inv.Stdout.Write(firstLines(data, opts.lines)); err != nil {
+		if _, err := inv.Stdout.Write(process(data)); err != nil {
 			return &ExitError{Code: 1, Err: err}
 		}
 	}

--- a/commands/head_tail.go
+++ b/commands/head_tail.go
@@ -9,7 +9,11 @@ import (
 
 type headTailOptions struct {
 	lines    int
+	bytes    int
+	hasBytes bool
 	fromLine bool
+	quiet    bool
+	verbose  bool
 	files    []string
 }
 
@@ -20,7 +24,7 @@ func parseHeadTailArgs(inv *Invocation, cmdName string, allowFromLine bool) (hea
 	for len(args) > 0 {
 		arg := args[0]
 		switch {
-		case arg == "-n":
+		case arg == "-n" || arg == "--lines":
 			if len(args) < 2 {
 				return headTailOptions{}, exitf(inv, 1, "%s: missing argument to -n", cmdName)
 			}
@@ -31,6 +35,33 @@ func parseHeadTailArgs(inv *Invocation, cmdName string, allowFromLine bool) (hea
 			opts.lines = count
 			opts.fromLine = fromLine
 			args = args[2:]
+		case strings.HasPrefix(arg, "--lines="):
+			count, err := strconv.Atoi(strings.TrimPrefix(arg, "--lines="))
+			if err != nil || count < 0 {
+				return headTailOptions{}, exitf(inv, 1, "%s: invalid number of lines", cmdName)
+			}
+			opts.lines = count
+			opts.fromLine = false
+			args = args[1:]
+		case arg == "-c" || arg == "--bytes":
+			if len(args) < 2 {
+				return headTailOptions{}, exitf(inv, 1, "%s: missing argument to -c", cmdName)
+			}
+			count, err := strconv.Atoi(args[1])
+			if err != nil || count < 0 {
+				return headTailOptions{}, exitf(inv, 1, "%s: invalid number of bytes", cmdName)
+			}
+			opts.bytes = count
+			opts.hasBytes = true
+			args = args[2:]
+		case strings.HasPrefix(arg, "--bytes="):
+			count, err := strconv.Atoi(strings.TrimPrefix(arg, "--bytes="))
+			if err != nil || count < 0 {
+				return headTailOptions{}, exitf(inv, 1, "%s: invalid number of bytes", cmdName)
+			}
+			opts.bytes = count
+			opts.hasBytes = true
+			args = args[1:]
 		case strings.HasPrefix(arg, "-n"):
 			count, fromLine, err := parseHeadTailCount(strings.TrimPrefix(arg, "-n"), allowFromLine)
 			if err != nil {
@@ -38,6 +69,20 @@ func parseHeadTailArgs(inv *Invocation, cmdName string, allowFromLine bool) (hea
 			}
 			opts.lines = count
 			opts.fromLine = fromLine
+			args = args[1:]
+		case strings.HasPrefix(arg, "-c"):
+			count, err := strconv.Atoi(strings.TrimPrefix(arg, "-c"))
+			if err != nil || count < 0 {
+				return headTailOptions{}, exitf(inv, 1, "%s: invalid number of bytes", cmdName)
+			}
+			opts.bytes = count
+			opts.hasBytes = true
+			args = args[1:]
+		case arg == "-q" || arg == "--quiet" || arg == "--silent":
+			opts.quiet = true
+			args = args[1:]
+		case arg == "-v" || arg == "--verbose":
+			opts.verbose = true
 			args = args[1:]
 		case len(arg) > 1 && arg[0] == '-' && arg[1] >= '0' && arg[1] <= '9':
 			count, err := strconv.Atoi(arg[1:])
@@ -112,4 +157,24 @@ func linesFrom(data []byte, startLine int) []byte {
 		return nil
 	}
 	return bytes.Join(lines[startLine-1:], nil)
+}
+
+func firstBytes(data []byte, count int) []byte {
+	if count <= 0 {
+		return nil
+	}
+	if count > len(data) {
+		count = len(data)
+	}
+	return append([]byte(nil), data[:count]...)
+}
+
+func lastBytes(data []byte, count int) []byte {
+	if count <= 0 {
+		return nil
+	}
+	if count > len(data) {
+		count = len(data)
+	}
+	return append([]byte(nil), data[len(data)-count:]...)
 }

--- a/commands/split.go
+++ b/commands/split.go
@@ -13,10 +13,12 @@ import (
 type Split struct{}
 
 type splitOptions struct {
-	lines     int
-	bytes     int
-	numeric   bool
-	suffixLen int
+	lines            int
+	bytes            int
+	chunks           int
+	numeric          bool
+	suffixLen        int
+	additionalSuffix string
 }
 
 func NewSplit() *Split {
@@ -49,6 +51,9 @@ func (c *Split) Run(ctx context.Context, inv *Invocation) error {
 	chunks := splitData(data, opts)
 	for i, chunk := range chunks {
 		target := jbfs.Resolve(inv.Dir, prefix+splitSuffix(i, opts))
+		if opts.additionalSuffix != "" {
+			target += opts.additionalSuffix
+		}
 		if err := writeFileContents(ctx, inv, target, chunk, stdfs.FileMode(0o644)); err != nil {
 			return err
 		}
@@ -109,6 +114,27 @@ func parseSplitArgs(inv *Invocation) (opts splitOptions, inputName, prefix strin
 			opts.lines = 0
 		case arg == "-d":
 			opts.numeric = true
+		case arg == "-n":
+			value, rest, err := parseSplitInt(inv, "n", args[1:])
+			if err != nil {
+				return splitOptions{}, "", "", err
+			}
+			if value <= 0 {
+				return splitOptions{}, "", "", exitf(inv, 1, "split: invalid chunk count %d", value)
+			}
+			opts.chunks = value
+			opts.lines = 0
+			opts.bytes = 0
+			args = rest
+			continue
+		case strings.HasPrefix(arg, "-n") && len(arg) > 2:
+			value, err := strconv.Atoi(arg[2:])
+			if err != nil || value <= 0 {
+				return splitOptions{}, "", "", exitf(inv, 1, "split: invalid chunk count %q", arg[2:])
+			}
+			opts.chunks = value
+			opts.lines = 0
+			opts.bytes = 0
 		case arg == "-a":
 			value, rest, err := parseSplitInt(inv, "a", args[1:])
 			if err != nil {
@@ -120,6 +146,15 @@ func parseSplitArgs(inv *Invocation) (opts splitOptions, inputName, prefix strin
 			opts.suffixLen = value
 			args = rest
 			continue
+		case arg == "--additional-suffix":
+			if len(args) < 2 {
+				return splitOptions{}, "", "", exitf(inv, 1, "split: option requires an argument -- additional-suffix")
+			}
+			opts.additionalSuffix = args[1]
+			args = args[2:]
+			continue
+		case strings.HasPrefix(arg, "--additional-suffix="):
+			opts.additionalSuffix = strings.TrimPrefix(arg, "--additional-suffix=")
 		case strings.HasPrefix(arg, "-a") && len(arg) > 2:
 			value, err := strconv.Atoi(arg[2:])
 			if err != nil || value <= 0 {
@@ -182,6 +217,19 @@ func parseSplitSize(value string) (int, error) {
 func splitData(data []byte, opts splitOptions) [][]byte {
 	if len(data) == 0 {
 		return nil
+	}
+	if opts.chunks > 0 {
+		var chunks [][]byte
+		chunkSize := (len(data) + opts.chunks - 1) / opts.chunks
+		for start := 0; start < len(data); start += chunkSize {
+			end := start + chunkSize
+			if end > len(data) {
+				end = len(data)
+			}
+			chunk := append([]byte(nil), data[start:end]...)
+			chunks = append(chunks, chunk)
+		}
+		return chunks
 	}
 	if opts.bytes > 0 {
 		var chunks [][]byte

--- a/commands/sqlite3.go
+++ b/commands/sqlite3.go
@@ -22,12 +22,18 @@ import (
 type sqliteOutputMode string
 
 const (
-	sqliteModeList   sqliteOutputMode = "list"
-	sqliteModeCSV    sqliteOutputMode = "csv"
-	sqliteModeJSON   sqliteOutputMode = "json"
-	sqliteModeLine   sqliteOutputMode = "line"
-	sqliteModeColumn sqliteOutputMode = "column"
-	sqliteModeTable  sqliteOutputMode = "table"
+	sqliteModeList     sqliteOutputMode = "list"
+	sqliteModeCSV      sqliteOutputMode = "csv"
+	sqliteModeJSON     sqliteOutputMode = "json"
+	sqliteModeLine     sqliteOutputMode = "line"
+	sqliteModeColumn   sqliteOutputMode = "column"
+	sqliteModeTable    sqliteOutputMode = "table"
+	sqliteModeMarkdown sqliteOutputMode = "markdown"
+	sqliteModeTabs     sqliteOutputMode = "tabs"
+	sqliteModeBox      sqliteOutputMode = "box"
+	sqliteModeQuote    sqliteOutputMode = "quote"
+	sqliteModeHTML     sqliteOutputMode = "html"
+	sqliteModeASCII    sqliteOutputMode = "ascii"
 )
 
 type sqliteOptions struct {
@@ -217,6 +223,18 @@ func parseSQLiteArgs(inv *Invocation) (parsed sqliteParsedArgs, err error) {
 			parsed.options.mode = sqliteModeColumn
 		case "-table":
 			parsed.options.mode = sqliteModeTable
+		case "-markdown":
+			parsed.options.mode = sqliteModeMarkdown
+		case "-tabs":
+			parsed.options.mode = sqliteModeTabs
+		case "-box":
+			parsed.options.mode = sqliteModeBox
+		case "-quote":
+			parsed.options.mode = sqliteModeQuote
+		case "-html":
+			parsed.options.mode = sqliteModeHTML
+		case "-ascii":
+			parsed.options.mode = sqliteModeASCII
 		case "-header":
 			parsed.options.header = true
 		case "-noheader":
@@ -522,6 +540,18 @@ func formatSQLiteResult(opts *sqliteOptions, result *sqliteStatementResult) ([]b
 		return formatSQLiteColumn(opts, result, false), nil
 	case sqliteModeTable:
 		return formatSQLiteColumn(opts, result, true), nil
+	case sqliteModeMarkdown:
+		return formatSQLiteMarkdown(opts, result), nil
+	case sqliteModeTabs:
+		return formatSQLiteTabs(opts, result), nil
+	case sqliteModeBox:
+		return formatSQLiteBox(opts, result), nil
+	case sqliteModeQuote:
+		return formatSQLiteQuote(opts, result), nil
+	case sqliteModeHTML:
+		return formatSQLiteHTML(opts, result), nil
+	case sqliteModeASCII:
+		return formatSQLiteASCII(opts, result), nil
 	default:
 		return formatSQLiteList(opts, result), nil
 	}
@@ -674,6 +704,162 @@ func formatSQLiteColumn(opts *sqliteOptions, result *sqliteStatementResult, tabl
 	return buf.Bytes()
 }
 
+func formatSQLiteMarkdown(opts *sqliteOptions, result *sqliteStatementResult) []byte {
+	if len(result.Rows) == 0 && (!opts.header || len(result.Columns) == 0) {
+		return nil
+	}
+	var buf bytes.Buffer
+	if opts.header && len(result.Columns) > 0 {
+		buf.WriteString("| ")
+		buf.WriteString(strings.Join(result.Columns, " | "))
+		buf.WriteString(" |\n|")
+		for i := range result.Columns {
+			if i > 0 {
+				buf.WriteByte('|')
+			}
+			buf.WriteString("---")
+		}
+		buf.WriteString("|\n")
+	}
+	for _, row := range result.Rows {
+		values := make([]string, len(row))
+		for i, value := range row {
+			values[i] = sqliteStringValue(value, opts.nullValue)
+		}
+		buf.WriteString("| ")
+		buf.WriteString(strings.Join(values, " | "))
+		buf.WriteString(" |\n")
+	}
+	return buf.Bytes()
+}
+
+func formatSQLiteTabs(opts *sqliteOptions, result *sqliteStatementResult) []byte {
+	if len(result.Rows) == 0 && (!opts.header || len(result.Columns) == 0) {
+		return nil
+	}
+	var buf bytes.Buffer
+	if opts.header && len(result.Columns) > 0 {
+		buf.WriteString(strings.Join(result.Columns, "\t"))
+		buf.WriteString(opts.newline)
+	}
+	for _, row := range result.Rows {
+		values := make([]string, len(row))
+		for i, value := range row {
+			values[i] = sqliteStringValue(value, opts.nullValue)
+		}
+		buf.WriteString(strings.Join(values, "\t"))
+		buf.WriteString(opts.newline)
+	}
+	return buf.Bytes()
+}
+
+func formatSQLiteBox(opts *sqliteOptions, result *sqliteStatementResult) []byte {
+	if len(result.Columns) == 0 {
+		return nil
+	}
+
+	widths := make([]int, len(result.Columns))
+	for i, name := range result.Columns {
+		widths[i] = len(name)
+	}
+	for _, row := range result.Rows {
+		for i, value := range row {
+			text := sqliteStringValue(value, opts.nullValue)
+			if len(text) > widths[i] {
+				widths[i] = len(text)
+			}
+		}
+	}
+
+	var buf bytes.Buffer
+	writeSQLiteUnicodeBorder(&buf, widths, "┌", "┬", "┐")
+	writeSQLiteUnicodeRow(&buf, result.Columns, widths)
+	writeSQLiteUnicodeBorder(&buf, widths, "├", "┼", "┤")
+	for _, row := range result.Rows {
+		record := make([]string, len(row))
+		for i, value := range row {
+			record[i] = sqliteStringValue(value, opts.nullValue)
+		}
+		writeSQLiteUnicodeRow(&buf, record, widths)
+	}
+	writeSQLiteUnicodeBorder(&buf, widths, "└", "┴", "┘")
+	return buf.Bytes()
+}
+
+func formatSQLiteQuote(opts *sqliteOptions, result *sqliteStatementResult) []byte {
+	if len(result.Rows) == 0 && (!opts.header || len(result.Columns) == 0) {
+		return nil
+	}
+	var buf bytes.Buffer
+	if opts.header && len(result.Columns) > 0 {
+		values := make([]string, len(result.Columns))
+		for i, name := range result.Columns {
+			values[i] = sqliteQuoteString(name)
+		}
+		buf.WriteString(strings.Join(values, ","))
+		buf.WriteString(opts.newline)
+	}
+	for _, row := range result.Rows {
+		values := make([]string, len(row))
+		for i, value := range row {
+			values[i] = sqliteQuoteValue(value)
+		}
+		buf.WriteString(strings.Join(values, ","))
+		buf.WriteString(opts.newline)
+	}
+	return buf.Bytes()
+}
+
+func formatSQLiteHTML(opts *sqliteOptions, result *sqliteStatementResult) []byte {
+	if len(result.Rows) == 0 && (!opts.header || len(result.Columns) == 0) {
+		return nil
+	}
+	var buf bytes.Buffer
+	if opts.header && len(result.Columns) > 0 {
+		buf.WriteString("<TR>")
+		for _, name := range result.Columns {
+			buf.WriteString("<TH>")
+			buf.WriteString(sqliteEscapeHTML(name))
+			buf.WriteString("</TH>")
+		}
+		buf.WriteString("\n</TR>\n")
+	}
+	for _, row := range result.Rows {
+		buf.WriteString("<TR>")
+		for _, value := range row {
+			buf.WriteString("<TD>")
+			buf.WriteString(sqliteEscapeHTML(sqliteStringValue(value, opts.nullValue)))
+			buf.WriteString("</TD>")
+		}
+		buf.WriteString("\n</TR>\n")
+	}
+	return buf.Bytes()
+}
+
+func formatSQLiteASCII(opts *sqliteOptions, result *sqliteStatementResult) []byte {
+	if len(result.Rows) == 0 && (!opts.header || len(result.Columns) == 0) {
+		return nil
+	}
+	const (
+		colSep = "\x1f"
+		rowSep = "\x1e"
+	)
+	var buf bytes.Buffer
+	if opts.header && len(result.Columns) > 0 {
+		buf.WriteString(strings.Join(result.Columns, colSep))
+		buf.WriteString(rowSep)
+	}
+	for _, row := range result.Rows {
+		values := make([]string, len(row))
+		for i, value := range row {
+			values[i] = sqliteStringValue(value, opts.nullValue)
+		}
+		buf.WriteString(strings.Join(values, colSep))
+		buf.WriteString(rowSep)
+	}
+	return buf.Bytes()
+}
+
 func writeSQLiteRow(buf *bytes.Buffer, values []string, widths []int, table bool) {
 	if table {
 		buf.WriteString("| ")
@@ -706,6 +892,32 @@ func writeSQLiteBorder(buf *bytes.Buffer, widths []int, fill byte) {
 	buf.WriteByte('\n')
 }
 
+func writeSQLiteUnicodeRow(buf *bytes.Buffer, values []string, widths []int) {
+	buf.WriteString("│ ")
+	for i, value := range values {
+		if i > 0 {
+			buf.WriteString(" │ ")
+		}
+		buf.WriteString(value)
+		if widths[i] > len(value) {
+			buf.WriteString(strings.Repeat(" ", widths[i]-len(value)))
+		}
+	}
+	buf.WriteString(" │\n")
+}
+
+func writeSQLiteUnicodeBorder(buf *bytes.Buffer, widths []int, left, middle, right string) {
+	buf.WriteString(left)
+	for i, width := range widths {
+		if i > 0 {
+			buf.WriteString(middle)
+		}
+		buf.WriteString(strings.Repeat("─", width+2))
+	}
+	buf.WriteString(right)
+	buf.WriteByte('\n')
+}
+
 func sqliteStringValue(value any, nullValue string) string {
 	switch v := value.(type) {
 	case nil:
@@ -715,10 +927,41 @@ func sqliteStringValue(value any, nullValue string) string {
 	case int64:
 		return strconv.FormatInt(v, 10)
 	case float64:
-		return strconv.FormatFloat(v, 'g', -1, 64)
+		return sqliteFloatString(v)
 	default:
 		return fmt.Sprint(v)
 	}
+}
+
+func sqliteQuoteString(value string) string {
+	return "'" + value + "'"
+}
+
+func sqliteQuoteValue(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return "NULL"
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case float64:
+		return sqliteFloatString(v)
+	default:
+		return sqliteQuoteString(fmt.Sprint(v))
+	}
+}
+
+func sqliteFloatString(value float64) string {
+	return strconv.FormatFloat(value, 'g', 17, 64)
+}
+
+func sqliteEscapeHTML(value string) string {
+	replacer := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+	)
+	return replacer.Replace(value)
 }
 
 func sqliteForbiddenStatement(sql string) string {

--- a/commands/tail.go
+++ b/commands/tail.go
@@ -22,6 +22,9 @@ func (c *Tail) Run(ctx context.Context, inv *Invocation) error {
 	}
 
 	process := func(data []byte) []byte {
+		if opts.hasBytes {
+			return lastBytes(data, opts.bytes)
+		}
 		if opts.fromLine {
 			return linesFrom(data, opts.lines)
 		}
@@ -40,6 +43,7 @@ func (c *Tail) Run(ctx context.Context, inv *Invocation) error {
 		return nil
 	}
 
+	showHeaders := opts.verbose || (!opts.quiet && len(opts.files) > 1)
 	exitCode := 0
 	for i, file := range opts.files {
 		data, _, err := readAllFile(ctx, inv, file)
@@ -48,7 +52,7 @@ func (c *Tail) Run(ctx context.Context, inv *Invocation) error {
 			exitCode = 1
 			continue
 		}
-		if len(opts.files) > 1 {
+		if showHeaders {
 			if i > 0 {
 				_, _ = fmt.Fprintln(inv.Stdout)
 			}

--- a/runtime/cut_sed_test.go
+++ b/runtime/cut_sed_test.go
@@ -40,6 +40,23 @@ func TestCutSupportsCharactersAndSuppressNoDelimiter(t *testing.T) {
 	}
 }
 
+func TestCutSupportsLongOnlyDelimitedFlag(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 'left:right\\nplain\\n' > /tmp/in.txt\ncut --only-delimited -d: -f2 /tmp/in.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "right\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
 func TestCutRequiresFieldOrCharacterSelector(t *testing.T) {
 	rt := newRuntime(t, &Config{})
 
@@ -122,5 +139,22 @@ func TestSedReturnsMissingFileError(t *testing.T) {
 	}
 	if !strings.Contains(result.Stderr, "/missing.txt") {
 		t.Fatalf("Stderr = %q, want missing-file error", result.Stderr)
+	}
+}
+
+func TestSedSupportsScriptFileFlag(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 's/foo/bar/\\n2p\\n' > /tmp/script.sed\nprintf 'foo\\nfoo\\n' > /tmp/in.txt\nsed -f /tmp/script.sed /tmp/in.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "bar\nbar\nbar\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }

--- a/runtime/file_commands_test.go
+++ b/runtime/file_commands_test.go
@@ -55,6 +55,23 @@ func TestCPRejectsDirectoryWithoutRecursiveFlag(t *testing.T) {
 	}
 }
 
+func TestCPSupportsNoClobberPreserveAndVerbose(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	setup := mustExecSession(t, session, "echo new > /src.txt\necho old > /dst.txt\n")
+	if setup.ExitCode != 0 {
+		t.Fatalf("setup ExitCode = %d, want 0", setup.ExitCode)
+	}
+
+	result := mustExecSession(t, session, "cp --no-clobber --preserve --verbose /src.txt /dst.txt\ncat /dst.txt\ncp -pv /src.txt /fresh.txt\ncat /fresh.txt\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "old\n'/src.txt' -> '/fresh.txt'\nnew\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
 func TestMVCanMoveDirectoryIntoExistingDirectory(t *testing.T) {
 	session := newSession(t, &Config{})
 
@@ -120,6 +137,23 @@ func TestMVRejectsMissingSource(t *testing.T) {
 	}
 	if !strings.Contains(result.Stderr, "cannot stat") {
 		t.Fatalf("Stderr = %q, want missing-source error", result.Stderr)
+	}
+}
+
+func TestMVSupportsNoClobberVerboseAndMovingFileIntoDirectory(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	setup := mustExecSession(t, session, "mkdir -p /dst\necho src > /src.txt\necho keep > /dst/src.txt\necho move > /move.txt\n")
+	if setup.ExitCode != 0 {
+		t.Fatalf("setup ExitCode = %d, want 0", setup.ExitCode)
+	}
+
+	result := mustExecSession(t, session, "mv --no-clobber /src.txt /dst/src.txt\ncat /dst/src.txt\nmv -v /move.txt /dst\ncat /dst/move.txt\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "keep\nrenamed '/move.txt' -> '/dst/move.txt'\nmove\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }
 

--- a/runtime/fuzz_command_targets_test.go
+++ b/runtime/fuzz_command_targets_test.go
@@ -35,7 +35,7 @@ func FuzzFilePathCommands(f *testing.F) {
 		writeSessionFile(t, session, inputPath, data)
 
 		script := []byte(fmt.Sprintf(
-			"touch %s\ncp %s %s\nmv %s %s\nln -s -f %s %s\nreadlink %s >/tmp/readlink.out\nstat %s >/tmp/stat.out\nbasename %s >/tmp/base.out\ndirname %s >/tmp/dir.out\nchmod 600 %s\nmkdir -p /tmp/fuzz-empty/sub\nrmdir /tmp/fuzz-empty/sub\nfile -b %s >/tmp/file.out\nrm %s %s %s\n",
+			"touch %s\ncp -pv %s %s\nmv -v %s %s\nln -s -f %s %s\nreadlink %s >/tmp/readlink.out\nstat %s >/tmp/stat.out\nbasename --suffix=.moved %s >/tmp/base.out\ndirname %s >/tmp/dir.out\nchmod 600 %s\nmkdir -p /tmp/fuzz-empty/sub\nrmdir /tmp/fuzz-empty/sub\nfile --brief %s >/tmp/file.out\nrm %s %s %s\n",
 			shellQuote(inputPath),
 			shellQuote(inputPath),
 			shellQuote(copyPath),
@@ -128,14 +128,13 @@ func FuzzTextSearchCommands(f *testing.F) {
 		writeSessionFile(t, session, otherPath, []byte(strings.ToUpper(string(text))))
 
 		script := []byte(fmt.Sprintf(
-			"sort %s >/tmp/sort.txt || true\nuniq /tmp/sort.txt >/tmp/uniq.txt || true\ncut -c 1-8 %s >/tmp/cut.txt || true\nsed -n '1,3p' %s >/tmp/sed.txt || true\ngrep -n %s %s >/tmp/grep.txt || true\nrg -n %s /tmp >/tmp/rg.txt || true\nawk '{print NF}' %s >/tmp/awk.txt || true\nhead -n 3 %s >/tmp/head.txt || true\ntail -n 3 %s >/tmp/tail.txt || true\nwc %s >/tmp/wc.txt\ntr 'a-z' 'A-Z' < %s >/tmp/tr.txt || true\nrev %s >/tmp/rev.txt || true\nnl -ba %s >/tmp/nl.txt || true\ntac %s >/tmp/tac.txt || true\nsplit -l 2 %s /tmp/split- || true\npaste %s %s >/tmp/paste.txt || true\ncomm -12 /tmp/sort.txt /tmp/sort.txt >/tmp/comm.txt || true\njoin %s %s >/tmp/join.txt || true\ndiff -u %s %s >/tmp/diff.txt || true\nbase64 %s | base64 -d >/tmp/base64.txt || true\n",
+			"printf '1,3p\\n' >/tmp/sed.fuzz\nsort %s >/tmp/sort.txt || true\nuniq --ignore-case /tmp/sort.txt >/tmp/uniq.txt || true\ncut --only-delimited -c 1-8 %s >/tmp/cut.txt || true\nsed -f /tmp/sed.fuzz %s >/tmp/sed.txt || true\ngrep -n %s %s >/tmp/grep.txt || true\nrg -n %s /tmp >/tmp/rg.txt || true\nawk '{print NF}' %s >/tmp/awk.txt || true\nhead --bytes=3 %s >/tmp/head.txt || true\ntail --bytes=3 %s >/tmp/tail.txt || true\nwc %s >/tmp/wc.txt\ntr --delete '[:digit:]' < %s >/tmp/tr.txt || true\nrev %s >/tmp/rev.txt || true\nnl -ba -n rz %s >/tmp/nl.txt || true\ntac %s >/tmp/tac.txt || true\nsplit -n 3 --additional-suffix=.part %s /tmp/split- || true\ncat /tmp/split-aa.part >/tmp/split.txt || true\npaste --serial --delimiters=, %s >/tmp/paste.txt || true\ncomm -1 /tmp/sort.txt /tmp/sort.txt >/tmp/comm.txt || true\njoin %s %s >/tmp/join.txt || true\ndiff -u %s %s >/tmp/diff.txt || true\nbase64 --wrap=0 %s | base64 -d >/tmp/base64.txt || true\ncat --number %s >/tmp/cat.txt || true\n",
 			shellQuote(inputPath),
 			shellQuote(inputPath),
 			shellQuote(inputPath),
 			shellQuote(needle),
 			shellQuote(inputPath),
 			shellQuote(needle),
-			shellQuote(inputPath),
 			shellQuote(inputPath),
 			shellQuote(inputPath),
 			shellQuote(inputPath),
@@ -150,6 +149,7 @@ func FuzzTextSearchCommands(f *testing.F) {
 			shellQuote(joinRightPath),
 			shellQuote(inputPath),
 			shellQuote(otherPath),
+			shellQuote(inputPath),
 			shellQuote(inputPath),
 		))
 
@@ -182,7 +182,7 @@ func FuzzShellProcessCommands(f *testing.F) {
 		writeSessionFile(t, session, inputPath, text)
 
 		script := []byte(fmt.Sprintf(
-			"cat %s | tee /tmp/tee.txt >/tmp/tee.out\nenv -i ONLY=%s printenv ONLY >/tmp/env.txt\nprintenv HOME >/tmp/printenv.txt\nwhich echo >/tmp/which.txt\nhelp -s pwd >/tmp/help.txt\ndate -u -d 2024-01-02T03:04:05 +%%F >/tmp/date.txt\ndate --utc --date 2024-01-02T03:04:05 +%%Z >/tmp/date-utc.txt\ndate --date 2024-01-02T03:04:05 --iso-8601 >/tmp/date-iso.txt\ndate --date 2024-01-02T03:04:05 --rfc-email >/tmp/date-rfc.txt\nsleep 0.001\ntrue\n/bin/false || true\n",
+			"cat %s | tee /tmp/tee.txt >/tmp/tee.out\nenv --ignore-environment ONLY=%s printenv ONLY >/tmp/env.txt\nprintenv HOME >/tmp/printenv.txt\nwhich echo >/tmp/which.txt\nhelp -s pwd >/tmp/help.txt\ndate -u -d 2024-01-02T03:04:05 +%%F >/tmp/date.txt\ndate --utc --date 2024-01-02T03:04:05 +%%Z >/tmp/date-utc.txt\ndate --date 2024-01-02T03:04:05 --iso-8601 >/tmp/date-iso.txt\ndate --date 2024-01-02T03:04:05 --rfc-email >/tmp/date-rfc.txt\nsleep 0.001\ntrue\n/bin/false || true\n",
 			shellQuote(inputPath),
 			shellQuote(value),
 		))
@@ -216,7 +216,7 @@ func FuzzNestedShellCommands(f *testing.F) {
 		writeSessionFile(t, session, inputPath, text)
 
 		script := []byte(fmt.Sprintf(
-			"timeout 0.01 sleep 1 || true\nprintf 'echo from-stdin\\n' | sh >/tmp/sh.txt\nbash -c 'echo \"$1\"' ignored %s >/tmp/bash.txt\ncat %s | xargs -n 1 echo >/tmp/xargs.txt || true\n",
+			"timeout --signal TERM --kill-after 0.01 0.01 sleep 1 || true\nprintf 'echo from-stdin\\n' | sh >/tmp/sh.txt\nbash -c 'echo \"$1\"' ignored %s >/tmp/bash.txt\ncat %s | xargs --verbose --max-args 1 echo >/tmp/xargs.txt || true\n",
 			shellQuote(value),
 			shellQuote(inputPath),
 		))

--- a/runtime/path_commands_test.go
+++ b/runtime/path_commands_test.go
@@ -184,6 +184,23 @@ func TestBasenameAndDirnameHandleSuffixesAndMultipleOperands(t *testing.T) {
 	}
 }
 
+func TestBasenameSupportsLongSuffixFlag(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "basename --suffix .log /tmp/build.log\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "build\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
 func TestTreeShowsHiddenFilesAndDepthLimits(t *testing.T) {
 	session := newSession(t, &Config{})
 
@@ -256,6 +273,19 @@ func TestFileMissingPathReportsErrorOnStdout(t *testing.T) {
 	}
 	if !strings.Contains(result.Stdout, "cannot open") {
 		t.Fatalf("Stdout = %q, want missing-path message", result.Stdout)
+	}
+}
+
+func TestFileSupportsLongBriefAndMimeFlags(t *testing.T) {
+	session := newSession(t, &Config{})
+	writeSessionFile(t, session, "/home/agent/note.txt", []byte("hello\n"))
+
+	result := mustExecSession(t, session, "file --brief /home/agent/note.txt\nfile --mime /home/agent/note.txt\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "ASCII text\n/home/agent/note.txt: text/plain\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }
 

--- a/runtime/process_helper_commands_test.go
+++ b/runtime/process_helper_commands_test.go
@@ -24,6 +24,23 @@ func TestEnvAndPrintEnvScopeNestedEnvironment(t *testing.T) {
 	}
 }
 
+func TestEnvSupportsLongIgnoreEnvironment(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "env --ignore-environment ONLY=present printenv ONLY\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "present\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
 func TestTeeAppendsAndWritesMultipleFiles(t *testing.T) {
 	rt := newRuntime(t, &Config{})
 
@@ -199,6 +216,26 @@ func TestTimeoutStopsNestedCommand(t *testing.T) {
 	}
 }
 
+func TestTimeoutSupportsLongKillAfterAndSignalOptions(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "timeout --signal TERM --kill-after 0.01 0.02 sleep 1 || echo timed\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "timed\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+	if !strings.Contains(result.Stderr, "execution timed out") {
+		t.Fatalf("Stderr = %q, want timeout message", result.Stderr)
+	}
+}
+
 func TestBashRunsNestedCommandString(t *testing.T) {
 	rt := newRuntime(t, &Config{})
 
@@ -247,5 +284,25 @@ func TestXArgsSupportsBatchingAndReplacement(t *testing.T) {
 	}
 	if got, want := result.Stdout, "a\nb\nitem:left\nitem:right\n"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestXArgsSupportsLongFlags(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 'a\\0b\\0' | xargs --null --verbose --max-args 1 echo\nprintf '' | xargs --no-run-if-empty echo skip\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "a\nb\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+	if got, want := result.Stderr, "'echo' 'a'\n'echo' 'b'\n"; got != want {
+		t.Fatalf("Stderr = %q, want %q", got, want)
 	}
 }

--- a/runtime/sort_uniq_test.go
+++ b/runtime/sort_uniq_test.go
@@ -124,3 +124,20 @@ func TestUniqReturnsErrorForMissingFile(t *testing.T) {
 		t.Fatalf("Stderr = %q, want missing-file error", result.Stderr)
 	}
 }
+
+func TestUniqSupportsIgnoreCase(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 'Apple\\napple\\nBanana\\n' > /tmp/in.txt\nuniq --ignore-case -c /tmp/in.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "   2 Apple\n   1 Banana\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}

--- a/runtime/sqlite3_test.go
+++ b/runtime/sqlite3_test.go
@@ -95,6 +95,72 @@ func TestSQLite3SupportsLineAndTableFormatting(t *testing.T) {
 	}
 }
 
+func TestSQLite3SupportsAdditionalOutputModes(t *testing.T) {
+	session := newSession(t, nil)
+
+	markdown := mustExecSession(t, session, `sqlite3 -markdown -header :memory: "create table t(a,b); insert into t values (1,'x'); select * from t;"`+"\n")
+	if markdown.ExitCode != 0 {
+		t.Fatalf("markdown ExitCode = %d, want 0; stderr=%q", markdown.ExitCode, markdown.Stderr)
+	}
+	if got, want := markdown.Stdout, "| a | b |\n|---|---|\n| 1 | x |\n"; got != want {
+		t.Fatalf("markdown Stdout = %q, want %q", got, want)
+	}
+
+	tabs := mustExecSession(t, session, `sqlite3 -tabs -header :memory: "create table t(a,b); insert into t values (1,'x'); select * from t;"`+"\n")
+	if tabs.ExitCode != 0 {
+		t.Fatalf("tabs ExitCode = %d, want 0; stderr=%q", tabs.ExitCode, tabs.Stderr)
+	}
+	if got, want := tabs.Stdout, "a\tb\n1\tx\n"; got != want {
+		t.Fatalf("tabs Stdout = %q, want %q", got, want)
+	}
+
+	box := mustExecSession(t, session, `sqlite3 -box :memory: "create table t(id,name); insert into t values (1,'alice'); select * from t;"`+"\n")
+	if box.ExitCode != 0 {
+		t.Fatalf("box ExitCode = %d, want 0; stderr=%q", box.ExitCode, box.Stderr)
+	}
+	for _, want := range []string{"┌", "│ id", "│ 1 "} {
+		if !strings.Contains(box.Stdout, want) {
+			t.Fatalf("box Stdout = %q, want fragment %q", box.Stdout, want)
+		}
+	}
+
+	quote := mustExecSession(t, session, `sqlite3 -quote :memory: "select 1 as a, 'x' as b, null as c;"`+"\n")
+	if quote.ExitCode != 0 {
+		t.Fatalf("quote ExitCode = %d, want 0; stderr=%q", quote.ExitCode, quote.Stderr)
+	}
+	if got, want := quote.Stdout, "1,'x',NULL\n"; got != want {
+		t.Fatalf("quote Stdout = %q, want %q", got, want)
+	}
+
+	html := mustExecSession(t, session, `sqlite3 -html -header :memory: "select '<tag>' as c;"`+"\n")
+	if html.ExitCode != 0 {
+		t.Fatalf("html ExitCode = %d, want 0; stderr=%q", html.ExitCode, html.Stderr)
+	}
+	if got, want := html.Stdout, "<TR><TH>c</TH>\n</TR>\n<TR><TD>&lt;tag&gt;</TD>\n</TR>\n"; got != want {
+		t.Fatalf("html Stdout = %q, want %q", got, want)
+	}
+
+	ascii := mustExecSession(t, session, `sqlite3 -ascii -header :memory: "create table t(a,b); insert into t values (1,2); select * from t;"`+"\n")
+	if ascii.ExitCode != 0 {
+		t.Fatalf("ascii ExitCode = %d, want 0; stderr=%q", ascii.ExitCode, ascii.Stderr)
+	}
+	if got, want := ascii.Stdout, "a\x1fb\x1e1\x1f2\x1e"; got != want {
+		t.Fatalf("ascii Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestSQLite3QuoteModeMatchesUpstreamQuotingAndFloatFormatting(t *testing.T) {
+	session := newSession(t, nil)
+
+	result := mustExecSession(t, session, `sqlite3 -quote -header :memory: "select 'O''Reilly' as author, 0.1 as ratio;"`+"\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "'author','ratio'\n'O'Reilly',0.10000000000000001\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
 func TestSQLite3RunsCmdBeforeMainSQL(t *testing.T) {
 	session := newSession(t, nil)
 

--- a/runtime/text_commands_test.go
+++ b/runtime/text_commands_test.go
@@ -144,6 +144,40 @@ func TestTailWorksInPipeline(t *testing.T) {
 	}
 }
 
+func TestHeadAndTailSupportLongByteAndHeaderFlags(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 'abcdef\\n' > /tmp/a.txt\nprintf 'uvwxyz\\n' > /tmp/b.txt\nhead --bytes=3 --verbose /tmp/a.txt /tmp/b.txt\ntail --bytes=2 --quiet /tmp/a.txt /tmp/b.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "==> /tmp/a.txt <==\nabc\n==> /tmp/b.txt <==\nuvwf\nz\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestTailLongLinesFlagDoesNotEnableFromLineMode(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 'one\\ntwo\\nthree\\nfour\\n' > /tmp/in.txt\ntail --lines=+3 /tmp/in.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "two\nthree\nfour\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
 func TestWCReportsTotalsForMultipleFiles(t *testing.T) {
 	rt := newRuntime(t, &Config{})
 
@@ -190,5 +224,22 @@ func TestWCCountsBinaryBytes(t *testing.T) {
 	}
 	if !strings.Contains(result.Stdout, "5 /tmp/binary.bin") {
 		t.Fatalf("Stdout = %q, want byte count for binary file", result.Stdout)
+	}
+}
+
+func TestCatSupportsNumberFlag(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 'first\\nsecond\\n' > /tmp/a.txt\nprintf 'third\\n' | cat --number /tmp/a.txt -\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "     1\tfirst\n     2\tsecond\n     3\tthird\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }

--- a/runtime/text_search_commands_test.go
+++ b/runtime/text_search_commands_test.go
@@ -40,6 +40,23 @@ func TestCommSupportsStdinAndColumnSuppression(t *testing.T) {
 	}
 }
 
+func TestCommSupportsExplicitColumnFlags(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 'apple\\nbanana\\n' > /tmp/left.txt\nprintf 'banana\\ncarrot\\n' > /tmp/right.txt\ncomm -1 /tmp/left.txt /tmp/right.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "\tbanana\ncarrot\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
 func TestPasteSupportsRepeatedStdin(t *testing.T) {
 	rt := newRuntime(t, &Config{})
 
@@ -70,6 +87,23 @@ func TestPasteSerialSupportsCustomDelimiter(t *testing.T) {
 		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
 	}
 	if got, want := result.Stdout, "one,two,three\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestPasteSupportsLongFlags(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 'one\\ntwo\\n' > /tmp/in.txt\npaste --serial --delimiters=':' /tmp/in.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "one:two\n"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }
@@ -108,6 +142,23 @@ func TestTRSupportsComplementDelete(t *testing.T) {
 	}
 }
 
+func TestTRSupportsLongDeleteAndSqueezeFlags(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 'aaabbbccc' | tr --squeeze-repeats abc\nprintf 'abc123' | tr --delete '[:alpha:]'\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "abc123"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
 func TestRevHandlesUnicode(t *testing.T) {
 	rt := newRuntime(t, &Config{})
 
@@ -138,6 +189,23 @@ func TestNLSupportsFormattingControls(t *testing.T) {
 		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
 	}
 	if got, want := result.Stdout, " 10: one\n 15: \n 20: two\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestNLSupportsNumberFormats(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 'one\\ntwo\\n' | nl -ba -n rz -w 3\nprintf 'one\\n' | nl -ba -n ln -w 3 -s ':'\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "001\tone\n002\ttwo\n1  :one\n"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }
@@ -181,6 +249,28 @@ func TestSplitWritesNumberedChunks(t *testing.T) {
 	}
 	if got, want := string(readSessionFile(t, session, "/tmp/out-02")), "five\n"; got != want {
 		t.Fatalf("out-02 = %q, want %q", got, want)
+	}
+}
+
+func TestSplitSupportsChunkingAndAdditionalSuffix(t *testing.T) {
+	session := newSession(t, &Config{})
+	writeSessionFile(t, session, "/tmp/in.txt", []byte("abcdef"))
+
+	result := mustExecSession(t, session, "split -n 3 --additional-suffix=.part /tmp/in.txt /tmp/chunk-\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if result.Stdout != "" {
+		t.Fatalf("Stdout = %q, want empty output", result.Stdout)
+	}
+	if got, want := string(readSessionFile(t, session, "/tmp/chunk-aa.part")), "ab"; got != want {
+		t.Fatalf("chunk-aa.part = %q, want %q", got, want)
+	}
+	if got, want := string(readSessionFile(t, session, "/tmp/chunk-ab.part")), "cd"; got != want {
+		t.Fatalf("chunk-ab.part = %q, want %q", got, want)
+	}
+	if got, want := string(readSessionFile(t, session, "/tmp/chunk-ac.part")), "ef"; got != want {
+		t.Fatalf("chunk-ac.part = %q, want %q", got, want)
 	}
 }
 
@@ -237,6 +327,23 @@ func TestDiffReportsIdenticalFiles(t *testing.T) {
 	}
 }
 
+func TestDiffSupportsLongFlags(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 'alpha\\n' > /tmp/a.txt\nprintf 'ALPHA\\n' > /tmp/b.txt\ndiff --ignore-case --report-identical-files /tmp/a.txt /tmp/b.txt\nprintf 'one\\n' > /tmp/c.txt\nprintf 'two\\n' > /tmp/d.txt\ndiff --brief /tmp/c.txt /tmp/d.txt || true\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "Files /tmp/a.txt and /tmp/b.txt are identical\nFiles /tmp/c.txt and /tmp/d.txt differ\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
 func TestBase64RoundTripsThroughPipelines(t *testing.T) {
 	rt := newRuntime(t, &Config{})
 
@@ -250,6 +357,23 @@ func TestBase64RoundTripsThroughPipelines(t *testing.T) {
 		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
 	}
 	if got, want := result.Stdout, "hello world"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestBase64SupportsLongWrapFlag(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf 'hello world' | base64 --wrap=0\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "aGVsbG8gd29ybGQ=\n"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- align the dirty `head`/`tail` long-flag work with upstream byte and `--lines` behavior
- keep the `split`, `sqlite3`, and runtime test updates while fixing the invalid expectations and quote/float parity drift
- extend regression coverage in runtime tests and the text-command fuzz target for the newly exercised long-flag paths

## Testing
- go test ./runtime -run 'TestSplitSupportsChunkingAndAdditionalSuffix|TestHeadAndTailSupportLongByteAndHeaderFlags|TestTailLongLinesFlagDoesNotEnableFromLineMode|TestSQLite3SupportsAdditionalOutputModes|TestSQLite3QuoteModeMatchesUpstreamQuotingAndFloatFormatting|TestXArgsSupportsLongFlags|TestTimeoutSupportsLongKillAfterAndSignalOptions|TestFileSupportsLongBriefAndMimeFlags|TestCPSupportsNoClobberPreserveAndVerbose|TestMVSupportsNoClobberVerboseAndMovingFileIntoDirectory|TestCutSupportsLongOnlyDelimitedFlag|TestSedSupportsScriptFileFlag|TestUniqSupportsIgnoreCase|TestEnvSupportsLongIgnoreEnvironment'
- go test ./...
- go test ./runtime -run=^$ -fuzz=FuzzTextSearchCommands -fuzztime=5s