### PR TITLE
compat: show inactive GNU utilities in report

### DIFF
--- a/cmd/jbgo-gnu/main.go
+++ b/cmd/jbgo-gnu/main.go
@@ -82,6 +82,7 @@ type testSummary struct {
 
 type utilityResult struct {
 	Name         string       `json:"name"`
+	Inactive     bool         `json:"inactive,omitempty"`
 	Tests        []string     `json:"tests"`
 	Skipped      []string     `json:"skipped,omitempty"`
 	TestResults  []testResult `json:"test_results,omitempty"`
@@ -280,6 +281,10 @@ func run(ctx context.Context, mf *manifest, opts *options) error {
 		}
 		summary.Utilities = append(summary.Utilities, result)
 		fmt.Printf("%s: %d tests, exit=%d, pass=%s\n", utility.Name, len(tests), makeCheckResult.ExitCode, formatPercent(result.Summary.PassPctSelected))
+	}
+
+	if len(explicitTests) == 0 {
+		summary.Utilities = completeUtilityResults(summary.Utilities, programs, mf.Utilities, selectedUtilities, supportedSet)
 	}
 
 	summary.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
@@ -864,10 +869,14 @@ func summarizeOverall(results []utilityResult) testSummary {
 }
 
 func summarizeUtilityTotals(results []utilityResult) utilityTotals {
-	totals := utilityTotals{Total: len(results)}
+	totals := utilityTotals{}
 	for i := range results {
 		result := &results[i]
-		if result.Summary.SelectedTotal == 0 {
+		if result.Inactive {
+			continue
+		}
+		totals.Total++
+		if result.Summary.RunnableTotal == 0 {
 			totals.NoRunnableTests++
 			continue
 		}
@@ -880,6 +889,57 @@ func summarizeUtilityTotals(results []utilityResult) utilityTotals {
 	totals.PassPctTotal = percentage(totals.Passed, totals.Total)
 	totals.PassPctRunnable = percentage(totals.Passed, totals.Passed+totals.Failed)
 	return totals
+}
+
+func completeUtilityResults(results []utilityResult, programs []string, manifestUtilities, selectedUtilities []utilityManifest, supportedSet map[string]struct{}) []utilityResult {
+	activeByName := make(map[string]utilityResult, len(results))
+	for i := range results {
+		result := results[i]
+		activeByName[result.Name] = result
+	}
+	manifestSet := make(map[string]struct{}, len(manifestUtilities))
+	for _, utility := range manifestUtilities {
+		manifestSet[utility.Name] = struct{}{}
+	}
+	selectedSet := make(map[string]struct{}, len(selectedUtilities))
+	for _, utility := range selectedUtilities {
+		selectedSet[utility.Name] = struct{}{}
+	}
+
+	out := make([]utilityResult, 0, len(programs))
+	for _, name := range programs {
+		if result, ok := activeByName[name]; ok {
+			out = append(out, result)
+			delete(activeByName, name)
+			continue
+		}
+		out = append(out, utilityResult{
+			Name:     name,
+			Inactive: true,
+			Reason:   inactiveUtilityReason(name, manifestSet, selectedSet, supportedSet),
+		})
+	}
+	for i := range results {
+		result := results[i]
+		if _, ok := activeByName[result.Name]; ok {
+			out = append(out, result)
+			delete(activeByName, result.Name)
+		}
+	}
+	return out
+}
+
+func inactiveUtilityReason(name string, manifestSet, selectedSet, supportedSet map[string]struct{}) string {
+	if _, ok := manifestSet[name]; ok {
+		if _, ok := selectedSet[name]; ok {
+			return ""
+		}
+		return "not selected in this run"
+	}
+	if _, ok := supportedSet[name]; ok {
+		return "implemented in jbgo, but not included in the compatibility manifest"
+	}
+	return "not currently covered by the compatibility manifest"
 }
 
 func writeJSON(path string, value any) error {

--- a/cmd/jbgo-gnu/main_test.go
+++ b/cmd/jbgo-gnu/main_test.go
@@ -111,6 +111,13 @@ func TestSummariesComputePercentagesAndRollups(t *testing.T) {
 		Summary: summarizeTestResults(nil, 3, 0),
 		Passed:  false,
 	}
+	fourth := utilityResult{
+		Name: "cp",
+		Summary: summarizeTestResults([]testResult{
+			{Name: "tests/cp/basic.sh", Status: "skip"},
+		}, 0, 0),
+		Passed: true,
+	}
 
 	if got, want := first.Summary.PassPctSelected, 25.0; got != want {
 		t.Fatalf("first pass_pct_selected = %v, want %v", got, want)
@@ -119,8 +126,8 @@ func TestSummariesComputePercentagesAndRollups(t *testing.T) {
 		t.Fatalf("first pass_pct_runnable = %v, want %v", got, want)
 	}
 
-	overall := summarizeOverall([]utilityResult{first, second, third})
-	if got, want := overall.SelectedTotal, 5; got != want {
+	overall := summarizeOverall([]utilityResult{first, second, third, fourth})
+	if got, want := overall.SelectedTotal, 6; got != want {
 		t.Fatalf("overall selected_total = %d, want %d", got, want)
 	}
 	if got, want := overall.FilteredSkipTotal, 5; got != want {
@@ -135,7 +142,7 @@ func TestSummariesComputePercentagesAndRollups(t *testing.T) {
 	if got, want := overall.Fail, 1; got != want {
 		t.Fatalf("overall fail = %d, want %d", got, want)
 	}
-	if got, want := overall.Skip, 1; got != want {
+	if got, want := overall.Skip, 2; got != want {
 		t.Fatalf("overall skip = %d, want %d", got, want)
 	}
 	if got, want := overall.Unreported, 1; got != want {
@@ -144,15 +151,15 @@ func TestSummariesComputePercentagesAndRollups(t *testing.T) {
 	if got, want := overall.RunnableTotal, 3; got != want {
 		t.Fatalf("overall runnable_total = %d, want %d", got, want)
 	}
-	if got, want := overall.PassPctSelected, 40.0; got != want {
+	if got, want := overall.PassPctSelected, 33.33; got != want {
 		t.Fatalf("overall pass_pct_selected = %v, want %v", got, want)
 	}
 	if got, want := overall.PassPctRunnable, 66.67; got != want {
 		t.Fatalf("overall pass_pct_runnable = %v, want %v", got, want)
 	}
 
-	totals := summarizeUtilityTotals([]utilityResult{first, second, third})
-	if got, want := totals.Total, 3; got != want {
+	totals := summarizeUtilityTotals([]utilityResult{first, second, third, fourth})
+	if got, want := totals.Total, 4; got != want {
 		t.Fatalf("utility total = %d, want %d", got, want)
 	}
 	if got, want := totals.Passed, 1; got != want {
@@ -161,14 +168,57 @@ func TestSummariesComputePercentagesAndRollups(t *testing.T) {
 	if got, want := totals.Failed, 1; got != want {
 		t.Fatalf("utility failed = %d, want %d", got, want)
 	}
-	if got, want := totals.NoRunnableTests, 1; got != want {
+	if got, want := totals.NoRunnableTests, 2; got != want {
 		t.Fatalf("utility no_runnable_tests = %d, want %d", got, want)
 	}
-	if got, want := totals.PassPctTotal, 33.33; got != want {
+	if got, want := totals.PassPctTotal, 25.0; got != want {
 		t.Fatalf("utility pass_pct_total = %v, want %v", got, want)
 	}
 	if got, want := totals.PassPctRunnable, 50.0; got != want {
 		t.Fatalf("utility pass_pct_runnable = %v, want %v", got, want)
+	}
+}
+
+func TestCompleteUtilityResultsAddsInactivePlaceholders(t *testing.T) {
+	results := []utilityResult{
+		{
+			Name:   "basename",
+			Passed: true,
+			Summary: testSummary{
+				SelectedTotal:   1,
+				Pass:            1,
+				RunnableTotal:   1,
+				PassPctSelected: 100,
+				PassPctRunnable: 100,
+			},
+		},
+	}
+	programs := []string{"base32", "basename", "expr"}
+	manifestUtilities := []utilityManifest{{Name: "basename"}, {Name: "cat"}}
+	selectedUtilities := []utilityManifest{{Name: "basename"}}
+	supportedSet := map[string]struct{}{
+		"base32":   {},
+		"basename": {},
+	}
+
+	got := completeUtilityResults(results, programs, manifestUtilities, selectedUtilities, supportedSet)
+	if len(got) != 3 {
+		t.Fatalf("completeUtilityResults() len = %d, want 3", len(got))
+	}
+	if got[0].Name != "base32" || !got[0].Inactive {
+		t.Fatalf("base32 row = %#v, want inactive placeholder", got[0])
+	}
+	if got[0].Reason != "implemented in jbgo, but not included in the compatibility manifest" {
+		t.Fatalf("base32 reason = %q", got[0].Reason)
+	}
+	if got[1].Name != "basename" || got[1].Inactive {
+		t.Fatalf("basename row = %#v, want active result", got[1])
+	}
+	if got[2].Name != "expr" || !got[2].Inactive {
+		t.Fatalf("expr row = %#v, want inactive placeholder", got[2])
+	}
+	if got[2].Reason != "not currently covered by the compatibility manifest" {
+		t.Fatalf("expr reason = %q", got[2].Reason)
 	}
 }
 

--- a/scripts/compat-report/main.go
+++ b/scripts/compat-report/main.go
@@ -18,9 +18,8 @@ import (
 var templateFS embed.FS
 
 var indexTemplate = htmltemplate.Must(htmltemplate.New("index.html.tmpl").Funcs(htmltemplate.FuncMap{
-	"formatPercent":   formatPercent,
-	"percentageClass": percentageClass,
-	"utilityNote":     utilityNote,
+	"formatPercent":     formatPercent,
+	"formatPercentOrNA": formatPercentOrNA,
 }).ParseFS(templateFS, "templates/index.html.tmpl"))
 
 var badgeTemplate = texttemplate.Must(texttemplate.New("badge.svg.tmpl").ParseFS(templateFS, "templates/badge.svg.tmpl"))
@@ -64,19 +63,49 @@ type utilityTotals struct {
 }
 
 type utilityResult struct {
-	Name    string      `json:"name"`
-	Skipped []string    `json:"skipped,omitempty"`
-	Summary testSummary `json:"summary"`
-	LogFile string      `json:"log_file,omitempty"`
-	Reason  string      `json:"reason,omitempty"`
+	Name     string      `json:"name"`
+	Inactive bool        `json:"inactive,omitempty"`
+	Skipped  []string    `json:"skipped,omitempty"`
+	Summary  testSummary `json:"summary"`
+	LogFile  string      `json:"log_file,omitempty"`
+	Reason   string      `json:"reason,omitempty"`
 }
 
 type indexView struct {
-	Summary        runSummary
-	OverallDetail  string
-	RunnableDetail string
-	CommandDetail  string
-	FilteredDetail string
+	Summary              runSummary
+	Rows                 []indexUtilityRow
+	CommandSummary       renderedUtilityTotals
+	OverallDetail        string
+	RunnableDetail       string
+	CommandDetail        string
+	FilteredDetail       string
+	CommandPassPercent   float64
+	CommandPassPercentNA bool
+}
+
+type renderedUtilityTotals struct {
+	RunnablePassed int
+	RunnableFailed int
+	SkipOnly       int
+	Empty          int
+	PassPct        float64
+}
+
+type indexUtilityRow struct {
+	Name         string
+	RowClass     string
+	Percent      string
+	PercentClass string
+	Selected     string
+	Pass         string
+	Fail         string
+	Skip         string
+	XFail        string
+	XPass        string
+	Error        string
+	Unreported   string
+	LogFile      string
+	Notes        string
 }
 
 type badgeView struct {
@@ -159,12 +188,17 @@ func writeReport(outputDir string, summary *runSummary) error {
 
 func renderIndex(summary *runSummary) ([]byte, error) {
 	var buf bytes.Buffer
+	commandSummary := summarizeRenderedUtilities(summary.Utilities)
 	view := indexView{
-		Summary:        *summary,
-		OverallDetail:  fmt.Sprintf("%d selected, %d pass, %d fail", summary.Overall.SelectedTotal, summary.Overall.Pass, summary.Overall.Fail),
-		RunnableDetail: fmt.Sprintf("%d runnable, %d skip, %d unreported", summary.Overall.RunnableTotal, summary.Overall.Skip, summary.Overall.Unreported),
-		CommandDetail:  fmt.Sprintf("%d passed, %d failed, %d empty", summary.UtilitySummary.Passed, summary.UtilitySummary.Failed, summary.UtilitySummary.NoRunnableTests),
-		FilteredDetail: fmt.Sprintf("%d extra reported results", summary.Overall.ReportedExtraTotal),
+		Summary:              *summary,
+		Rows:                 buildUtilityRows(summary.Utilities),
+		CommandSummary:       commandSummary,
+		OverallDetail:        fmt.Sprintf("%d selected, %d pass, %d fail, %d skip", summary.Overall.SelectedTotal, summary.Overall.Pass, summary.Overall.Fail, summary.Overall.Skip),
+		RunnableDetail:       fmt.Sprintf("%d runnable, %d pass, %d fail", summary.Overall.RunnableTotal, summary.Overall.Pass, summary.Overall.Fail),
+		CommandDetail:        fmt.Sprintf("%d passed, %d failed, %d skip-only, %d empty", commandSummary.RunnablePassed, commandSummary.RunnableFailed, commandSummary.SkipOnly, commandSummary.Empty),
+		FilteredDetail:       fmt.Sprintf("%d manifest-level skips, %d extra reported results", summary.Overall.FilteredSkipTotal, summary.Overall.ReportedExtraTotal),
+		CommandPassPercent:   commandSummary.PassPct,
+		CommandPassPercentNA: commandSummary.RunnablePassed+commandSummary.RunnableFailed == 0,
 	}
 	if err := indexTemplate.ExecuteTemplate(&buf, "index.html.tmpl", view); err != nil {
 		return nil, err
@@ -201,14 +235,90 @@ func buildBadgeView(summary *runSummary) badgeView {
 	}
 }
 
-func utilityNote(reason string, skipped []string) string {
-	if reason != "" {
-		return reason
+func summarizeRenderedUtilities(results []utilityResult) renderedUtilityTotals {
+	var totals renderedUtilityTotals
+	for i := range results {
+		summary := results[i].Summary
+		switch {
+		case results[i].Inactive:
+			continue
+		case summary.SelectedTotal == 0:
+			totals.Empty++
+		case summary.RunnableTotal == 0:
+			totals.SkipOnly++
+		case summary.Pass == summary.RunnableTotal && summary.Fail == 0 && summary.XPass == 0 && summary.Error == 0 && summary.Unreported == 0:
+			totals.RunnablePassed++
+		default:
+			totals.RunnableFailed++
+		}
 	}
-	if len(skipped) > 0 {
-		return fmt.Sprintf("%d filtered skips", len(skipped))
+	totals.PassPct = percentage(float64(totals.RunnablePassed), float64(totals.RunnablePassed+totals.RunnableFailed))
+	return totals
+}
+
+func buildUtilityRows(results []utilityResult) []indexUtilityRow {
+	rows := make([]indexUtilityRow, 0, len(results))
+	for i := range results {
+		result := &results[i]
+		rows = append(rows, indexUtilityRow{
+			Name:         result.Name,
+			RowClass:     utilityRowClass(result.Inactive),
+			Percent:      utilityPercentText(result),
+			PercentClass: utilityPercentClass(result),
+			Selected:     countOrDash(result.Summary.SelectedTotal, result.Inactive),
+			Pass:         countOrDash(result.Summary.Pass, result.Inactive),
+			Fail:         countOrDash(result.Summary.Fail, result.Inactive),
+			Skip:         countOrDash(result.Summary.Skip, result.Inactive),
+			XFail:        countOrDash(result.Summary.XFail, result.Inactive),
+			XPass:        countOrDash(result.Summary.XPass, result.Inactive),
+			Error:        countOrDash(result.Summary.Error, result.Inactive),
+			Unreported:   countOrDash(result.Summary.Unreported, result.Inactive),
+			LogFile:      result.LogFile,
+			Notes:        utilityNoteText(result),
+		})
+	}
+	return rows
+}
+
+func utilityPercentText(result *utilityResult) string {
+	if result.Inactive {
+		return "-"
+	}
+	if result.Summary.RunnableTotal == 0 {
+		return "n/a"
+	}
+	return formatPercent(result.Summary.PassPctRunnable)
+}
+
+func utilityPercentClass(result *utilityResult) string {
+	if result.Inactive {
+		return "na"
+	}
+	return percentageClass(result.Summary.RunnableTotal, result.Summary.PassPctRunnable)
+}
+
+func utilityRowClass(inactive bool) string {
+	if inactive {
+		return "inactive"
 	}
 	return ""
+}
+
+func utilityNoteText(result *utilityResult) string {
+	var notes []string
+	if result.Reason != "" {
+		notes = append(notes, result.Reason)
+	}
+	if result.Inactive {
+		return strings.Join(notes, "; ")
+	}
+	if result.Summary.SelectedTotal > 0 && result.Summary.RunnableTotal == 0 {
+		notes = append(notes, "all selected tests skipped")
+	}
+	if len(result.Skipped) > 0 {
+		notes = append(notes, fmt.Sprintf("%d filtered skips", len(result.Skipped)))
+	}
+	return strings.Join(notes, "; ")
 }
 
 func badgeTextWidth(text string) int {
@@ -243,6 +353,20 @@ func percentageClass(selected int, percent float64) string {
 	}
 }
 
+func formatPercentOrNA(value float64, na bool) string {
+	if na {
+		return "n/a"
+	}
+	return formatPercent(value)
+}
+
+func countOrDash(value int, inactive bool) string {
+	if inactive {
+		return "-"
+	}
+	return fmt.Sprintf("%d", value)
+}
+
 func formatPercent(value float64) string {
 	if value == 0 {
 		return "0%"
@@ -253,6 +377,13 @@ func formatPercent(value float64) string {
 	formatted := fmt.Sprintf("%.2f", value)
 	formatted = strings.TrimRight(strings.TrimRight(formatted, "0"), ".")
 	return formatted + "%"
+}
+
+func percentage(numerator, denominator float64) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return math.Round((numerator/denominator)*10000) / 100
 }
 
 func fatalf(format string, args ...any) {

--- a/scripts/compat-report/main_test.go
+++ b/scripts/compat-report/main_test.go
@@ -13,18 +13,20 @@ func TestWriteReportWritesIndexAndBadge(t *testing.T) {
 		GNUVersion:  "9.10",
 		GeneratedAt: "2026-03-11T18:30:00Z",
 		Overall: testSummary{
-			SelectedTotal:   2,
+			SelectedTotal:   3,
 			Pass:            1,
 			Fail:            1,
 			RunnableTotal:   2,
-			PassPctSelected: 50,
+			Skip:            1,
+			PassPctSelected: 33.33,
 			PassPctRunnable: 50,
 		},
 		UtilitySummary: utilityTotals{
-			Total:           2,
+			Total:           3,
 			Passed:          1,
 			Failed:          1,
-			PassPctTotal:    50,
+			NoRunnableTests: 1,
+			PassPctTotal:    33.33,
 			PassPctRunnable: 50,
 		},
 		Utilities: []utilityResult{
@@ -32,6 +34,11 @@ func TestWriteReportWritesIndexAndBadge(t *testing.T) {
 				Name:    "basename",
 				LogFile: "basename.log",
 				Summary: testSummary{SelectedTotal: 1, Pass: 1, RunnableTotal: 1, PassPctSelected: 100, PassPctRunnable: 100},
+			},
+			{
+				Name:    "cat",
+				LogFile: "cat.log",
+				Summary: testSummary{SelectedTotal: 1, Skip: 1, RunnableTotal: 0, PassPctSelected: 0, PassPctRunnable: 0},
 			},
 			{
 				Name:   "dirname",
@@ -43,6 +50,11 @@ func TestWriteReportWritesIndexAndBadge(t *testing.T) {
 					PassPctSelected: 0,
 					PassPctRunnable: 0,
 				},
+			},
+			{
+				Name:     "base32",
+				Inactive: true,
+				Reason:   "implemented in jbgo, but not included in the compatibility manifest",
 			},
 		},
 	}
@@ -56,7 +68,24 @@ func TestWriteReportWritesIndexAndBadge(t *testing.T) {
 		t.Fatalf("ReadFile(index.html) error = %v", err)
 	}
 	index := string(indexData)
-	for _, needle := range []string{"GNU Coreutils Compatibility", "summary.json", "basename.log", "dirname", "50%"} {
+	for _, needle := range []string{
+		"GNU Coreutils Compatibility",
+		"Selected Test Pass",
+		"Runnable Command Pass",
+		"summary.json",
+		"basename.log",
+		"dirname",
+		"cat.log",
+		"base32",
+		"<tr class=\"inactive\">",
+		"implemented in jbgo, but not included in the compatibility manifest",
+		"all selected tests skipped",
+		"1 passed, 1 failed, 1 skip-only, 0 empty",
+		"n/a",
+		">-</span>",
+		"33.33%",
+		"50%",
+	} {
 		if !strings.Contains(index, needle) {
 			t.Fatalf("index.html missing %q", needle)
 		}
@@ -67,8 +96,8 @@ func TestWriteReportWritesIndexAndBadge(t *testing.T) {
 		t.Fatalf("ReadFile(badge.svg) error = %v", err)
 	}
 	badge := string(badgeData)
-	if !strings.Contains(badge, "compat") || !strings.Contains(badge, "50%") {
-		t.Fatalf("badge.svg content = %q, want compat and 50%%", badge)
+	if !strings.Contains(badge, "compat") || !strings.Contains(badge, "33.33%") {
+		t.Fatalf("badge.svg content = %q, want compat and 33.33%%", badge)
 	}
 }
 

--- a/scripts/compat-report/templates/index.html.tmpl
+++ b/scripts/compat-report/templates/index.html.tmpl
@@ -99,6 +99,13 @@ th {
   background: rgba(246,244,239,0.85);
 }
 tbody tr:last-child td { border-bottom: 0; }
+.inactive td {
+  color: var(--muted);
+  background: rgba(246,244,239,0.65);
+}
+.inactive a {
+  color: var(--muted);
+}
 .pill {
   display: inline-block;
   min-width: 64px;
@@ -125,7 +132,7 @@ tbody tr:last-child td { border-bottom: 0; }
 
     <section class="cards">
       <article class="card">
-        <div class="card-label">Overall Test Pass</div>
+        <div class="card-label">Selected Test Pass</div>
         <div class="card-value">{{ formatPercent .Summary.Overall.PassPctSelected }}</div>
         <div class="card-detail">{{ .OverallDetail }}</div>
       </article>
@@ -135,8 +142,8 @@ tbody tr:last-child td { border-bottom: 0; }
         <div class="card-detail">{{ .RunnableDetail }}</div>
       </article>
       <article class="card">
-        <div class="card-label">Command Pass</div>
-        <div class="card-value">{{ formatPercent .Summary.UtilitySummary.PassPctRunnable }}</div>
+        <div class="card-label">Runnable Command Pass</div>
+        <div class="card-value">{{ formatPercentOrNA .CommandPassPercent .CommandPassPercentNA }}</div>
         <div class="card-detail">{{ .CommandDetail }}</div>
       </article>
       <article class="card">
@@ -151,7 +158,7 @@ tbody tr:last-child td { border-bottom: 0; }
         <thead>
           <tr>
             <th>Utility</th>
-            <th>Pass %</th>
+            <th>Runnable %</th>
             <th>Selected</th>
             <th>Pass</th>
             <th>Fail</th>
@@ -165,20 +172,20 @@ tbody tr:last-child td { border-bottom: 0; }
           </tr>
         </thead>
         <tbody>
-          {{- range .Summary.Utilities }}
-          <tr>
+          {{- range .Rows }}
+          <tr class="{{ .RowClass }}">
             <td><strong>{{ .Name }}</strong></td>
-            <td><span class="pill {{ percentageClass .Summary.SelectedTotal .Summary.PassPctSelected }}">{{ formatPercent .Summary.PassPctSelected }}</span></td>
-            <td>{{ .Summary.SelectedTotal }}</td>
-            <td>{{ .Summary.Pass }}</td>
-            <td>{{ .Summary.Fail }}</td>
-            <td>{{ .Summary.Skip }}</td>
-            <td>{{ .Summary.XFail }}</td>
-            <td>{{ .Summary.XPass }}</td>
-            <td>{{ .Summary.Error }}</td>
-            <td>{{ .Summary.Unreported }}</td>
+            <td><span class="pill {{ .PercentClass }}">{{ .Percent }}</span></td>
+            <td>{{ .Selected }}</td>
+            <td>{{ .Pass }}</td>
+            <td>{{ .Fail }}</td>
+            <td>{{ .Skip }}</td>
+            <td>{{ .XFail }}</td>
+            <td>{{ .XPass }}</td>
+            <td>{{ .Error }}</td>
+            <td>{{ .Unreported }}</td>
             <td>{{ if .LogFile }}<a href="{{ .LogFile }}">{{ .LogFile }}</a>{{ else }}<span class="notes">n/a</span>{{ end }}</td>
-            <td class="notes">{{ utilityNote .Reason .Skipped }}</td>
+            <td class="notes">{{ .Notes }}</td>
           </tr>
           {{- end }}
         </tbody>


### PR DESCRIPTION
## Summary
- include inactive GNU utilities in `summary.json` so omitted commands still appear in the report
- render inactive utility rows as greyed-out entries with `-` metrics and explanatory notes
- keep command rollups scoped to active utilities with runnable tests

## Testing
- go test ./cmd/jbgo-gnu ./scripts/compat-report