### PR TITLE
compat: cache prepared GNU builds

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -28,6 +28,16 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Compute GNU build cache key
+        id: gnu-build-cache-key
+        run: echo "key=$(./scripts/gnu-build-cache.sh cache-key)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore prepared GNU build archive cache
+        uses: actions/cache@v4
+        with:
+          path: .cache/gnu/prebuilt
+          key: ${{ steps.gnu-build-cache-key.outputs.key }}
+
       - uses: actions/configure-pages@v5
 
       - name: Run GNU compatibility harness

--- a/.github/workflows/gnu-build-cache.yml
+++ b/.github/workflows/gnu-build-cache.yml
@@ -1,0 +1,51 @@
+name: GNU Build Cache
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: gnu-build-cache-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  ensure-release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Ensure build cache release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GNU_BUILD_CACHE_REPO: ${{ github.repository }}
+          GNU_BUILD_CACHE_TAG: gnu-build-cache-v1
+        run: |
+          set -euo pipefail
+          if ! gh release view "$GNU_BUILD_CACHE_TAG" -R "$GNU_BUILD_CACHE_REPO" >/dev/null 2>&1; then
+            gh release create "$GNU_BUILD_CACHE_TAG" \
+              -R "$GNU_BUILD_CACHE_REPO" \
+              --title "GNU build cache" \
+              --notes "Prepared GNU coreutils build caches for the jbgo compatibility harness."
+          fi
+
+  publish:
+    needs: ensure-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+          - runner: macos-14
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Publish prepared GNU build archive
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GNU_BUILD_CACHE_REPO: ${{ github.repository }}
+        run: ./scripts/gnu-build-cache.sh publish

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test build fuzz fuzz-run fuzz-shard fuzz-smoke fuzz-full bench-smoke bench-full gnu-test gnu-test-setup release-check release-snapshot
+.PHONY: lint test build fuzz fuzz-run fuzz-shard fuzz-smoke fuzz-full bench-smoke bench-full gnu-test gnu-test-setup gnu-build-cache-fetch gnu-build-cache-publish release-check release-snapshot
 
 GO_PACKAGES := ./... ./examples/...
 
@@ -13,6 +13,10 @@ BENCH_SMOKE_REGEX ?= Benchmark(NewSession|RuntimeRunSimpleScript|SessionExecWarm
 GNU_CACHE_DIR ?= .cache/gnu
 GNU_JBGO_BIN ?= $(GNU_CACHE_DIR)/bin/jbgo
 GNU_RESULTS_DIR ?=
+GNU_FORCE_REBUILD ?=
+GNU_BUILD_CACHE_REPO ?= ewhauser/jbgo
+GNU_BUILD_CACHE_TAG ?= gnu-build-cache-v1
+GNU_BUILD_CACHE_VERSION ?= v1
 
 FUZZ_SMOKE_SHARD_CORE := \
 	FuzzRuntimeScript \
@@ -134,10 +138,14 @@ gnu-test-setup:
 	mkdir -p $(GNU_CACHE_DIR)/bin
 	go run ./cmd/jbgo-gnu --cache-dir $(GNU_CACHE_DIR) --setup
 
+gnu-build-cache-fetch:
+	GNU_CACHE_DIR='$(GNU_CACHE_DIR)' GNU_JBGO_BIN='$(GNU_JBGO_BIN)' GNU_BUILD_CACHE_REPO='$(GNU_BUILD_CACHE_REPO)' GNU_BUILD_CACHE_TAG='$(GNU_BUILD_CACHE_TAG)' GNU_BUILD_CACHE_VERSION='$(GNU_BUILD_CACHE_VERSION)' ./scripts/gnu-build-cache.sh fetch
+
+gnu-build-cache-publish:
+	GNU_CACHE_DIR='$(GNU_CACHE_DIR)' GNU_JBGO_BIN='$(GNU_JBGO_BIN)' GNU_BUILD_CACHE_REPO='$(GNU_BUILD_CACHE_REPO)' GNU_BUILD_CACHE_TAG='$(GNU_BUILD_CACHE_TAG)' GNU_BUILD_CACHE_VERSION='$(GNU_BUILD_CACHE_VERSION)' ./scripts/gnu-build-cache.sh publish
+
 gnu-test:
-	mkdir -p $(GNU_CACHE_DIR)/bin
-	go build -o $(GNU_JBGO_BIN) ./cmd/jbgo
-	GNU_UTILS='$(GNU_UTILS)' GNU_TESTS='$(GNU_TESTS)' GNU_KEEP_WORKDIR='$(GNU_KEEP_WORKDIR)' GNU_RESULTS_DIR='$(GNU_RESULTS_DIR)' go run ./cmd/jbgo-gnu --cache-dir $(GNU_CACHE_DIR) --jbgo-bin $(GNU_JBGO_BIN) $(if $(GNU_RESULTS_DIR),--results-dir $(GNU_RESULTS_DIR),)
+	GNU_CACHE_DIR='$(GNU_CACHE_DIR)' GNU_JBGO_BIN='$(GNU_JBGO_BIN)' GNU_RESULTS_DIR='$(GNU_RESULTS_DIR)' GNU_UTILS='$(GNU_UTILS)' GNU_TESTS='$(GNU_TESTS)' GNU_KEEP_WORKDIR='$(GNU_KEEP_WORKDIR)' GNU_FORCE_REBUILD='$(GNU_FORCE_REBUILD)' GNU_BUILD_CACHE_REPO='$(GNU_BUILD_CACHE_REPO)' GNU_BUILD_CACHE_TAG='$(GNU_BUILD_CACHE_TAG)' GNU_BUILD_CACHE_VERSION='$(GNU_BUILD_CACHE_VERSION)' ./scripts/gnu-build-cache.sh run
 
 release-check:
 	go run github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION) check

