### PR TITLE
runtime: batch GNU harness utility runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ dist/
 
 # Go fuzz generated artifacts
 runtime/testdata/fuzz/Fuzz*/
+
+gbash-gnu

--- a/cmd/gbash-gnu/main_test.go
+++ b/cmd/gbash-gnu/main_test.go
@@ -224,6 +224,127 @@ func TestCompleteUtilityResultsAddsInactivePlaceholders(t *testing.T) {
 	}
 }
 
+func TestCombinedTestsForRunsDeduplicatesSharedTests(t *testing.T) {
+	runs := []utilityRun{
+		{
+			Utility: utilityManifest{Name: "dir"},
+			Tests:   []string{"tests/misc/invalid-opt.pl"},
+		},
+		{
+			Utility: utilityManifest{Name: "link"},
+			Tests:   []string{"tests/misc/invalid-opt.pl"},
+		},
+		{
+			Utility: utilityManifest{Name: "test"},
+			Tests:   []string{"tests/misc/invalid-opt.pl"},
+		},
+	}
+
+	got := combinedTestsForRuns(runs)
+	want := []string{"tests/misc/invalid-opt.pl"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("combinedTestsForRuns() = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildBatchedUtilityResultsSharesLogAndSynthesizesExitCodes(t *testing.T) {
+	runs := []utilityRun{
+		{
+			Utility: utilityManifest{Name: "basename", Patterns: []string{"tests/misc/basename*"}},
+			Tests:   []string{"tests/misc/basename.pl"},
+		},
+		{
+			Utility: utilityManifest{Name: "dirname", Patterns: []string{"tests/misc/dirname*"}},
+			Tests:   []string{"tests/misc/dirname.pl"},
+		},
+	}
+
+	got := buildBatchedUtilityResults(runs, makeCheckResult{
+		ExitCode: 1,
+		Output: []byte(`
+PASS: tests/misc/basename.pl
+FAIL: tests/misc/dirname.pl
+`),
+	}, "compat.log", "/tmp/compat.log")
+
+	if len(got) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(got))
+	}
+	if !got[0].Passed || got[0].ExitCode != 0 {
+		t.Fatalf("basename result = %#v, want passed with exit 0", got[0])
+	}
+	if got[0].LogFile != "compat.log" || got[0].LogPath != "/tmp/compat.log" {
+		t.Fatalf("basename log = (%q, %q), want shared compat.log", got[0].LogFile, got[0].LogPath)
+	}
+	if got[1].Passed || got[1].ExitCode != 1 {
+		t.Fatalf("dirname result = %#v, want failed with exit 1", got[1])
+	}
+	if got[1].Summary.Fail != 1 {
+		t.Fatalf("dirname summary = %#v, want one failure", got[1].Summary)
+	}
+}
+
+func TestBuildBatchedUtilityResultsReusesSharedManifestTestAcrossUtilities(t *testing.T) {
+	runs := []utilityRun{
+		{
+			Utility: utilityManifest{Name: "dir", Patterns: []string{"tests/misc/invalid-opt.pl"}},
+			Tests:   []string{"tests/misc/invalid-opt.pl"},
+		},
+		{
+			Utility: utilityManifest{Name: "link", Patterns: []string{"tests/misc/invalid-opt.pl"}},
+			Tests:   []string{"tests/misc/invalid-opt.pl"},
+		},
+		{
+			Utility: utilityManifest{Name: "test", Patterns: []string{"tests/misc/invalid-opt.pl"}},
+			Tests:   []string{"tests/misc/invalid-opt.pl"},
+		},
+	}
+
+	got := buildBatchedUtilityResults(runs, makeCheckResult{
+		ExitCode: 0,
+		Output:   []byte("PASS: tests/misc/invalid-opt.pl\n"),
+	}, "compat.log", "/tmp/compat.log")
+
+	if len(got) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(got))
+	}
+	for _, result := range got {
+		if !result.Passed || result.ExitCode != 0 {
+			t.Fatalf("%s result = %#v, want passed with exit 0", result.Name, result)
+		}
+		if len(result.TestResults) != 1 || result.TestResults[0].Status != "pass" {
+			t.Fatalf("%s test results = %#v, want shared pass", result.Name, result.TestResults)
+		}
+	}
+}
+
+func TestBuildBatchedUtilityResultsAttributesMatchingExtras(t *testing.T) {
+	runs := []utilityRun{
+		{
+			Utility: utilityManifest{Name: "basename", Patterns: []string{"tests/misc/basename*"}},
+			Tests:   []string{"tests/misc/basename.pl"},
+		},
+	}
+
+	got := buildBatchedUtilityResults(runs, makeCheckResult{
+		ExitCode: 1,
+		Output: []byte(`
+PASS: tests/misc/basename.pl
+FAIL: tests/misc/basename-extra.pl
+`),
+	}, "compat.log", "/tmp/compat.log")
+
+	if len(got) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(got))
+	}
+	if len(got[0].ExtraResults) != 1 || got[0].ExtraResults[0].Name != "tests/misc/basename-extra.pl" {
+		t.Fatalf("extra results = %#v, want matched basename extra", got[0].ExtraResults)
+	}
+	if got[0].Summary.ReportedExtraTotal != 1 {
+		t.Fatalf("reported extra total = %d, want 1", got[0].Summary.ReportedExtraTotal)
+	}
+}
+
 func TestPrepareResultsDirCreatesParentAndRunDir(t *testing.T) {
 	cacheDir := t.TempDir()
 

--- a/cmd/gbash-gnu/run.go
+++ b/cmd/gbash-gnu/run.go
@@ -216,32 +216,70 @@ func executeCompatibilityRun(ctx context.Context, makeBin string, mf *manifest, 
 		WorkDir:    env.workDir,
 		ResultsDir: env.resultsDir,
 	}
-	hadFailure := false
-	for _, utility := range plan.runTargets {
-		tests, skipped, err := resolveUtilityTests(env.workDir, utility, mf.SkipPatterns, plan.explicitTests)
+	utilityRuns, err := resolveUtilityRuns(env.workDir, plan.runTargets, mf.SkipPatterns, plan.explicitTests)
+	if err != nil {
+		return runSummary{}, false, err
+	}
+
+	results, hadFailure, err := executeUtilityRuns(ctx, makeBin, env, plan.configShell, utilityRuns)
+	if err != nil {
+		return runSummary{}, false, err
+	}
+	summary.Utilities = append(summary.Utilities, results...)
+
+	if len(plan.explicitTests) == 0 {
+		summary.Utilities = completeUtilityResults(summary.Utilities, plan.programs, mf.Utilities, plan.selectedUtilities, plan.supportedSet)
+	}
+	return summary, hadFailure, nil
+}
+
+func resolveUtilityRuns(workDir string, runTargets []utilityManifest, globalSkips []skipPattern, explicitTests []string) ([]utilityRun, error) {
+	runs := make([]utilityRun, 0, len(runTargets))
+	for _, utility := range runTargets {
+		tests, skipped, err := resolveUtilityTests(workDir, utility, globalSkips, explicitTests)
 		if err != nil {
-			return runSummary{}, false, err
+			return nil, err
 		}
-		result := utilityResult{
-			Name:    utility.Name,
+		runs = append(runs, utilityRun{
+			Utility: utility,
 			Tests:   tests,
 			Skipped: skipped,
-			Summary: summarizeTestResults(nil, len(skipped), 0),
+		})
+	}
+	return runs, nil
+}
+
+func executeUtilityRuns(ctx context.Context, makeBin string, env *executionEnv, configShell string, runs []utilityRun) ([]utilityResult, bool, error) {
+	if len(runs) <= 1 {
+		return executeUtilityRunsIndividually(ctx, makeBin, env, configShell, runs)
+	}
+	return executeUtilityRunsBatched(ctx, makeBin, env, configShell, runs)
+}
+
+func executeUtilityRunsIndividually(ctx context.Context, makeBin string, env *executionEnv, configShell string, runs []utilityRun) ([]utilityResult, bool, error) {
+	results := make([]utilityResult, 0, len(runs))
+	hadFailure := false
+	for _, run := range runs {
+		result := utilityResult{
+			Name:    run.Utility.Name,
+			Tests:   run.Tests,
+			Skipped: run.Skipped,
+			Summary: summarizeTestResults(nil, len(run.Skipped), 0),
 		}
-		if len(tests) == 0 {
+		if len(run.Tests) == 0 {
 			result.Reason = "no runnable GNU tests matched after applying skip filters"
-			summary.Utilities = append(summary.Utilities, result)
+			results = append(results, result)
 			continue
 		}
 
-		logFile := utility.Name + ".log"
+		logFile := run.Utility.Name + ".log"
 		logPath := filepath.Join(env.resultsDir, logFile)
-		makeCheckResult, err := runMakeCheck(ctx, makeBin, env.workDir, plan.configShell, tests, logPath)
+		makeCheckResult, err := runMakeCheck(ctx, makeBin, env.workDir, configShell, run.Tests, logPath)
 		if err != nil {
-			return runSummary{}, false, err
+			return nil, false, err
 		}
-		result.TestResults, result.ExtraResults = parseReportedTestResults(makeCheckResult.Output, tests)
-		result.Summary = summarizeTestResults(result.TestResults, len(skipped), len(result.ExtraResults))
+		result.TestResults, result.ExtraResults = parseReportedTestResults(makeCheckResult.Output, run.Tests)
+		result.Summary = summarizeTestResults(result.TestResults, len(run.Skipped), len(result.ExtraResults))
 		result.LogFile = logFile
 		result.LogPath = logPath
 		result.ExitCode = makeCheckResult.ExitCode
@@ -249,12 +287,140 @@ func executeCompatibilityRun(ctx context.Context, makeBin string, mf *manifest, 
 		if makeCheckResult.ExitCode != 0 {
 			hadFailure = true
 		}
-		summary.Utilities = append(summary.Utilities, result)
-		fmt.Printf("%s: %d tests, exit=%d, pass=%s\n", utility.Name, len(tests), makeCheckResult.ExitCode, formatPercent(result.Summary.PassPctSelected))
+		results = append(results, result)
+		fmt.Printf("%s: %d tests, exit=%d, pass=%s\n", run.Utility.Name, len(run.Tests), makeCheckResult.ExitCode, formatPercent(result.Summary.PassPctSelected))
+	}
+	return results, hadFailure, nil
+}
+
+func executeUtilityRunsBatched(ctx context.Context, makeBin string, env *executionEnv, configShell string, runs []utilityRun) ([]utilityResult, bool, error) {
+	combinedTests := combinedTestsForRuns(runs)
+	if len(combinedTests) == 0 {
+		results := make([]utilityResult, 0, len(runs))
+		for _, run := range runs {
+			result := utilityResult{
+				Name:    run.Utility.Name,
+				Tests:   run.Tests,
+				Skipped: run.Skipped,
+				Summary: summarizeTestResults(nil, len(run.Skipped), 0),
+				Reason:  "no runnable GNU tests matched after applying skip filters",
+			}
+			results = append(results, result)
+		}
+		return results, false, nil
 	}
 
-	if len(plan.explicitTests) == 0 {
-		summary.Utilities = completeUtilityResults(summary.Utilities, plan.programs, mf.Utilities, plan.selectedUtilities, plan.supportedSet)
+	logFile := "compat.log"
+	logPath := filepath.Join(env.resultsDir, logFile)
+	makeCheckResult, err := runMakeCheck(ctx, makeBin, env.workDir, configShell, combinedTests, logPath)
+	if err != nil {
+		return nil, false, err
 	}
-	return summary, hadFailure, nil
+
+	results := buildBatchedUtilityResults(runs, makeCheckResult, logFile, logPath)
+	hadFailure := false
+	for i := range results {
+		result := &results[i]
+		if !result.Passed && len(result.Tests) != 0 {
+			hadFailure = true
+		}
+		fmt.Printf("%s: %d tests, exit=%d, pass=%s\n", result.Name, len(result.Tests), result.ExitCode, formatPercent(result.Summary.PassPctSelected))
+	}
+	return results, hadFailure, nil
+}
+
+func combinedTestsForRuns(runs []utilityRun) []string {
+	combined := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, run := range runs {
+		for _, test := range run.Tests {
+			if _, ok := seen[test]; ok {
+				continue
+			}
+			seen[test] = struct{}{}
+			combined = append(combined, test)
+		}
+	}
+	return combined
+}
+
+func buildBatchedUtilityResults(runs []utilityRun, makeCheckResult makeCheckResult, logFile, logPath string) []utilityResult {
+	combinedTests := combinedTestsForRuns(runs)
+	combinedResults, combinedExtras := parseReportedTestResults(makeCheckResult.Output, combinedTests)
+	resultByName := make(map[string]testResult, len(combinedResults))
+	for _, result := range combinedResults {
+		resultByName[result.Name] = result
+	}
+
+	results := make([]utilityResult, 0, len(runs))
+	for _, run := range runs {
+		result := utilityResult{
+			Name:    run.Utility.Name,
+			Tests:   run.Tests,
+			Skipped: run.Skipped,
+			Summary: summarizeTestResults(nil, len(run.Skipped), 0),
+		}
+		if len(run.Tests) == 0 {
+			result.Reason = "no runnable GNU tests matched after applying skip filters"
+			results = append(results, result)
+			continue
+		}
+
+		testResults := make([]testResult, 0, len(run.Tests))
+		for _, testName := range run.Tests {
+			canonicalName := filepath.ToSlash(testName)
+			if mapped, ok := resultByName[canonicalName]; ok {
+				testResults = append(testResults, mapped)
+				continue
+			}
+			testResults = append(testResults, testResult{Name: canonicalName, Status: "unreported"})
+		}
+
+		extraResults := extraResultsForUtility(run.Utility, combinedExtras)
+		result.TestResults = testResults
+		result.ExtraResults = extraResults
+		result.Summary = summarizeTestResults(result.TestResults, len(run.Skipped), len(result.ExtraResults))
+		result.LogFile = logFile
+		result.LogPath = logPath
+		result.ExitCode = utilityExitCode(&result.Summary, makeCheckResult.ExitCode)
+		result.Passed = utilityPassed(&result.Summary)
+		results = append(results, result)
+	}
+	return results
+}
+
+func extraResultsForUtility(utility utilityManifest, extras []testResult) []testResult {
+	if len(extras) == 0 {
+		return nil
+	}
+	filtered := make([]testResult, 0)
+	for _, extra := range extras {
+		if utilityMatchesTestPath(utility, extra.Name) {
+			filtered = append(filtered, extra)
+		}
+	}
+	return filtered
+}
+
+func utilityMatchesTestPath(utility utilityManifest, rel string) bool {
+	for _, pattern := range utility.Patterns {
+		if matched, err := filepath.Match(pattern, rel); err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
+
+func utilityPassed(summary *testSummary) bool {
+	return summary.Fail == 0 && summary.XPass == 0 && summary.Error == 0 && summary.Unreported == 0
+}
+
+func utilityExitCode(summary *testSummary, batchExitCode int) int {
+	if utilityPassed(summary) {
+		return 0
+	}
+	if batchExitCode != 0 {
+		return batchExitCode
+	}
+	return 1
 }

--- a/cmd/gbash-gnu/types.go
+++ b/cmd/gbash-gnu/types.go
@@ -92,4 +92,10 @@ type makeCheckResult struct {
 	Output   []byte
 }
 
+type utilityRun struct {
+	Utility utilityManifest
+	Tests   []string
+	Skipped []string
+}
+
 const sourceCacheVersion = "2"


### PR DESCRIPTION
## Summary
- batch multi-utility GNU harness runs into a single `make check` invocation
- split the combined log back into per-utility summary rows while keeping the existing `summary.json` shape
- add unit coverage for shared test deduping, per-utility exit code synthesis, and extra-result attribution

## Why
The GNU harness was invoking `make check` once per selected utility. That repeated GNU test harness setup and rebuild/relink work in the same copied coreutils tree, which dominated runtime.

On the same machine:
- `GNU_UTILS='basename dirname'` previously took about `49s`
- the same two tests now complete in about `5.8s`

## Verification
- `go test ./cmd/gbash-gnu -count=1`
- `/usr/bin/time -p env GNU_UTILS='basename dirname' GNU_KEEP_WORKDIR=1 GNU_FORCE_REBUILD=0 GNU_RESULTS_DIR=.cache/gnu/results/eval-small-batched ./scripts/gnu-build-cache.sh run`
