### PR TITLE
tail: harden follow-by-name CI coverage

### DIFF
--- a/cmd/gbash/cli_test.go
+++ b/cmd/gbash/cli_test.go
@@ -392,7 +392,7 @@ func TestRunCLICompatExecTailFollowByNameHandlesRenameAndReplacement(t *testing.
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	stdout := newStreamingWriter()
@@ -415,27 +415,36 @@ func TestRunCLICompatExecTailFollowByNameHandlesRenameAndReplacement(t *testing.
 	if err := os.WriteFile(filepath.Join(tmp, "a"), []byte("x\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(a) error = %v", err)
 	}
-	if !stdout.WaitForSubstring("==> a <==\nx\n", time.Second) {
+	if !stdout.WaitForSubstring("==> a <==\nx\n", 1500*time.Millisecond) {
 		t.Fatalf("stdout did not emit followed content for a; got %q", stdout.String())
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "b"), []byte("b0\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(b) error = %v", err)
+	}
+	if !stdout.WaitForSubstring("==> b <==\nb0\n", 1500*time.Millisecond) {
+		t.Fatalf("stdout did not emit followed content for b; got %q", stdout.String())
 	}
 
 	if err := os.Rename(filepath.Join(tmp, "a"), filepath.Join(tmp, "b")); err != nil {
 		t.Fatalf("Rename(a,b) error = %v", err)
 	}
-	if !stderr.WaitForSubstring("has become inaccessible", time.Second) {
+	if !stderr.WaitForSubstring("'a' has become inaccessible", 1500*time.Millisecond) {
 		t.Fatalf("stderr did not report inaccessible file; got %q", stderr.String())
 	}
-	if !stderr.WaitForSubstring("has been replaced", time.Second) {
+	if !stderr.WaitForSubstring("'b' has been replaced", 1500*time.Millisecond) {
 		t.Fatalf("stderr did not report replaced file; got %q", stderr.String())
+	}
+	if !stdout.WaitForSubstring("==> b <==\nb0\nx\n", 1500*time.Millisecond) {
+		t.Fatalf("stdout did not emit replacement content for b; got %q", stdout.String())
 	}
 
 	if err := os.WriteFile(filepath.Join(tmp, "a"), []byte("x2\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(a) second generation error = %v", err)
 	}
-	if !stderr.WaitForSubstring("has appeared", time.Second) {
+	if !stderr.WaitForSubstring("'a' has appeared", 1500*time.Millisecond) {
 		t.Fatalf("stderr did not report file appearance; got %q", stderr.String())
 	}
-	if !stdout.WaitForSubstring("==> a <==\nx2\n", time.Second) {
+	if !stdout.WaitForSubstring("==> a <==\nx2\n", 1500*time.Millisecond) {
 		t.Fatalf("stdout did not emit replacement content for a; got %q", stdout.String())
 	}
 
@@ -450,7 +459,7 @@ func TestRunCLICompatExecTailFollowByNameHandlesRenameAndReplacement(t *testing.
 	if err := bFile.Close(); err != nil {
 		t.Fatalf("Close(b) error = %v", err)
 	}
-	if !stdout.WaitForSubstring("==> b <==\ny\n", time.Second) {
+	if !stdout.WaitForSubstring("==> b <==\ny\n", 1500*time.Millisecond) {
 		t.Fatalf("stdout did not continue following renamed b; got %q", stdout.String())
 	}
 
@@ -465,7 +474,7 @@ func TestRunCLICompatExecTailFollowByNameHandlesRenameAndReplacement(t *testing.
 	if err := aFile.Close(); err != nil {
 		t.Fatalf("Close(a) error = %v", err)
 	}
-	if !stdout.WaitForSubstring("==> a <==\nz\n", time.Second) {
+	if !stdout.WaitForSubstring("==> a <==\nz\n", 1500*time.Millisecond) {
 		t.Fatalf("stdout did not continue following recreated a; got %q", stdout.String())
 	}
 
@@ -567,15 +576,15 @@ func TestRunCLICompatExecTailFollowByNameWithoutRetryStopsWhenFileDisappears(t *
 	tmp := t.TempDir()
 	t.Chdir(tmp)
 
-	if err := os.WriteFile(filepath.Join(tmp, "file"), nil, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "file"), []byte("seed\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(file) error = %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
 	defer cancel()
 
-	var stdout strings.Builder
-	var stderr strings.Builder
+	stdout := newStreamingWriter()
+	stderr := newStreamingWriter()
 	done := make(chan struct {
 		exitCode int
 		err      error
@@ -584,14 +593,16 @@ func TestRunCLICompatExecTailFollowByNameWithoutRetryStopsWhenFileDisappears(t *
 	go func() {
 		exitCode, err := runCLI(ctx, "gbash", []string{
 			"compat", "exec", "tail", "--follow=name", "-s0.05", "--max-unchanged-stats=1", "file",
-		}, strings.NewReader(""), &stdout, &stderr, false)
+		}, strings.NewReader(""), stdout, stderr, false)
 		done <- struct {
 			exitCode int
 			err      error
 		}{exitCode: exitCode, err: err}
 	}()
 
-	time.Sleep(150 * time.Millisecond)
+	if !stdout.WaitForSubstring("seed\n", time.Second) {
+		t.Fatalf("stdout did not emit initial content; got %q", stdout.String())
+	}
 	if err := os.Rename(filepath.Join(tmp, "file"), filepath.Join(tmp, "file.unfollow")); err != nil {
 		t.Fatalf("Rename(file, file.unfollow) error = %v", err)
 	}
@@ -604,11 +615,11 @@ func TestRunCLICompatExecTailFollowByNameWithoutRetryStopsWhenFileDisappears(t *
 		if result.exitCode != 1 {
 			t.Fatalf("exitCode = %d, want 1; stderr=%q", result.exitCode, stderr.String())
 		}
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatalf("tail --follow=name did not exit after the file disappeared; stderr=%q", stderr.String())
 	}
 
-	if !strings.Contains(stderr.String(), "has become inaccessible") {
+	if !strings.Contains(stderr.String(), "'file' has become inaccessible") {
 		t.Fatalf("stderr = %q, want inaccessible diagnostic", stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "no files remaining") {
@@ -626,7 +637,7 @@ func TestRunCLICompatExecTailFollowByNameWithoutRetryTracksReappearingFileWhileO
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	stdout := newStreamingWriter()
@@ -649,23 +660,28 @@ func TestRunCLICompatExecTailFollowByNameWithoutRetryTracksReappearingFileWhileO
 	if err := os.WriteFile(filepath.Join(tmp, "a"), []byte("x\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(a) error = %v", err)
 	}
-	if !stdout.WaitForSubstring("x\n", 500*time.Millisecond) {
+	if !stdout.WaitForSubstring("==> a <==\nx\n", time.Second) {
 		t.Fatalf("stdout did not emit initial content; got %q", stdout.String())
 	}
-	time.Sleep(150 * time.Millisecond)
+	if err := os.WriteFile(filepath.Join(tmp, "foo"), []byte("foo0\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(foo) error = %v", err)
+	}
+	if !stdout.WaitForSubstring("==> foo <==\nfoo0\n", time.Second) {
+		t.Fatalf("stdout did not emit initial content for foo; got %q", stdout.String())
+	}
 	if err := os.Remove(filepath.Join(tmp, "foo")); err != nil {
 		t.Fatalf("Remove(foo) error = %v", err)
 	}
-	if !stderr.WaitForSubstring("has become inaccessible", 500*time.Millisecond) {
+	if !stderr.WaitForSubstring("'foo' has become inaccessible", time.Second) {
 		t.Fatalf("stderr did not report inaccessible file; got %q", stderr.String())
 	}
 	if err := os.WriteFile(filepath.Join(tmp, "foo"), []byte("ok ok ok\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(foo) error = %v", err)
 	}
-	if !stderr.WaitForSubstring("has appeared", 500*time.Millisecond) {
+	if !stderr.WaitForSubstring("'foo' has appeared", time.Second) {
 		t.Fatalf("stderr did not report reappearing file; got %q", stderr.String())
 	}
-	if !stdout.WaitForSubstring("ok ok ok\n", 500*time.Millisecond) {
+	if !stdout.WaitForSubstring("==> foo <==\nfoo0\nok ok ok\n", time.Second) {
 		t.Fatalf("stdout did not resume the reappearing file; got %q", stdout.String())
 	}
 

--- a/commands/tail.go
+++ b/commands/tail.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	stdfs "io/fs"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -44,7 +45,7 @@ type tailOptions struct {
 type tailFollowState struct {
 	path            string
 	file            gbfs.File
-	identity        string
+	fileInfo        stdfs.FileInfo
 	offset          int64
 	active          bool
 	exists          bool
@@ -166,14 +167,10 @@ func (c *Tail) Run(ctx context.Context, inv *Invocation) error {
 			return err
 		}
 
-		identity := ""
-		if opts.follow == tailFollowName {
-			identity = tailFileIdentity(info)
-		}
 		states = append(states, tailFollowState{
 			path:          file,
 			file:          followFile,
-			identity:      identity,
+			fileInfo:      info,
 			offset:        int64(len(data)),
 			active:        true,
 			exists:        true,
@@ -327,13 +324,13 @@ func (c *Tail) pollTailByName(
 	if info.IsDir() {
 		state.exists = false
 		state.offset = 0
-		state.identity = ""
+		state.fileInfo = nil
 		state.untailable = true
 		return nil
 	}
 
-	identity := tailFileIdentity(info)
-	replaced := state.exists && state.identity != "" && identity != "" && state.identity != identity
+	sameFile, identityKnown := tailSameFileInfo(state.fileInfo, info)
+	replaced := state.exists && identityKnown && !sameFile
 	if !state.exists && state.announcedAbsent && opts.follow == tailFollowName {
 		if state.untailable {
 			writeTailBecameAccessible(inv, state.path)
@@ -352,7 +349,7 @@ func (c *Tail) pollTailByName(
 
 	if !state.exists || replaced {
 		state.exists = true
-		state.identity = identity
+		state.fileInfo = info
 		state.announcedAbsent = false
 		state.untailable = false
 		state.offset = int64(len(data))
@@ -363,13 +360,13 @@ func (c *Tail) pollTailByName(
 		state.offset = 0
 	}
 	if int64(len(data)) == state.offset {
-		state.identity = identity
+		state.fileInfo = info
 		return nil
 	}
 	if err := writeTailOutput(inv, outputState, state.path, data[state.offset:], showHeaders, false); err != nil {
 		return err
 	}
-	state.identity = identity
+	state.fileInfo = info
 	state.offset = int64(len(data))
 	return nil
 }
@@ -761,12 +758,26 @@ func writeTailOutput(inv *Invocation, outputState *tailOutputState, file string,
 	return nil
 }
 
-func tailFileIdentity(info stdfs.FileInfo) string {
-	dev, ino, ok := tailDeviceAndInode(info)
-	if !ok {
-		return ""
+func tailSameFileInfo(prev, curr stdfs.FileInfo) (same, known bool) {
+	if prev == nil || curr == nil {
+		return false, false
 	}
-	return fmt.Sprintf("%d:%d", dev, ino)
+	if tailSupportsOSSameFile(prev) && tailSupportsOSSameFile(curr) {
+		return os.SameFile(prev, curr), true
+	}
+	devPrev, inoPrev, okPrev := tailDeviceAndInode(prev)
+	devCurr, inoCurr, okCurr := tailDeviceAndInode(curr)
+	if okPrev && okCurr {
+		return devPrev == devCurr && inoPrev == inoCurr, true
+	}
+	return false, false
+}
+
+func tailSupportsOSSameFile(info stdfs.FileInfo) bool {
+	if info == nil || info.Sys() == nil {
+		return false
+	}
+	return os.SameFile(info, info)
 }
 
 func tailDeviceAndInode(info stdfs.FileInfo) (dev, ino uint64, ok bool) {

--- a/commands/tail_test.go
+++ b/commands/tail_test.go
@@ -1,0 +1,65 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type tailTestFileInfo struct {
+	name string
+	size int64
+	mode os.FileMode
+}
+
+func (i tailTestFileInfo) Name() string       { return i.name }
+func (i tailTestFileInfo) Size() int64        { return i.size }
+func (i tailTestFileInfo) Mode() os.FileMode  { return i.mode }
+func (i tailTestFileInfo) ModTime() time.Time { return time.Unix(0, 0) }
+func (i tailTestFileInfo) IsDir() bool        { return i.mode.IsDir() }
+func (i tailTestFileInfo) Sys() any           { return nil }
+
+func TestTailSameFileInfoDetectsRenameOverExistingFile(t *testing.T) {
+	tmp := t.TempDir()
+
+	aPath := filepath.Join(tmp, "a")
+	bPath := filepath.Join(tmp, "b")
+	if err := os.WriteFile(aPath, []byte("a\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(a) error = %v", err)
+	}
+	if err := os.WriteFile(bPath, []byte("b\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(b) error = %v", err)
+	}
+
+	aInfoBefore, err := os.Stat(aPath)
+	if err != nil {
+		t.Fatalf("Stat(a before) error = %v", err)
+	}
+	bInfoBefore, err := os.Stat(bPath)
+	if err != nil {
+		t.Fatalf("Stat(b before) error = %v", err)
+	}
+
+	if err := os.Rename(aPath, bPath); err != nil {
+		t.Fatalf("Rename(a, b) error = %v", err)
+	}
+	bInfoAfter, err := os.Stat(bPath)
+	if err != nil {
+		t.Fatalf("Stat(b after) error = %v", err)
+	}
+
+	if same, known := tailSameFileInfo(bInfoBefore, bInfoAfter); !known || same {
+		t.Fatalf("tailSameFileInfo(old b, new b) = (%v, %v), want (false, true)", same, known)
+	}
+	if same, known := tailSameFileInfo(aInfoBefore, bInfoAfter); !known || !same {
+		t.Fatalf("tailSameFileInfo(old a, new b) = (%v, %v), want (true, true)", same, known)
+	}
+}
+
+func TestTailSameFileInfoReturnsUnknownWithoutComparableIdentity(t *testing.T) {
+	info := tailTestFileInfo{name: "virtual", mode: 0o644}
+	if same, known := tailSameFileInfo(info, info); known || same {
+		t.Fatalf("tailSameFileInfo(virtual, virtual) = (%v, %v), want (false, false)", same, known)
+	}
+}


### PR DESCRIPTION
## Summary
- use a dedicated same-file helper for follow-by-name replacement detection
- make the rename/replacement and reappearance CLI tests event-driven instead of sleep-driven
- add focused tail identity tests outside the CLI harness

## Testing
- go test ./commands ./cmd/gbash
- go test ./cmd/gbash -run 'TestRunCLICompatExecTailFollowByNameHandlesRenameAndReplacement|TestRunCLICompatExecTailFollowByNameWithoutRetryStopsWhenFileDisappears|TestRunCLICompatExecTailFollowByNameWithoutRetryTracksReappearingFileWhileOthersRemain' -count=50