--- a/README.md
+++ b/README.md
@@ -524,7 +524,16 @@ Prepare the pinned GNU source tree:
 make gnu-test-setup
 ```
 
-Run the full configured harness or limit it to selected utilities:
+Fetch the prepared GNU build cache for your platform:
+
+```bash
+make gnu-build-cache-fetch
+```
+
+Run the full configured harness or limit it to selected utilities. `make gnu-test`
+now prefers a prepared GNU build archive from the local cache, then the dedicated
+GitHub Release cache, and only falls back to a local `configure && make` when no
+prepared archive is available:
 
 ```bash
 make gnu-test
@@ -536,6 +545,13 @@ Useful overrides:
 - `GNU_UTILS` limits the utility list.
 - `GNU_TESTS` runs exact GNU test files instead of the manifest-selected utility suites.
 - `GNU_KEEP_WORKDIR=1` preserves the temporary patched/build workdir.
+- `GNU_FORCE_REBUILD=1` bypasses any prepared archive and forces a fresh local GNU build.
+
+Maintainers can refresh the published prepared build archive set with:
+
+```bash
+make gnu-build-cache-publish
+```
 
 ## License
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -973,6 +973,10 @@ The compatibility harness should stay curated. It is not a Bash conformance suit
 - support an explicit results directory so CI and local tooling can publish a stable `summary.json`, with a separate report-rendering script generating `index.html` and `badge.svg` from that summary
 - when the scheduled/manual reporting workflow does not produce a complete report bundle, skip deployment and leave the previously published Pages report in place
 - allow branch and pull-request-adjacent manual runs to generate raw artifacts without attempting a Pages deployment; only the default branch publishes the latest report
+- prefer a prepared GNU build archive fast path for local runs and CI so the harness can skip repeated `configure && make` work on warm runs
+- keep the prepared build archive optional and versioned by GNU release plus a harness cache version, with a full local rebuild fallback when extraction or rehydration fails
+- support a helper script under `scripts/` that can fetch, publish, and run against prepared GNU build archives offline and in CI
+- allow a dedicated GitHub Release tag to seed prepared GNU build archives for supported OS and architecture combinations, with CI cache layered on top for faster repeated runs
 
 ## 18. Future Roadmap
 

