### PR TITLE
compat: pin GNU tarball checksum

### DIFF
--- a/cmd/jbgo-gnu/manifest.json
+++ b/cmd/jbgo-gnu/manifest.json
@@ -1,7 +1,7 @@
 {
   "gnu_version": "9.10",
   "tarball_url": "https://ftp.gnu.org/gnu/coreutils/coreutils-9.10.tar.gz",
-  "tarball_sha256": "",
+  "tarball_sha256": "e0bde1fb68509447fc723cf2517e8a8c7fa46769919bb7490ed350a2e9238562",
   "utilities": [
     { "name": "base64", "patterns": ["tests/basenc/base64.pl"] },
     { "name": "basename", "patterns": ["tests/misc/basename*"] },


### PR DESCRIPTION
## Summary
- pin the GNU coreutils 9.10 tarball SHA256 in the GNU compatibility manifest
- enforce checksum verification against the exact `ftp.gnu.org` tarball URL already used by the harness
- keep the change scoped to the manifest only

## Validation
- `go test ./cmd/jbgo-gnu`
- `go run ./cmd/jbgo-gnu --cache-dir .cache/gnu-sha-verify --setup`
