### PR TITLE
fs: add host-backed lower overlay backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,11 +289,28 @@ Filesystem choice is controlled through `Config.FSFactory`.
 
 - `jbfs.MemoryFactory{}` is the default: each session gets a fresh in-memory filesystem.
 - `jbfs.OverlayFactory{Lower: ...}` creates a copy-on-write filesystem over another `jbfs.Factory`.
+- `jbfs.HostFactory{Root: ..., VirtualRoot: ..., MaxFileReadBytes: ...}` exposes a read-only host directory at a virtual path and is intended to sit underneath `jbfs.OverlayFactory`. `VirtualRoot` defaults to `/home/agent/project`; `MaxFileReadBytes` defaults to 10 MiB and caps regular-file opens from the host tree.
 - `jbfs.NewSnapshot(ctx, fsys)` creates a read-only point-in-time snapshot of an existing filesystem. If you want snapshot-backed sessions, wrap it behind your own `jbfs.Factory`.
 
-You can also provide your own `jbfs.Factory` implementation for seeded, host-backed, or otherwise custom sandbox filesystems.
+You can also provide your own `jbfs.Factory` implementation for seeded, remote, or otherwise custom sandbox filesystems.
 
 If you already have a Go filesystem implementation, the runtime is flexible about what sits underneath that factory. The integration point is `jbfs.FileSystem`, so plain `io/fs.FS` is not enough by itself, but you can wrap stdlib-compatible or third-party backends behind a `jbfs.Factory`.
+
+For the closest parity with `just-bash`'s real-directory overlay, use `HostFactory` as the lower layer for `OverlayFactory` and point the runtime at the mounted virtual root:
+
+```go
+rt, err := jbruntime.New(&jbruntime.Config{
+	DefaultDir: "/home/agent/project",
+	FSFactory: jbfs.OverlayFactory{
+		Lower: jbfs.HostFactory{
+			Root:        "/path/to/project",
+			VirtualRoot: "/home/agent/project",
+		},
+	},
+})
+```
+
+That gives the session a host-backed read-only project tree while keeping all writes, deletes, and command stubs in the in-memory upper layer. If you want the host tree at `/`, set `VirtualRoot: "/"`.
 
 That makes it practical to integrate things like:
 