--- a/cmd/jbgo-gnu/main.go
+++ b/cmd/jbgo-gnu/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
@@ -50,13 +51,15 @@ type skipPattern struct {
 }
 
 type options struct {
-	cacheDir    string
-	jbgoBin     string
-	utils       string
-	tests       string
-	resultsDir  string
-	setupOnly   bool
-	keepWorkdir bool
+	cacheDir                  string
+	jbgoBin                   string
+	utils                     string
+	tests                     string
+	resultsDir                string
+	preparedBuildArchive      string
+	writePreparedBuildArchive string
+	setupOnly                 bool
+	keepWorkdir               bool
 }
 
 type testResult struct {
@@ -120,7 +123,10 @@ type makeCheckResult struct {
 	Output   []byte
 }
 
-const sourceCacheVersion = "2"
+const (
+	sourceCacheVersion        = "2"
+	preparedBuildCacheVersion = "v1"
+)
 
 func main() {
 	ctx := context.Background()
@@ -145,6 +151,8 @@ func parseOptions() (options, error) {
 	fs.StringVar(&opts.utils, "utils", strings.TrimSpace(os.Getenv("GNU_UTILS")), "comma or space separated utility list")
 	fs.StringVar(&opts.tests, "tests", strings.TrimSpace(os.Getenv("GNU_TESTS")), "comma or newline separated explicit GNU test files")
 	fs.StringVar(&opts.resultsDir, "results-dir", strings.TrimSpace(os.Getenv("GNU_RESULTS_DIR")), "directory to write summary.json, logs, and published report assets")
+	fs.StringVar(&opts.preparedBuildArchive, "prepared-build-archive", strings.TrimSpace(os.Getenv("GNU_PREPARED_BUILD_ARCHIVE")), "path to a prepared GNU build archive to restore before running tests")
+	fs.StringVar(&opts.writePreparedBuildArchive, "write-prepared-build-archive", strings.TrimSpace(os.Getenv("GNU_WRITE_PREPARED_BUILD_ARCHIVE")), "write a prepared GNU build archive to this path, then exit")
 	fs.BoolVar(&opts.setupOnly, "setup", false, "download and extract the pinned GNU source tree, then exit")
 	fs.BoolVar(&opts.keepWorkdir, "keep-workdir", os.Getenv("GNU_KEEP_WORKDIR") == "1", "preserve the per-run workdir")
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -153,8 +161,14 @@ func parseOptions() (options, error) {
 	if fs.NArg() != 0 {
 		return options{}, fmt.Errorf("unexpected arguments: %v", fs.Args())
 	}
-	if !opts.setupOnly && strings.TrimSpace(opts.jbgoBin) == "" {
-		return options{}, fmt.Errorf("--jbgo-bin is required unless --setup is used")
+	if opts.setupOnly && strings.TrimSpace(opts.writePreparedBuildArchive) != "" {
+		return options{}, fmt.Errorf("--setup and --write-prepared-build-archive cannot be combined")
+	}
+	if strings.TrimSpace(opts.preparedBuildArchive) != "" && strings.TrimSpace(opts.writePreparedBuildArchive) != "" {
+		return options{}, fmt.Errorf("--prepared-build-archive and --write-prepared-build-archive cannot be combined")
+	}
+	if !opts.setupOnly && strings.TrimSpace(opts.writePreparedBuildArchive) == "" && strings.TrimSpace(opts.jbgoBin) == "" {
+		return options{}, fmt.Errorf("--jbgo-bin is required unless --setup or --write-prepared-build-archive is used")
 	}
 	return opts, nil
 }
@@ -187,12 +201,28 @@ func run(ctx context.Context, mf *manifest, opts *options) error {
 	if err != nil {
 		return err
 	}
-	sourceDir, err := ensureSourceCache(ctx, mf, cacheDir)
-	if err != nil {
-		return err
-	}
 	if opts.setupOnly {
+		sourceDir, err := ensureSourceCache(ctx, mf, cacheDir)
+		if err != nil {
+			return err
+		}
 		fmt.Printf("GNU coreutils %s prepared at %s\n", mf.GNUVersion, sourceDir)
+		return nil
+	}
+
+	if strings.TrimSpace(opts.writePreparedBuildArchive) != "" {
+		archivePath, err := filepath.Abs(opts.writePreparedBuildArchive)
+		if err != nil {
+			return err
+		}
+		sourceDir, err := ensureSourceCache(ctx, mf, cacheDir)
+		if err != nil {
+			return err
+		}
+		if err := buildPreparedBuildArchive(ctx, makeBin, cacheDir, mf.GNUVersion, sourceDir, archivePath, opts.keepWorkdir); err != nil {
+			return err
+		}
+		fmt.Printf("prepared GNU build archive: %s\n", archivePath)
 		return nil
 	}
 
@@ -204,21 +234,41 @@ func run(ctx context.Context, mf *manifest, opts *options) error {
 		return err
 	}
 
-	workDir, err := prepareWorkDir(cacheDir, mf.GNUVersion, sourceDir)
-	if err != nil {
-		return err
-	}
-	if !opts.keepWorkdir {
-		defer func() { _ = os.RemoveAll(workDir) }()
-	}
-
 	resultsDir, err := prepareResultsDir(cacheDir, opts.resultsDir)
 	if err != nil {
 		return fmt.Errorf("create results dir: %w", err)
 	}
 
-	if err := configureAndBuild(ctx, makeBin, workDir); err != nil {
-		return err
+	preparedArchivePath := strings.TrimSpace(opts.preparedBuildArchive)
+	if preparedArchivePath != "" {
+		preparedArchivePath, err = filepath.Abs(preparedArchivePath)
+		if err != nil {
+			return err
+		}
+	}
+
+	var workDir string
+	if preparedArchivePath != "" {
+		workDir, err = prepareWorkDirFromPreparedArchive(ctx, cacheDir, mf.GNUVersion, preparedArchivePath)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "jbgo-gnu: prepared build archive unavailable (%v); falling back to full build\n", err)
+		}
+	}
+	if workDir == "" {
+		sourceDir, err := ensureSourceCache(ctx, mf, cacheDir)
+		if err != nil {
+			return err
+		}
+		workDir, err = prepareWorkDir(cacheDir, mf.GNUVersion, sourceDir)
+		if err != nil {
+			return err
+		}
+		if err := configureAndBuild(ctx, makeBin, workDir); err != nil {
+			return err
+		}
+	}
+	if !opts.keepWorkdir {
+		defer func() { _ = os.RemoveAll(workDir) }()
 	}
 
 	programs, err := listGNUPrograms(ctx, workDir)
@@ -392,6 +442,156 @@ func prepareWorkDir(cacheDir, version, sourceDir string) (string, error) {
 		return "", fmt.Errorf("copy source tree: %w", err)
 	}
 	return workDir, nil
+}
+
+func prepareWorkDirFromPreparedArchive(ctx context.Context, cacheDir, version, archivePath string) (string, error) {
+	workRoot := filepath.Join(cacheDir, "work")
+	if err := os.MkdirAll(workRoot, 0o755); err != nil {
+		return "", err
+	}
+	workDir, err := os.MkdirTemp(workRoot, "coreutils-"+version+"-")
+	if err != nil {
+		return "", err
+	}
+	if err := extractTarGz(archivePath, workDir); err != nil {
+		_ = os.RemoveAll(workDir)
+		return "", fmt.Errorf("extract prepared GNU build archive: %w", err)
+	}
+	if err := relocatePreparedBuild(ctx, workDir); err != nil {
+		_ = os.RemoveAll(workDir)
+		return "", err
+	}
+	return workDir, nil
+}
+
+func buildPreparedBuildArchive(ctx context.Context, makeBin, cacheDir, version, sourceDir, archivePath string, keepWorkdir bool) error {
+	workDir, err := prepareWorkDir(cacheDir, version, sourceDir)
+	if err != nil {
+		return err
+	}
+	if !keepWorkdir {
+		defer func() { _ = os.RemoveAll(workDir) }()
+	}
+	if err := configureAndBuild(ctx, makeBin, workDir); err != nil {
+		return err
+	}
+	if err := archiveDirectoryAsTarGz(workDir, archivePath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func relocatePreparedBuild(_ context.Context, workDir string) error {
+	originalWorkDir, err := preparedBuildOriginalWorkDir(workDir)
+	if err != nil {
+		return fmt.Errorf("relocate prepared GNU build: %w", err)
+	}
+	if originalWorkDir == "" || originalWorkDir == workDir {
+		return nil
+	}
+
+	return filepath.Walk(workDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if bytes.IndexByte(data, 0) >= 0 || !bytes.Contains(data, []byte(originalWorkDir)) {
+			return nil
+		}
+
+		updated := bytes.ReplaceAll(data, []byte(originalWorkDir), []byte(workDir))
+		if err := os.WriteFile(path, updated, info.Mode().Perm()); err != nil {
+			return err
+		}
+		return os.Chtimes(path, info.ModTime(), info.ModTime())
+	})
+}
+
+func preparedBuildOriginalWorkDir(workDir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(workDir, "config.status"))
+	if err != nil {
+		return "", err
+	}
+	const prefix = "ac_pwd='"
+	start := bytes.Index(data, []byte(prefix))
+	if start == -1 {
+		return "", nil
+	}
+	start += len(prefix)
+	end := bytes.IndexByte(data[start:], '\'')
+	if end == -1 {
+		return "", fmt.Errorf("could not parse original workdir from config.status")
+	}
+	return string(data[start : start+end]), nil
+}
+
+func archiveDirectoryAsTarGz(sourceDir, archivePath string) error {
+	if err := os.MkdirAll(filepath.Dir(archivePath), 0o755); err != nil {
+		return err
+	}
+	file, err := os.Create(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	gzw := gzip.NewWriter(file)
+	defer func() { _ = gzw.Close() }()
+
+	tw := tar.NewWriter(gzw)
+	defer func() { _ = tw.Close() }()
+
+	return filepath.Walk(sourceDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == sourceDir {
+			return nil
+		}
+		rel, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+
+		linkTarget := ""
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err = os.Readlink(path)
+			if err != nil {
+				return err
+			}
+		}
+		hdr, err := tar.FileInfoHeader(info, linkTarget)
+		if err != nil {
+			return err
+		}
+		hdr.Name = rel
+		if info.IsDir() && !strings.HasSuffix(hdr.Name, "/") {
+			hdr.Name += "/"
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		src, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = src.Close() }()
+		if _, err := io.Copy(tw, src); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 func configureAndBuild(ctx context.Context, makeBin, workDir string) error {

--- a/cmd/jbgo-gnu/main_test.go
+++ b/cmd/jbgo-gnu/main_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -306,6 +308,57 @@ func TestPrepareWorkDirPreservesFileTimes(t *testing.T) {
 	}
 }
 
+func TestPrepareWorkDirFromPreparedArchiveRelocatesPathsAndPreservesSymlink(t *testing.T) {
+	cacheDir := t.TempDir()
+	sourceDir := t.TempDir()
+	originalWorkDir := "/tmp/coreutils-build"
+	configStatus := filepath.Join(sourceDir, "config.status")
+	configBody := "#!/bin/sh\nac_pwd='" + originalWorkDir + "'\n"
+	if err := os.WriteFile(configStatus, []byte(configBody), 0o755); err != nil {
+		t.Fatalf("WriteFile(config.status) error = %v", err)
+	}
+	makefilePath := filepath.Join(sourceDir, "Makefile")
+	makefileBody := "abs_top_builddir = " + originalWorkDir + "\n"
+	if err := os.WriteFile(makefilePath, []byte(makefileBody), 0o644); err != nil {
+		t.Fatalf("WriteFile(Makefile) error = %v", err)
+	}
+	targetPath := filepath.Join(sourceDir, "target.txt")
+	if err := os.WriteFile(targetPath, []byte("payload\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(target.txt) error = %v", err)
+	}
+	linkPath := filepath.Join(sourceDir, "link.txt")
+	if err := os.Symlink("target.txt", linkPath); err != nil {
+		t.Fatalf("Symlink(link.txt) error = %v", err)
+	}
+	archivePath := filepath.Join(t.TempDir(), "prepared.tar.gz")
+	if err := archiveDirectoryAsTarGz(sourceDir, archivePath); err != nil {
+		t.Fatalf("archiveDirectoryAsTarGz() error = %v", err)
+	}
+
+	workDir, err := prepareWorkDirFromPreparedArchive(context.Background(), cacheDir, "9.10", archivePath)
+	if err != nil {
+		t.Fatalf("prepareWorkDirFromPreparedArchive() error = %v", err)
+	}
+
+	makefileData, err := os.ReadFile(filepath.Join(workDir, "Makefile"))
+	if err != nil {
+		t.Fatalf("ReadFile(Makefile) error = %v", err)
+	}
+	if strings.Contains(string(makefileData), originalWorkDir) {
+		t.Fatalf("Makefile still mentions original workdir %q", originalWorkDir)
+	}
+	if !strings.Contains(string(makefileData), workDir) {
+		t.Fatalf("Makefile does not mention restored workdir %q", workDir)
+	}
+	target, err := os.Readlink(filepath.Join(workDir, "link.txt"))
+	if err != nil {
+		t.Fatalf("Readlink(link.txt) error = %v", err)
+	}
+	if target != "target.txt" {
+		t.Fatalf("link target = %q, want %q", target, "target.txt")
+	}
+}
+
 func TestExtractTarGzPreservesTarHeaderModTimes(t *testing.T) {
 	archivePath := filepath.Join(t.TempDir(), "coreutils.tar.gz")
 	dest := t.TempDir()
@@ -355,6 +408,30 @@ func TestExtractTarGzPreservesTarHeaderModTimes(t *testing.T) {
 	}
 	if !inInfo.ModTime().Equal(makefileINTime) {
 		t.Fatalf("Makefile.in mod time = %v, want %v", inInfo.ModTime(), makefileINTime)
+	}
+}
+
+func TestParseOptionsAllowsPreparedArchiveWriterWithoutJBGOBin(t *testing.T) {
+	argv := os.Args
+	t.Cleanup(func() { os.Args = argv })
+	os.Args = []string{"jbgo-gnu", "--write-prepared-build-archive", "/tmp/prepared.tar.gz"}
+
+	opts, err := parseOptions()
+	if err != nil {
+		t.Fatalf("parseOptions() error = %v", err)
+	}
+	if opts.writePreparedBuildArchive != "/tmp/prepared.tar.gz" {
+		t.Fatalf("writePreparedBuildArchive = %q, want /tmp/prepared.tar.gz", opts.writePreparedBuildArchive)
+	}
+}
+
+func TestParseOptionsRejectsConflictingPreparedArchiveFlags(t *testing.T) {
+	argv := os.Args
+	t.Cleanup(func() { os.Args = argv })
+	os.Args = []string{"jbgo-gnu", "--jbgo-bin", "/tmp/jbgo", "--prepared-build-archive", "/tmp/in.tar.gz", "--write-prepared-build-archive", "/tmp/out.tar.gz"}
+
+	if _, err := parseOptions(); err == nil {
+		t.Fatalf("parseOptions() error = nil, want conflict error")
 	}
 }
 

--- a/scripts/gnu-build-cache.sh
+++ b/scripts/gnu-build-cache.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+
+GNU_BUILD_CACHE_VERSION=${GNU_BUILD_CACHE_VERSION:-v1}
+GNU_BUILD_CACHE_REPO=${GNU_BUILD_CACHE_REPO:-ewhauser/jbgo}
+GNU_BUILD_CACHE_TAG=${GNU_BUILD_CACHE_TAG:-gnu-build-cache-v1}
+GNU_CACHE_DIR=${GNU_CACHE_DIR:-.cache/gnu}
+GNU_JBGO_BIN=${GNU_JBGO_BIN:-${GNU_CACHE_DIR}/bin/jbgo}
+
+if [[ "$GNU_CACHE_DIR" != /* ]]; then
+  GNU_CACHE_DIR="$REPO_ROOT/$GNU_CACHE_DIR"
+fi
+if [[ "$GNU_JBGO_BIN" != /* ]]; then
+  GNU_JBGO_BIN="$REPO_ROOT/$GNU_JBGO_BIN"
+fi
+
+GNU_VERSION=$(
+  python3 - "$REPO_ROOT/cmd/jbgo-gnu/manifest.json" <<'PY'
+import json, sys
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    print(json.load(f)["gnu_version"])
+PY
+)
+
+HOST_GOOS=$(cd "$REPO_ROOT" && go env GOOS)
+HOST_GOARCH=$(cd "$REPO_ROOT" && go env GOARCH)
+ASSET_BASENAME="gnu-build-cache_${GNU_BUILD_CACHE_VERSION}_coreutils-${GNU_VERSION}_${HOST_GOOS}_${HOST_GOARCH}"
+ARCHIVE_NAME="${ASSET_BASENAME}.tar.gz"
+SHA_NAME="${ARCHIVE_NAME}.sha256"
+META_NAME="${ASSET_BASENAME}.json"
+PREBUILT_DIR="${GNU_CACHE_DIR}/prebuilt"
+ARCHIVE_PATH="${PREBUILT_DIR}/${ARCHIVE_NAME}"
+SHA_PATH="${PREBUILT_DIR}/${SHA_NAME}"
+META_PATH="${PREBUILT_DIR}/${META_NAME}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/gnu-build-cache.sh archive-dir
+  scripts/gnu-build-cache.sh archive-path
+  scripts/gnu-build-cache.sh cache-key
+  scripts/gnu-build-cache.sh fetch
+  scripts/gnu-build-cache.sh publish
+  scripts/gnu-build-cache.sh run
+EOF
+}
+
+need_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing required tool: $1" >&2
+    exit 1
+  }
+}
+
+compute_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+    return
+  fi
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+verify_sha256() {
+  local archive_path=$1
+  local sha_path=$2
+  local expected actual
+  expected=$(awk '{print $1}' "$sha_path")
+  actual=$(compute_sha256 "$archive_path")
+  if [[ "$expected" != "$actual" ]]; then
+    echo "checksum mismatch for $archive_path" >&2
+    echo "expected: $expected" >&2
+    echo "actual:   $actual" >&2
+    exit 1
+  fi
+}
+
+ensure_archive_dir() {
+  mkdir -p "$PREBUILT_DIR"
+}
+
+write_metadata() {
+  local archive_path=$1
+  local sha256=$2
+  cat > "$META_PATH" <<EOF
+{
+  "cache_version": "${GNU_BUILD_CACHE_VERSION}",
+  "gnu_version": "${GNU_VERSION}",
+  "goos": "${HOST_GOOS}",
+  "goarch": "${HOST_GOARCH}",
+  "archive_name": "${ARCHIVE_NAME}",
+  "archive_path": "${archive_path}",
+  "archive_sha256": "${sha256}",
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "release_repo": "${GNU_BUILD_CACHE_REPO}",
+  "release_tag": "${GNU_BUILD_CACHE_TAG}"
+}
+EOF
+}
+
+fetch_archive() {
+  ensure_archive_dir
+  if [[ -f "$ARCHIVE_PATH" && -f "$SHA_PATH" ]]; then
+    verify_sha256 "$ARCHIVE_PATH" "$SHA_PATH"
+    echo "$ARCHIVE_PATH"
+    return
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "gh is not installed; cannot fetch prepared GNU build archive" >&2
+    return 1
+  fi
+
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+
+  gh release download "$GNU_BUILD_CACHE_TAG" \
+    -R "$GNU_BUILD_CACHE_REPO" \
+    -D "$tmpdir" \
+    -p "$ARCHIVE_NAME" \
+    -p "$SHA_NAME" \
+    -p "$META_NAME"
+
+  mv "$tmpdir/$ARCHIVE_NAME" "$ARCHIVE_PATH"
+  mv "$tmpdir/$SHA_NAME" "$SHA_PATH"
+  mv "$tmpdir/$META_NAME" "$META_PATH"
+  verify_sha256 "$ARCHIVE_PATH" "$SHA_PATH"
+  echo "$ARCHIVE_PATH"
+}
+
+publish_archive() {
+  need_tool gh
+  ensure_archive_dir
+
+  local tmpdir archive sha256
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+  archive="$tmpdir/$ARCHIVE_NAME"
+
+  (
+    cd "$REPO_ROOT"
+    go run ./cmd/jbgo-gnu --cache-dir "$GNU_CACHE_DIR" --write-prepared-build-archive "$archive"
+  )
+
+  sha256=$(compute_sha256 "$archive")
+  printf '%s  %s\n' "$sha256" "$ARCHIVE_NAME" > "$tmpdir/$SHA_NAME"
+  cp "$archive" "$ARCHIVE_PATH"
+  cp "$tmpdir/$SHA_NAME" "$SHA_PATH"
+  write_metadata "$ARCHIVE_PATH" "$sha256"
+  cp "$META_PATH" "$tmpdir/$META_NAME"
+
+  if ! gh release view "$GNU_BUILD_CACHE_TAG" -R "$GNU_BUILD_CACHE_REPO" >/dev/null 2>&1; then
+    gh release create "$GNU_BUILD_CACHE_TAG" \
+      -R "$GNU_BUILD_CACHE_REPO" \
+      --title "GNU build cache" \
+      --notes "Prepared GNU coreutils build caches for the jbgo compatibility harness."
+  fi
+
+  gh release upload "$GNU_BUILD_CACHE_TAG" \
+    -R "$GNU_BUILD_CACHE_REPO" \
+    --clobber \
+    "$archive" \
+    "$tmpdir/$SHA_NAME" \
+    "$tmpdir/$META_NAME"
+
+  echo "$ARCHIVE_PATH"
+}
+
+run_harness() {
+  local use_archive=1
+
+  ensure_archive_dir
+  mkdir -p "$(dirname "$GNU_JBGO_BIN")"
+
+  if [[ "${GNU_FORCE_REBUILD:-0}" == "1" ]]; then
+    use_archive=0
+  elif [[ ! -f "$ARCHIVE_PATH" ]]; then
+    if ! fetch_archive >/dev/null 2>&1; then
+      echo "prepared GNU build archive unavailable; building local archive" >&2
+      publish_local_archive
+    fi
+  fi
+
+  (
+    cd "$REPO_ROOT"
+    go build -o "$GNU_JBGO_BIN" ./cmd/jbgo
+  )
+
+  local cmd=(go run ./cmd/jbgo-gnu --cache-dir "$GNU_CACHE_DIR" --jbgo-bin "$GNU_JBGO_BIN")
+  if [[ -n "${GNU_RESULTS_DIR:-}" ]]; then
+    cmd+=(--results-dir "$GNU_RESULTS_DIR")
+  fi
+  if [[ $use_archive -eq 1 ]]; then
+    cmd+=(--prepared-build-archive "$ARCHIVE_PATH")
+  fi
+
+  (
+    cd "$REPO_ROOT"
+    "${cmd[@]}"
+  )
+}
+
+publish_local_archive() {
+  ensure_archive_dir
+  (
+    cd "$REPO_ROOT"
+    go run ./cmd/jbgo-gnu --cache-dir "$GNU_CACHE_DIR" --write-prepared-build-archive "$ARCHIVE_PATH"
+  )
+  local sha256
+  sha256=$(compute_sha256 "$ARCHIVE_PATH")
+  printf '%s  %s\n' "$sha256" "$ARCHIVE_NAME" > "$SHA_PATH"
+  write_metadata "$ARCHIVE_PATH" "$sha256"
+}
+
+subcommand=${1:-}
+case "$subcommand" in
+  archive-dir)
+    echo "$PREBUILT_DIR"
+    ;;
+  archive-path)
+    echo "$ARCHIVE_PATH"
+    ;;
+  cache-key)
+    echo "gnu-build-cache-${GNU_BUILD_CACHE_VERSION}-${HOST_GOOS}-${HOST_GOARCH}-coreutils-${GNU_VERSION}"
+    ;;
+  fetch)
+    fetch_archive
+    ;;
+  publish)
+    publish_archive
+    ;;
+  run)
+    run_harness
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add prepared GNU build archive support to `jbgo-gnu` so warm compat runs can skip repeated `configure && make`
- add `scripts/gnu-build-cache.sh` plus `make` targets for fetch, publish, and run flows
- add Actions cache and a manual GitHub Release publish workflow for the prepared GNU build archives

## Testing
- go test ./...
- bash -n scripts/gnu-build-cache.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/compat.yml"); YAML.load_file(".github/workflows/gnu-build-cache.yml")'
- go run ./cmd/jbgo-gnu --cache-dir .cache/gnu-smoke --write-prepared-build-archive .cache/gnu-smoke/prebuilt/test-prepared.tar.gz
- GNU_CACHE_DIR=.cache/gnu GNU_RESULTS_DIR=.cache/gnu/results/script-basename GNU_UTILS=basename ./scripts/gnu-build-cache.sh run
- GNU_UTILS=basename GNU_RESULTS_DIR=.cache/gnu/results/make-basename make gnu-test