@@ -320,7 +337,7 @@ rt, err := jbruntime.New(&jbruntime.Config{
 })
 ```
 
-If you want copy-on-write behavior over an existing Go filesystem, wrap that backend as the lower layer and put `jbfs.OverlayFactory` on top of it.
+If you want copy-on-write behavior over an existing Go filesystem, wrap that backend as the lower layer and put `jbfs.OverlayFactory` on top of it. A direct host read-write backend and a general mount router are still out of scope for the default runtime path.
 
 ### Network Access
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -179,7 +179,7 @@ Package responsibilities:
 
 - `runtime/`: public API, runtime/session creation, run configuration, result collection, output capture
 - `shell/`: parser and runner adapter; no product policy lives here
-- `fs/`: POSIX-like path normalization, memory filesystem, future overlay/snapshot backends
+- `fs/`: POSIX-like path normalization, memory filesystem, host-backed lower layers, overlay, and snapshot backends
 - `network/`: runtime-owned HTTP sandbox with URL-prefix allowlists, method controls, redirect revalidation, and response-size limits
 - `commands/`: registry and Go-native command implementations such as `echo`, `cat`, `ls`, and `pwd`
 - `policy/`: allowlists, root restrictions, size limits, network stance, and decision helpers
@@ -465,7 +465,7 @@ Important properties:
 - paths use POSIX semantics internally
 - the default backend is in-memory
 - the default backend exposes a Unix-like virtual layout rooted at `/`
-- host-backed filesystems, if ever added, must still satisfy policy checks and must never imply host command execution
+- host-backed filesystems must still satisfy policy checks and must never imply host command execution
 - developer-only CLI compatibility runs may use a host-backed filesystem adapter, but that adapter is not the default runtime backend and is only for opt-in test harnesses
 - shell redirects and command file access share the same filesystem view
 - symlink support is optional and must default to the safer behavior when policy is ambiguous
@@ -484,11 +484,13 @@ Implementation detail for the current runtime:
 Current and planned backends:
 
 - `MemoryFS`: default mutable sandbox
+- `HostFS`: read-only host-backed directory view mounted at a configurable virtual root with sanitized errors and a backend-local regular-file read cap
 - `OverlayFS`: copy-on-write backend with a read-only lower layer, writable in-memory upper layer, merged `readdir`, and tombstones for deletions
 - `SnapshotFS`: deterministic read-only clone of another filesystem for tests and replay fixtures
 
 Backend boundary for the current implementation:
 
+- `HostFS` is an opt-in lower-layer backend exposed through `HostFactory`; it is intended to sit underneath `OverlayFactory`, not to replace the default in-memory runtime path
 - `OverlayFS` is intended for runtime/session use and is exposed through `OverlayFactory`
 - `SnapshotFS` is a read-only backend for deterministic fixtures and direct tests
 - `SnapshotFS` is not the default `runtime` session backend because session bootstrap still creates the sandbox layout and command stubs
@@ -946,7 +948,6 @@ The gap analysis against `just-bash` yields two categories: gaps we should close
 
 - broader command coverage for agent workflows, especially deeper parity for the newer archive/compression, helper, and text/search tools
 - stronger execution budgets and policy enforcement, including richer CPU and memory accounting
-- host-backed overlay filesystem support so real directories can be mounted read-only underneath an in-memory writable layer
 - fuller `jq` and `curl` compatibility for structured data flows and safe networked workflows
 - richer tracing and compatibility corpus
 - continued fuzzing depth as new commands land, including additional attack-corpus entries, richer metadata variants, and longer-running schedules outside the default CI path
@@ -967,7 +968,6 @@ The gap analysis against `just-bash` yields two categories: gaps we should close
 - richer trace correlation IDs
 - safe HTTP fetch with policy allowlists
 - resource accounting for CPU and memory budgets
-- host-backed overlay lower filesystems for copy-on-write sessions
 - broader command-family parity with `just-bash`
 - optional line-editing support for the interactive CLI if it can be added without weakening sandbox determinism
 
@@ -983,4 +983,4 @@ These questions should be decided early but do not block the initial scaffold:
 
 1. Which shell builtins should be explicitly denied even if `mvdan/sh` supports them?
 2. Do we want a first-class JSON command set in MVP+1?
-3. When we add a host-backed lower filesystem for `OverlayFS`, do we want it limited to read-only roots at first or to support a narrower write-through mode under policy control?
+3. If we ever add a direct host read-write backend or general mount routing, do we keep those as separate opt-in surfaces rather than folding them into the default runtime contract?

--- a/TODO.md
+++ b/TODO.md
@@ -132,10 +132,10 @@ This file is the implementation queue derived from [`SPEC.md`](./SPEC.md), espec
 
 ### 14. Host-backed overlay parity
 
-- [ ] Add a host-backed lower `FileSystem` implementation for `OverlayFS`
-- [ ] Keep reads constrained to explicit host roots while leaving all writes in memory
-- [ ] Add integration tests for copy-on-write behavior against a real directory tree
-- [ ] Document when host-backed overlays are appropriate and when pure virtual FS should remain the default
+- [x] Add a host-backed lower `FileSystem` implementation for `OverlayFS`
+- [x] Keep reads constrained to explicit host roots while leaving all writes in memory
+- [x] Add integration tests for copy-on-write behavior against a real directory tree
+- [x] Document when host-backed overlays are appropriate and when pure virtual FS should remain the default
 
 ### 15. Hardening and maturity
 

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -188,6 +188,24 @@ func TestOverlayFSRenameCopiesUpAndTombstonesSource(t *testing.T) {
 	}
 }
 
+func TestOverlayFSRealpathResolvesLowerSymlinks(t *testing.T) {
+	lower := seededMemory(t, map[string]string{
+		"/safe/target.txt": "hello\n",
+	})
+	if err := lower.Symlink(context.Background(), "target.txt", "/safe/link.txt"); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	overlay := NewOverlay(lower)
+	realpath, err := overlay.Realpath(context.Background(), "/safe/link.txt")
+	if err != nil {
+		t.Fatalf("Realpath() error = %v", err)
+	}
+	if got, want := realpath, "/safe/target.txt"; got != want {
+		t.Fatalf("Realpath() = %q, want %q", got, want)
+	}
+}
+
 func TestSnapshotFSPreservesSourceViewAndRejectsWrites(t *testing.T) {
 	source := seededMemory(t, map[string]string{
 		"/data.txt": "before\n",

--- a/fs/host.go
+++ b/fs/host.go
@@ -1,0 +1,22 @@
+package fs
+
+type HostOptions struct {
+	Root             string
+	VirtualRoot      string
+	MaxFileReadBytes int64
+}
+
+type HostFactory struct {
+	Root             string
+	VirtualRoot      string
+	MaxFileReadBytes int64
+}
+
+const (
+	defaultHostVirtualRoot      = "/home/agent/project"
+	defaultHostMaxFileReadBytes = 10 << 20
+)
+
+func (f HostFactory) options() HostOptions {
+	return HostOptions(f)
+}

--- a/fs/host_posix.go
+++ b/fs/host_posix.go
@@ -1,0 +1,584 @@
+//go:build !windows
+
+package fs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	stdfs "io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type HostFS struct {
+	mu sync.RWMutex
+
+	root             string
+	canonicalRoot    string
+	virtualRoot      string
+	virtualRootParts []string
+	cwd              string
+	maxFileReadBytes int64
+}
+
+type hostPathKind uint8
+
+const (
+	hostPathNone hostPathKind = iota
+	hostPathAncestor
+	hostPathMounted
+)
+
+func NewHost(opts HostOptions) (*HostFS, error) {
+	root := strings.TrimSpace(opts.Root)
+	if root == "" {
+		return nil, fmt.Errorf("host root is required")
+	}
+
+	if !filepath.IsAbs(root) {
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			return nil, err
+		}
+		root = absRoot
+	}
+	root = filepath.Clean(root)
+
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("host root %q is not a directory", root)
+	}
+
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, err
+	}
+	canonicalRoot = filepath.Clean(canonicalRoot)
+
+	virtualRoot := strings.TrimSpace(opts.VirtualRoot)
+	switch {
+	case virtualRoot == "":
+		virtualRoot = defaultHostVirtualRoot
+	case !strings.HasPrefix(virtualRoot, "/"):
+		return nil, fmt.Errorf("virtual root must be absolute: %q", opts.VirtualRoot)
+	default:
+		virtualRoot = Clean(virtualRoot)
+	}
+
+	maxFileReadBytes := opts.MaxFileReadBytes
+	if maxFileReadBytes == 0 {
+		maxFileReadBytes = defaultHostMaxFileReadBytes
+	}
+
+	return &HostFS{
+		root:             root,
+		canonicalRoot:    canonicalRoot,
+		virtualRoot:      virtualRoot,
+		virtualRootParts: splitVirtualPath(virtualRoot),
+		cwd:              virtualRoot,
+		maxFileReadBytes: maxFileReadBytes,
+	}, nil
+}
+
+func (f HostFactory) New(context.Context) (FileSystem, error) {
+	return NewHost(f.options())
+}
+
+func (h *HostFS) Open(ctx context.Context, name string) (File, error) {
+	return h.OpenFile(ctx, name, os.O_RDONLY, 0)
+}
+
+func (h *HostFS) OpenFile(_ context.Context, name string, flag int, perm stdfs.FileMode) (File, error) {
+	abs := h.resolve(name)
+	if hasWriteIntent(flag) {
+		return nil, h.readOnlyError("open", abs)
+	}
+
+	switch kind, _ := h.classify(abs); kind {
+	case hostPathMounted:
+	case hostPathAncestor:
+		return nil, h.pathError("open", abs, stdfs.ErrInvalid)
+	default:
+		return nil, h.pathError("open", abs, stdfs.ErrNotExist)
+	}
+
+	canonical, err := h.resolveMountedCanonical(abs)
+	if err != nil {
+		return nil, h.pathError("open", abs, err)
+	}
+
+	file, err := os.OpenFile(canonical, flag, perm)
+	if err != nil {
+		return nil, h.pathError("open", abs, err)
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, h.pathError("open", abs, err)
+	}
+	if err := h.checkFileSize(info); err != nil {
+		_ = file.Close()
+		return nil, h.pathError("open", abs, err)
+	}
+
+	return file, nil
+}
+
+func (h *HostFS) Stat(_ context.Context, name string) (stdfs.FileInfo, error) {
+	abs := h.resolve(name)
+
+	switch kind, _ := h.classify(abs); kind {
+	case hostPathAncestor:
+		return h.syntheticDirInfo(abs), nil
+	case hostPathMounted:
+		canonical, err := h.resolveMountedCanonical(abs)
+		if err != nil {
+			return nil, h.pathError("stat", abs, err)
+		}
+		info, err := os.Stat(canonical)
+		if err != nil {
+			return nil, h.pathError("stat", abs, err)
+		}
+		return namedFileInfo{name: path.Base(abs), info: info}, nil
+	default:
+		return nil, h.pathError("stat", abs, stdfs.ErrNotExist)
+	}
+}
+
+func (h *HostFS) Lstat(_ context.Context, name string) (stdfs.FileInfo, error) {
+	abs := h.resolve(name)
+
+	switch kind, _ := h.classify(abs); kind {
+	case hostPathAncestor:
+		return h.syntheticDirInfo(abs), nil
+	case hostPathMounted:
+		if abs == h.virtualRoot {
+			info, err := os.Stat(h.canonicalRoot)
+			if err != nil {
+				return nil, h.pathError("lstat", abs, err)
+			}
+			return namedFileInfo{name: path.Base(abs), info: info}, nil
+		}
+		leaf, err := h.resolveMountedLeaf(abs)
+		if err != nil {
+			return nil, h.pathError("lstat", abs, err)
+		}
+		info, err := os.Lstat(leaf)
+		if err != nil {
+			return nil, h.pathError("lstat", abs, err)
+		}
+		return namedFileInfo{name: path.Base(abs), info: info}, nil
+	default:
+		return nil, h.pathError("lstat", abs, stdfs.ErrNotExist)
+	}
+}
+
+func (h *HostFS) ReadDir(_ context.Context, name string) ([]stdfs.DirEntry, error) {
+	abs := h.resolve(name)
+
+	switch kind, rel := h.classify(abs); kind {
+	case hostPathAncestor:
+		child, ok := h.syntheticChild(abs)
+		if !ok {
+			return nil, h.pathError("readdir", abs, stdfs.ErrNotExist)
+		}
+		entry := stdfs.FileInfoToDirEntry(staticFileInfo{
+			name:    child,
+			mode:    stdfs.ModeDir | 0o755,
+			modTime: time.Time{},
+		})
+		return []stdfs.DirEntry{entry}, nil
+	case hostPathMounted:
+		canonical, err := h.resolveMountedCanonical(abs)
+		if err != nil {
+			return nil, h.pathError("readdir", abs, err)
+		}
+		info, err := os.Stat(canonical)
+		if err != nil {
+			return nil, h.pathError("readdir", abs, err)
+		}
+		if !info.IsDir() {
+			return nil, h.pathError("readdir", abs, stdfs.ErrInvalid)
+		}
+		entries, err := os.ReadDir(canonical)
+		if err != nil {
+			return nil, h.pathError("readdir", abs, err)
+		}
+		if rel == "/" {
+			return entries, nil
+		}
+		return entries, nil
+	default:
+		return nil, h.pathError("readdir", abs, stdfs.ErrNotExist)
+	}
+}
+
+func (h *HostFS) Readlink(_ context.Context, name string) (string, error) {
+	abs := h.resolve(name)
+
+	switch kind, _ := h.classify(abs); kind {
+	case hostPathMounted:
+		if abs == h.virtualRoot {
+			return "", h.pathError("readlink", abs, stdfs.ErrInvalid)
+		}
+		leaf, err := h.resolveMountedLeaf(abs)
+		if err != nil {
+			return "", h.pathError("readlink", abs, err)
+		}
+		target, err := os.Readlink(leaf)
+		if err != nil {
+			return "", h.pathError("readlink", abs, err)
+		}
+		if !filepath.IsAbs(target) {
+			return filepath.ToSlash(target), nil
+		}
+		virtualTarget, err := h.virtualizeAbsoluteTarget(target)
+		if err != nil {
+			return "", h.pathError("readlink", abs, err)
+		}
+		return virtualTarget, nil
+	case hostPathAncestor:
+		return "", h.pathError("readlink", abs, stdfs.ErrInvalid)
+	default:
+		return "", h.pathError("readlink", abs, stdfs.ErrNotExist)
+	}
+}
+
+func (h *HostFS) Realpath(_ context.Context, name string) (string, error) {
+	abs := h.resolve(name)
+
+	switch kind, _ := h.classify(abs); kind {
+	case hostPathAncestor:
+		return abs, nil
+	case hostPathMounted:
+		canonical, err := h.resolveMountedCanonical(abs)
+		if err != nil {
+			return "", h.pathError("realpath", abs, err)
+		}
+		return h.virtualFromCanonical(canonical), nil
+	default:
+		return "", h.pathError("realpath", abs, stdfs.ErrNotExist)
+	}
+}
+
+func (h *HostFS) Symlink(_ context.Context, _, linkName string) error {
+	return h.readOnlyError("symlink", h.resolve(linkName))
+}
+
+func (h *HostFS) Link(_ context.Context, _, newName string) error {
+	return h.readOnlyError("link", h.resolve(newName))
+}
+
+func (h *HostFS) Chmod(_ context.Context, name string, _ stdfs.FileMode) error {
+	return h.readOnlyError("chmod", h.resolve(name))
+}
+
+func (h *HostFS) Chtimes(_ context.Context, name string, _, _ time.Time) error {
+	return h.readOnlyError("chtimes", h.resolve(name))
+}
+
+func (h *HostFS) MkdirAll(_ context.Context, name string, _ stdfs.FileMode) error {
+	return h.readOnlyError("mkdir", h.resolve(name))
+}
+
+func (h *HostFS) Remove(_ context.Context, name string, _ bool) error {
+	return h.readOnlyError("remove", h.resolve(name))
+}
+
+func (h *HostFS) Rename(_ context.Context, oldName, _ string) error {
+	return h.readOnlyError("rename", h.resolve(oldName))
+}
+
+func (h *HostFS) Getwd() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.cwd
+}
+
+func (h *HostFS) Chdir(name string) error {
+	abs := h.resolve(name)
+
+	switch kind, _ := h.classify(abs); kind {
+	case hostPathAncestor:
+		h.mu.Lock()
+		h.cwd = abs
+		h.mu.Unlock()
+		return nil
+	case hostPathMounted:
+		canonical, err := h.resolveMountedCanonical(abs)
+		if err != nil {
+			return h.pathError("chdir", abs, err)
+		}
+		info, err := os.Stat(canonical)
+		if err != nil {
+			return h.pathError("chdir", abs, err)
+		}
+		if !info.IsDir() {
+			return h.pathError("chdir", abs, stdfs.ErrInvalid)
+		}
+		h.mu.Lock()
+		h.cwd = abs
+		h.mu.Unlock()
+		return nil
+	default:
+		return h.pathError("chdir", abs, stdfs.ErrNotExist)
+	}
+}
+
+func (h *HostFS) resolve(name string) string {
+	return Resolve(h.Getwd(), name)
+}
+
+func (h *HostFS) classify(abs string) (kind hostPathKind, rel string) {
+	abs = Clean(abs)
+	if h.virtualRoot == "/" {
+		return hostPathMounted, abs
+	}
+	if abs == h.virtualRoot {
+		return hostPathMounted, "/"
+	}
+	if strings.HasPrefix(abs, h.virtualRoot+"/") {
+		return hostPathMounted, strings.TrimPrefix(abs, h.virtualRoot)
+	}
+	if abs == "/" || strings.HasPrefix(h.virtualRoot, abs+"/") {
+		return hostPathAncestor, ""
+	}
+	return hostPathNone, ""
+}
+
+func (h *HostFS) syntheticChild(abs string) (string, bool) {
+	if h.virtualRoot == "/" {
+		return "", false
+	}
+	abs = Clean(abs)
+	if abs == h.virtualRoot {
+		return "", false
+	}
+	depth := 0
+	if abs != "/" {
+		depth = len(splitVirtualPath(abs))
+	}
+	if depth >= len(h.virtualRootParts) {
+		return "", false
+	}
+	return h.virtualRootParts[depth], true
+}
+
+func (h *HostFS) syntheticDirInfo(abs string) stdfs.FileInfo {
+	name := path.Base(abs)
+	if abs == "/" {
+		name = "/"
+	}
+	return staticFileInfo{
+		name:    name,
+		mode:    stdfs.ModeDir | 0o755,
+		modTime: time.Time{},
+	}
+}
+
+func (h *HostFS) resolveMountedCanonical(abs string) (string, error) {
+	switch kind, rel := h.classify(abs); kind {
+	case hostPathMounted:
+		if rel == "/" {
+			return h.canonicalRoot, nil
+		}
+		lexical := h.lexicalPath(rel)
+		canonical, err := filepath.EvalSymlinks(lexical)
+		if err != nil {
+			return "", err
+		}
+		canonical = filepath.Clean(canonical)
+		if !withinHostRoot(canonical, h.canonicalRoot) {
+			return "", stdfs.ErrPermission
+		}
+		return canonical, nil
+	default:
+		return "", stdfs.ErrNotExist
+	}
+}
+
+func (h *HostFS) resolveMountedLeaf(abs string) (string, error) {
+	switch kind, rel := h.classify(abs); kind {
+	case hostPathMounted:
+		if rel == "/" {
+			return h.canonicalRoot, nil
+		}
+		lexical := h.lexicalPath(rel)
+		parent := filepath.Dir(lexical)
+		canonicalParent, err := filepath.EvalSymlinks(parent)
+		if err != nil {
+			return "", err
+		}
+		canonicalParent = filepath.Clean(canonicalParent)
+		if !withinHostRoot(canonicalParent, h.canonicalRoot) {
+			return "", stdfs.ErrPermission
+		}
+		return filepath.Join(canonicalParent, filepath.Base(lexical)), nil
+	default:
+		return "", stdfs.ErrNotExist
+	}
+}
+
+func (h *HostFS) lexicalPath(rel string) string {
+	if rel == "/" {
+		return h.root
+	}
+	return filepath.Clean(filepath.Join(h.root, filepath.FromSlash(strings.TrimPrefix(rel, "/"))))
+}
+
+func (h *HostFS) virtualFromCanonical(canonical string) string {
+	rel, err := filepath.Rel(h.canonicalRoot, canonical)
+	if err != nil || rel == "." {
+		return h.virtualRoot
+	}
+	return Resolve(h.virtualRoot, filepath.ToSlash(rel))
+}
+
+func (h *HostFS) virtualFromRootPath(rootPath, target string) string {
+	rel, err := filepath.Rel(rootPath, target)
+	if err != nil || rel == "." {
+		return h.virtualRoot
+	}
+	return Resolve(h.virtualRoot, filepath.ToSlash(rel))
+}
+
+func (h *HostFS) virtualizeAbsoluteTarget(target string) (string, error) {
+	target = filepath.Clean(target)
+	if withinHostRoot(target, h.root) {
+		return h.virtualFromRootPath(h.root, target), nil
+	}
+	if withinHostRoot(target, h.canonicalRoot) {
+		return h.virtualFromCanonical(target), nil
+	}
+
+	canonical, err := filepath.EvalSymlinks(target)
+	if err == nil {
+		canonical = filepath.Clean(canonical)
+		if withinHostRoot(canonical, h.canonicalRoot) {
+			return h.virtualFromCanonical(canonical), nil
+		}
+	}
+
+	return "", stdfs.ErrPermission
+}
+
+func (h *HostFS) checkFileSize(info stdfs.FileInfo) error {
+	if h.maxFileReadBytes <= 0 || info == nil || !info.Mode().IsRegular() {
+		return nil
+	}
+	if info.Size() <= h.maxFileReadBytes {
+		return nil
+	}
+	return fileTooLargeError{
+		size: info.Size(),
+		max:  h.maxFileReadBytes,
+	}
+}
+
+func (h *HostFS) readOnlyError(op, name string) error {
+	return h.pathError(op, name, stdfs.ErrPermission)
+}
+
+func (h *HostFS) pathError(op, name string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &os.PathError{
+		Op:   op,
+		Path: Clean(name),
+		Err:  sanitizeHostErr(err),
+	}
+}
+
+func sanitizeHostErr(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, stdfs.ErrNotExist), errors.Is(err, os.ErrNotExist):
+		return stdfs.ErrNotExist
+	case errors.Is(err, stdfs.ErrPermission), errors.Is(err, os.ErrPermission):
+		return stdfs.ErrPermission
+	case errors.Is(err, stdfs.ErrInvalid):
+		return stdfs.ErrInvalid
+	case errors.Is(err, syscall.ENOTDIR), errors.Is(err, syscall.EISDIR):
+		return stdfs.ErrInvalid
+	}
+
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		return sanitizeHostErr(pathErr.Err)
+	}
+
+	var linkErr *os.LinkError
+	if errors.As(err, &linkErr) {
+		return sanitizeHostErr(linkErr.Err)
+	}
+
+	return err
+}
+
+func splitVirtualPath(name string) []string {
+	name = strings.TrimPrefix(Clean(name), "/")
+	if name == "" {
+		return nil
+	}
+	return strings.Split(name, "/")
+}
+
+func withinHostRoot(candidate, root string) bool {
+	candidate = filepath.Clean(candidate)
+	root = filepath.Clean(root)
+	if candidate == root {
+		return true
+	}
+	return strings.HasPrefix(candidate, root+string(os.PathSeparator))
+}
+
+type namedFileInfo struct {
+	name string
+	info stdfs.FileInfo
+}
+
+func (i namedFileInfo) Name() string         { return i.name }
+func (i namedFileInfo) Size() int64          { return i.info.Size() }
+func (i namedFileInfo) Mode() stdfs.FileMode { return i.info.Mode() }
+func (i namedFileInfo) ModTime() time.Time   { return i.info.ModTime() }
+func (i namedFileInfo) IsDir() bool          { return i.info.IsDir() }
+func (i namedFileInfo) Sys() any             { return i.info.Sys() }
+
+type staticFileInfo struct {
+	name    string
+	size    int64
+	mode    stdfs.FileMode
+	modTime time.Time
+}
+
+func (i staticFileInfo) Name() string         { return i.name }
+func (i staticFileInfo) Size() int64          { return i.size }
+func (i staticFileInfo) Mode() stdfs.FileMode { return i.mode }
+func (i staticFileInfo) ModTime() time.Time   { return i.modTime }
+func (i staticFileInfo) IsDir() bool          { return i.mode.IsDir() }
+func (i staticFileInfo) Sys() any             { return nil }
+
+type fileTooLargeError struct {
+	size int64
+	max  int64
+}
+
+func (e fileTooLargeError) Error() string {
+	return fmt.Sprintf("file too large (%d bytes, max %d)", e.size, e.max)
+}
+
+func (e fileTooLargeError) Unwrap() error {
+	return syscall.EFBIG
+}

--- a/fs/host_posix_test.go
+++ b/fs/host_posix_test.go
@@ -1,0 +1,218 @@
+//go:build !windows
+
+package fs
+
+import (
+	"context"
+	"errors"
+	"io"
+	stdfs "io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestHostFSMountsHostTreeAtVirtualRootAndSynthesizesAncestors(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "guide.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	fsys, err := NewHost(HostOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewHost() error = %v", err)
+	}
+
+	if got, want := fsys.Getwd(), defaultHostVirtualRoot; got != want {
+		t.Fatalf("Getwd() = %q, want %q", got, want)
+	}
+
+	assertDirEntries(t, fsys, "/", "home")
+	assertDirEntries(t, fsys, "/home", "agent")
+	assertDirEntries(t, fsys, "/home/agent", "project")
+	assertDirEntries(t, fsys, defaultHostVirtualRoot, "docs")
+
+	if err := fsys.Chdir("/home/agent"); err != nil {
+		t.Fatalf("Chdir(/home/agent) error = %v", err)
+	}
+	if err := fsys.Chdir("project"); err != nil {
+		t.Fatalf("Chdir(project) error = %v", err)
+	}
+
+	file, err := fsys.Open(context.Background(), "docs/guide.txt")
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if got, want := string(data), "hello\n"; got != want {
+		t.Fatalf("contents = %q, want %q", got, want)
+	}
+}
+
+func TestHostFSReadOnlyAndSanitizesErrors(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "note.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	fsys, err := NewHost(HostOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewHost() error = %v", err)
+	}
+
+	_, err = fsys.Open(context.Background(), defaultHostVirtualRoot+"/missing.txt")
+	if err == nil {
+		t.Fatal("Open(missing) error = nil, want not exist")
+	}
+	if !errors.Is(err, stdfs.ErrNotExist) {
+		t.Fatalf("Open(missing) error = %v, want not exist", err)
+	}
+	if strings.Contains(err.Error(), root) {
+		t.Fatalf("Open(missing) error leaked host root: %v", err)
+	}
+
+	_, err = fsys.OpenFile(context.Background(), defaultHostVirtualRoot+"/note.txt", os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err == nil {
+		t.Fatal("OpenFile(write) error = nil, want permission")
+	}
+	if !errors.Is(err, stdfs.ErrPermission) {
+		t.Fatalf("OpenFile(write) error = %v, want permission", err)
+	}
+	if strings.Contains(err.Error(), root) {
+		t.Fatalf("OpenFile(write) error leaked host root: %v", err)
+	}
+}
+
+func TestHostFSReadCapRejectsLargeFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "big.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	fsys, err := NewHost(HostOptions{
+		Root:             root,
+		MaxFileReadBytes: 4,
+	})
+	if err != nil {
+		t.Fatalf("NewHost() error = %v", err)
+	}
+
+	_, err = fsys.Open(context.Background(), defaultHostVirtualRoot+"/big.txt")
+	if err == nil {
+		t.Fatal("Open(big.txt) error = nil, want file too large")
+	}
+	if !errors.Is(err, syscall.EFBIG) {
+		t.Fatalf("Open(big.txt) error = %v, want EFBIG", err)
+	}
+	if !strings.Contains(err.Error(), "file too large") {
+		t.Fatalf("Open(big.txt) error = %v, want file too large message", err)
+	}
+	if strings.Contains(err.Error(), root) {
+		t.Fatalf("Open(big.txt) error leaked host root: %v", err)
+	}
+}
+
+func TestHostFSSymlinkResolutionAndReadlinkSanitization(t *testing.T) {
+	root := t.TempDir()
+	outsideRoot := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "target.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(target) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideRoot, "secret.txt"), []byte("secret\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(secret) error = %v", err)
+	}
+	if err := os.Symlink("target.txt", filepath.Join(root, "rel-link.txt")); err != nil {
+		t.Fatalf("Symlink(rel) error = %v", err)
+	}
+	if err := os.Symlink(filepath.Join(root, "target.txt"), filepath.Join(root, "abs-in-link.txt")); err != nil {
+		t.Fatalf("Symlink(abs-in) error = %v", err)
+	}
+	if err := os.Symlink(filepath.Join(outsideRoot, "secret.txt"), filepath.Join(root, "abs-out-link.txt")); err != nil {
+		t.Fatalf("Symlink(abs-out) error = %v", err)
+	}
+
+	fsys, err := NewHost(HostOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewHost() error = %v", err)
+	}
+
+	realpath, err := fsys.Realpath(context.Background(), defaultHostVirtualRoot+"/rel-link.txt")
+	if err != nil {
+		t.Fatalf("Realpath(rel-link) error = %v", err)
+	}
+	if got, want := realpath, defaultHostVirtualRoot+"/target.txt"; got != want {
+		t.Fatalf("Realpath(rel-link) = %q, want %q", got, want)
+	}
+
+	target, err := fsys.Readlink(context.Background(), defaultHostVirtualRoot+"/rel-link.txt")
+	if err != nil {
+		t.Fatalf("Readlink(rel-link) error = %v", err)
+	}
+	if got, want := target, "target.txt"; got != want {
+		t.Fatalf("Readlink(rel-link) = %q, want %q", got, want)
+	}
+
+	target, err = fsys.Readlink(context.Background(), defaultHostVirtualRoot+"/abs-in-link.txt")
+	if err != nil {
+		t.Fatalf("Readlink(abs-in-link) error = %v", err)
+	}
+	if got, want := target, defaultHostVirtualRoot+"/target.txt"; got != want {
+		t.Fatalf("Readlink(abs-in-link) = %q, want %q", got, want)
+	}
+
+	info, err := fsys.Lstat(context.Background(), defaultHostVirtualRoot+"/abs-out-link.txt")
+	if err != nil {
+		t.Fatalf("Lstat(abs-out-link) error = %v", err)
+	}
+	if info.Mode()&stdfs.ModeSymlink == 0 {
+		t.Fatalf("Lstat(abs-out-link).Mode() = %v, want symlink", info.Mode())
+	}
+
+	_, err = fsys.Readlink(context.Background(), defaultHostVirtualRoot+"/abs-out-link.txt")
+	if err == nil {
+		t.Fatal("Readlink(abs-out-link) error = nil, want permission")
+	}
+	if !errors.Is(err, stdfs.ErrPermission) {
+		t.Fatalf("Readlink(abs-out-link) error = %v, want permission", err)
+	}
+	if strings.Contains(err.Error(), outsideRoot) {
+		t.Fatalf("Readlink(abs-out-link) error leaked outside root: %v", err)
+	}
+
+	_, err = fsys.Realpath(context.Background(), defaultHostVirtualRoot+"/abs-out-link.txt")
+	if err == nil {
+		t.Fatal("Realpath(abs-out-link) error = nil, want permission")
+	}
+	if !errors.Is(err, stdfs.ErrPermission) {
+		t.Fatalf("Realpath(abs-out-link) error = %v, want permission", err)
+	}
+}
+
+func assertDirEntries(t *testing.T, fsys *HostFS, dir string, want ...string) {
+	t.Helper()
+
+	entries, err := fsys.ReadDir(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%q) error = %v", dir, err)
+	}
+
+	got := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		got = append(got, entry.Name())
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("ReadDir(%q) = %v, want %v", dir, got, want)
+	}
+}

--- a/fs/host_windows.go
+++ b/fs/host_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package fs
+
+import (
+	"context"
+	"errors"
+)
+
+var errHostUnsupported = errors.New("host-backed filesystem is unsupported on Windows")
+
+type HostFS struct{}
+
+func NewHost(HostOptions) (*HostFS, error) {
+	return nil, errHostUnsupported
+}
+
+func (HostFactory) New(context.Context) (FileSystem, error) {
+	return nil, errHostUnsupported
+}

--- a/fs/overlay.go
+++ b/fs/overlay.go
@@ -176,10 +176,11 @@ func (o *OverlayFS) Readlink(ctx context.Context, name string) (string, error) {
 
 func (o *OverlayFS) Realpath(ctx context.Context, name string) (string, error) {
 	abs := o.resolve(name)
-	if _, _, err := o.visibleInfo(ctx, abs); err != nil {
-		return "", &os.PathError{Op: "realpath", Path: abs, Err: stdfs.ErrNotExist}
+	resolved, err := o.resolveRealpath(ctx, abs, 0)
+	if err != nil {
+		return "", &os.PathError{Op: "realpath", Path: abs, Err: err}
 	}
-	return abs, nil
+	return resolved, nil
 }
 
 func (o *OverlayFS) Symlink(ctx context.Context, target, linkName string) error {
@@ -394,6 +395,58 @@ func (o *OverlayFS) visibleInfo(ctx context.Context, abs string) (stdfs.FileInfo
 		return nil, overlaySourceNone, err
 	}
 	return info, overlaySourceLower, nil
+}
+
+func (o *OverlayFS) resolveRealpath(ctx context.Context, abs string, depth int) (string, error) {
+	abs = Clean(abs)
+	if depth > maxSymlinkDepth {
+		return "", errTooManySymlinks
+	}
+	if abs == "/" {
+		return "/", nil
+	}
+
+	current := "/"
+	parts := strings.Split(strings.TrimPrefix(abs, "/"), "/")
+	for i, part := range parts {
+		next := Resolve(current, part)
+		info, source, err := o.visibleInfo(ctx, next)
+		if err != nil {
+			return "", err
+		}
+		isLast := i == len(parts)-1
+		if info.Mode()&stdfs.ModeSymlink != 0 {
+			target, err := o.readlinkAt(ctx, source, next)
+			if err != nil {
+				return "", err
+			}
+			resolved := Resolve(parentDir(next), target)
+			if !isLast {
+				resolved = Resolve(resolved, path.Join(parts[i+1:]...))
+			}
+			return o.resolveRealpath(ctx, resolved, depth+1)
+		}
+		if isLast {
+			return next, nil
+		}
+		if !info.IsDir() {
+			return "", stdfs.ErrInvalid
+		}
+		current = next
+	}
+
+	return "/", nil
+}
+
+func (o *OverlayFS) readlinkAt(ctx context.Context, source overlaySource, abs string) (string, error) {
+	switch source {
+	case overlaySourceUpper:
+		return o.upper.Readlink(ctx, abs)
+	case overlaySourceLower:
+		return o.lower.Readlink(ctx, abs)
+	default:
+		return "", stdfs.ErrNotExist
+	}
 }
 
 func (o *OverlayFS) resolve(name string) string {

--- a/runtime/host_overlay_test.go
+++ b/runtime/host_overlay_test.go
@@ -1,0 +1,164 @@
+//go:build !windows
+
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	jbfs "github.com/ewhauser/jbgo/fs"
+	"github.com/ewhauser/jbgo/policy"
+)
+
+const hostOverlayVirtualRoot = "/home/agent/project"
+
+func TestOverlayFactoryWithHostLowerSupportsCopyOnWrite(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	rt := newRuntime(t, &Config{
+		DefaultDir: hostOverlayVirtualRoot,
+		FSFactory: jbfs.OverlayFactory{
+			Lower: jbfs.HostFactory{
+				Root:        root,
+				VirtualRoot: hostOverlayVirtualRoot,
+			},
+		},
+	})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "cat seed.txt\necho upper > seed.txt\ncat seed.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "seed\nupper\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "seed.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile(host) error = %v", err)
+	}
+	if got, want := string(data), "seed\n"; got != want {
+		t.Fatalf("host file = %q, want %q", got, want)
+	}
+}
+
+func TestOverlayHostLowerTombstonesDoNotDeleteHostFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	session := newSession(t, &Config{
+		DefaultDir: hostOverlayVirtualRoot,
+		FSFactory: jbfs.OverlayFactory{
+			Lower: jbfs.HostFactory{
+				Root:        root,
+				VirtualRoot: hostOverlayVirtualRoot,
+			},
+		},
+	})
+
+	result, err := session.Exec(context.Background(), &ExecutionRequest{
+		Script: "rm seed.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+
+	if _, err := session.FileSystem().Stat(context.Background(), hostOverlayVirtualRoot+"/seed.txt"); !os.IsNotExist(err) {
+		t.Fatalf("session Stat(seed.txt) error = %v, want not exist", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "seed.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile(host) error = %v", err)
+	}
+	if got, want := string(data), "seed\n"; got != want {
+		t.Fatalf("host file = %q, want %q", got, want)
+	}
+}
+
+func TestOverlayHostLowerDefaultPolicyDeniesSymlinkTraversal(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "target.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.Symlink("target.txt", filepath.Join(root, "link.txt")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	rt := newRuntime(t, &Config{
+		DefaultDir: hostOverlayVirtualRoot,
+		FSFactory: jbfs.OverlayFactory{
+			Lower: jbfs.HostFactory{
+				Root:        root,
+				VirtualRoot: hostOverlayVirtualRoot,
+			},
+		},
+	})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "cat link.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 126 {
+		t.Fatalf("ExitCode = %d, want 126", result.ExitCode)
+	}
+	if !strings.Contains(result.Stderr, "symlink traversal denied") {
+		t.Fatalf("Stderr = %q, want symlink denial", result.Stderr)
+	}
+}
+
+func TestOverlayHostLowerFollowModeAllowsInRootSymlinkReads(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "target.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.Symlink("target.txt", filepath.Join(root, "link.txt")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	rt := newRuntime(t, &Config{
+		DefaultDir: hostOverlayVirtualRoot,
+		FSFactory: jbfs.OverlayFactory{
+			Lower: jbfs.HostFactory{
+				Root:        root,
+				VirtualRoot: hostOverlayVirtualRoot,
+			},
+		},
+		Policy: policy.NewStatic(&policy.Config{
+			ReadRoots:   []string{hostOverlayVirtualRoot, "/usr/bin", "/bin"},
+			WriteRoots:  []string{hostOverlayVirtualRoot},
+			SymlinkMode: policy.SymlinkFollow,
+		}),
+	})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "cat link.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "hello\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add a read-only host-backed `HostFS` and `HostFactory` for use as an `OverlayFactory` lower layer
- mount host content at a configurable virtual root with sanitized errors and a backend-local read cap
- fix `OverlayFS.Realpath` to resolve symlinks through the visible upper/lower overlay state
- update `README.md`, `SPEC.md`, and `TODO.md` to document the new filesystem behavior and parity status

## Testing
- go test ./...