### PR TITLE
Fix yes uutils compatibility

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -688,7 +688,7 @@ For the shell/process helper batch, the runtime should expose practical, sandbox
 - `sleep` supports decimal durations and `s`, `m`, `h`, and `d` suffixes with a bounded maximum delay
 - `timeout` supports duration-bounded nested command execution and accepts `--foreground`, `-k/--kill-after`, and `-s/--signal` as compatibility flags without host signal semantics
 - `xargs` supports the default `echo` behavior plus `-n`, `-I`, `-0`, `-d`, `-t`, and `-r`
-- `yes` repeatedly emits either `y` or the provided argument string using buffered writes and relies on sandbox timeouts or downstream consumers to bound execution
+- `yes` follows the uutils/GNU operand model (`y` by default, otherwise space-joined operands plus a trailing newline), fills its 16 KiB write buffer with only whole-record copies, ignores broken-pipe termination, and reports other stdout write failures as `yes: standard output: ...`
 - `bash` and `sh` are nested shell wrappers for `-c`, script files, and stdin scripts; they do not escape to host shells
 
 For network access, the runtime now exposes a safe `curl` subset instead of ambient host networking. That subset is enabled only when `runtime.Config.Network` or a prebuilt `NetworkClient` is provided. The sandboxed network layer must:

--- a/cmd/gbash/cli.go
+++ b/cmd/gbash/cli.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	osexec "os/exec"
 	"path/filepath"
 	"strings"
 
@@ -73,7 +74,7 @@ func parseCLIOptions(args []string, stderr io.Writer) (cliOptions, error) {
 
 func parseCompatInvocation(argv0 string, args []string) (*compatInvocation, error) {
 	if utility := multicallUtilityName(argv0); utility != "" {
-		commandDir, err := resolveCommandDir(filepath.Dir(argv0))
+		commandDir, err := resolveCompatCommandDir(argv0)
 		if err != nil {
 			return nil, err
 		}
@@ -116,6 +117,18 @@ func resolveCommandDir(dir string) (string, error) {
 		return "", err
 	}
 	return filepath.ToSlash(resolved), nil
+}
+
+func resolveCompatCommandDir(argv0 string) (string, error) {
+	if strings.Contains(argv0, string(os.PathSeparator)) {
+		return resolveCommandDir(filepath.Dir(argv0))
+	}
+
+	resolved, err := osexec.LookPath(argv0)
+	if err != nil {
+		return "", err
+	}
+	return resolveCommandDir(filepath.Dir(resolved))
 }
 
 func runScript(ctx context.Context, rt *gbruntime.Runtime, stdin io.Reader, stdout, stderr io.Writer) (int, error) {

--- a/cmd/gbash/cli_test.go
+++ b/cmd/gbash/cli_test.go
@@ -116,6 +116,34 @@ func TestRunCLICompatExecUnknownCommandReturns127(t *testing.T) {
 	}
 }
 
+func TestRunCLICompatExecYesReportsSingleWriteErrorOnDevFull(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	info, err := os.Stat("/dev/full")
+	if err != nil || info.Mode()&os.ModeDevice == 0 {
+		t.Skip("/dev/full unavailable")
+	}
+
+	full, err := os.OpenFile("/dev/full", os.O_WRONLY, 0)
+	if err != nil {
+		t.Skipf("OpenFile(/dev/full) error = %v", err)
+	}
+	defer func() { _ = full.Close() }()
+
+	var stderr strings.Builder
+	exitCode, err := runCLI(context.Background(), "gbash", []string{"compat", "exec", "yes", "x"}, strings.NewReader(""), full, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 1 {
+		t.Fatalf("exitCode = %d, want 1; stderr=%q", exitCode, stderr.String())
+	}
+	if got, want := strings.Count(stderr.String(), "yes: standard output"), 1; got != want {
+		t.Fatalf("stderr = %q, want %d write diagnostic", stderr.String(), want)
+	}
+}
+
 func TestRunCLICompatExecEnvSupportsDoubleDashCommandSeparator(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)
@@ -1131,6 +1159,40 @@ func TestRunCLIMulticallUsesArgv0CommandAndBypassesTTYRepl(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "~$") {
 		t.Fatalf("stdout = %q, did not expect interactive prompt", stdout.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
+func TestRunCLIMulticallBareArgv0ResolvesCommandDirFromPATH(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	commandDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(commandDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	for _, name := range []string{"sh", "echo", "printf"} {
+		commandPath := filepath.Join(commandDir, name)
+		if err := os.WriteFile(commandPath, []byte("# compat shim\n"), 0o755); err != nil {
+			t.Fatalf("WriteFile(%q) error = %v", commandPath, err)
+		}
+	}
+	t.Setenv("PATH", commandDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), "sh", []string{"-c", "printf 'ok\\n'; echo $#", "ignored", "1", "2", "3"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if got, want := stdout.String(), "ok\n3\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
 	}
 	if got := stderr.String(); got != "" {
 		t.Fatalf("stderr = %q, want empty", got)

--- a/commands/yes.go
+++ b/commands/yes.go
@@ -4,9 +4,9 @@ import (
 	"bufio"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"strings"
+	"syscall"
 )
 
 const yesBufferSize = 16 * 1024
@@ -28,37 +28,21 @@ func (c *Yes) Run(ctx context.Context, inv *Invocation) error {
 	}
 	switch mode {
 	case "help":
-		_, _ = fmt.Fprintln(inv.Stdout, "usage: yes [STRING]...")
+		_, _ = io.WriteString(inv.Stdout, yesHelpText)
 		return nil
 	case "version":
-		_, _ = fmt.Fprintln(inv.Stdout, "yes (gbash)")
+		_, _ = io.WriteString(inv.Stdout, yesVersionText)
 		return nil
 	}
 
-	line := "y\n"
-	if len(operands) > 0 {
-		line = strings.Join(operands, " ") + "\n"
-	}
-	chunk := []byte(line)
-	if len(chunk) == 0 {
-		chunk = []byte{'\n'}
-	}
-	for len(chunk) < yesBufferSize {
-		remaining := yesBufferSize - len(chunk)
-		if remaining >= len(line) {
-			chunk = append(chunk, line...)
-			continue
-		}
-		chunk = append(chunk, line[:remaining]...)
-		break
-	}
+	buffer := prepareYesBuffer(yesArgsIntoBuffer(operands))
 
 	writer := bufio.NewWriterSize(inv.Stdout, yesBufferSize)
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if _, err := writer.Write(chunk); err != nil {
+		if _, err := writer.Write(buffer); err != nil {
 			if yesBrokenPipe(err) {
 				return nil
 			}
@@ -71,6 +55,28 @@ func (c *Yes) Run(ctx context.Context, inv *Invocation) error {
 			return exitf(inv, 1, "yes: standard output: %v", err)
 		}
 	}
+}
+
+func yesArgsIntoBuffer(operands []string) []byte {
+	if len(operands) == 0 {
+		return []byte("y\n")
+	}
+	line := strings.Join(operands, " ") + "\n"
+	return []byte(line)
+}
+
+func prepareYesBuffer(buffer []byte) []byte {
+	if len(buffer) == 0 || len(buffer)*2 > yesBufferSize {
+		return buffer
+	}
+
+	lineLen := len(buffer)
+	targetSize := lineLen * (yesBufferSize / lineLen)
+	for len(buffer) < targetSize {
+		toCopy := min(targetSize-len(buffer), len(buffer))
+		buffer = append(buffer, buffer[:toCopy]...)
+	}
+	return buffer
 }
 
 func parseYesArgs(inv *Invocation) (operands []string, mode string, err error) {
@@ -86,30 +92,54 @@ func parseYesArgs(inv *Invocation) (operands []string, mode string, err error) {
 			continue
 		}
 
-		switch arg {
-		case "--help":
-			return nil, "help", nil
-		case "--version":
-			return nil, "version", nil
-		case "--":
+		switch {
+		case arg == "--":
 			parsingOptions = false
+		case arg == "-h":
+			return nil, "help", nil
+		case arg == "-V":
+			return nil, "version", nil
+		case yesMatchesLongOption(arg, "help"):
+			return nil, "help", nil
+		case yesMatchesLongOption(arg, "version"):
+			return nil, "version", nil
+		case arg == "-" || !strings.HasPrefix(arg, "-"):
+			operands = append(operands, arg)
+			parsingOptions = false
+		case strings.HasPrefix(arg, "--"):
+			return nil, "", exitf(inv, 1, "yes: unrecognized option '%s'\nTry 'yes --help' for more information.", arg)
 		default:
-			if arg == "-" || !strings.HasPrefix(arg, "-") {
-				operands = append(operands, arg)
-				parsingOptions = false
-				continue
-			}
-			if strings.HasPrefix(arg, "--") {
-				return nil, "", exitf(inv, 1, "yes: unrecognized option '%s'", arg)
-			}
-			return nil, "", exitf(inv, 1, "yes: invalid option -- '%s'", strings.TrimPrefix(arg, "-"))
+			return nil, "", exitf(inv, 1, "yes: invalid option -- '%s'\nTry 'yes --help' for more information.", strings.TrimPrefix(arg, "-"))
 		}
 	}
 	return operands, "", nil
 }
 
-func yesBrokenPipe(err error) bool {
-	return errors.Is(err, io.ErrClosedPipe) || strings.Contains(strings.ToLower(err.Error()), "broken pipe")
+func yesMatchesLongOption(arg, name string) bool {
+	if !strings.HasPrefix(arg, "--") || arg == "--" {
+		return false
+	}
+	return strings.HasPrefix(name, strings.TrimPrefix(arg, "--"))
 }
+
+func yesBrokenPipe(err error) bool {
+	return errors.Is(err, io.ErrClosedPipe) ||
+		errors.Is(err, syscall.EPIPE) ||
+		strings.Contains(strings.ToLower(err.Error()), "broken pipe")
+}
+
+const yesHelpText = `Repeatedly display a line with STRING (or 'y')
+
+Usage: yes [STRING]...
+
+Arguments:
+  [STRING]...  [default: y]
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+`
+
+const yesVersionText = "yes (uutils coreutils) 0.7.0\n"
 
 var _ Command = (*Yes)(nil)

--- a/commands/yes_test.go
+++ b/commands/yes_test.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPrepareYesBufferMatchesUutilsBoundaries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		lineLen int
+		wantLen int
+	}{
+		{150, 16350},
+		{1000, 16000},
+		{4093, 16372},
+		{4099, 12297},
+		{4111, 12333},
+		{2, 16384},
+		{3, 16383},
+		{4, 16384},
+		{5, 16380},
+		{8192, 16384},
+		{8191, 16382},
+		{8193, 8193},
+		{10000, 10000},
+		{15000, 15000},
+		{25000, 25000},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("len=%d", tc.lineLen), func(t *testing.T) {
+			buffer := make([]byte, tc.lineLen)
+			for i := range buffer {
+				buffer[i] = 'a'
+			}
+			got := prepareYesBuffer(buffer)
+			if len(got) != tc.wantLen {
+				t.Fatalf("prepareYesBuffer(len=%d) = %d, want %d", tc.lineLen, len(got), tc.wantLen)
+			}
+		})
+	}
+}
+
+func TestYesArgsIntoBuffer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		operands []string
+		want     string
+	}{
+		{name: "default", want: "y\n"},
+		{name: "single", operands: []string{"foo"}, want: "foo\n"},
+		{name: "multiple", operands: []string{"foo", "bar    baz", "qux"}, want: "foo bar    baz qux\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := string(yesArgsIntoBuffer(tc.operands)); got != tc.want {
+				t.Fatalf("yesArgsIntoBuffer(%q) = %q, want %q", tc.operands, got, tc.want)
+			}
+		})
+	}
+}

--- a/runtime/id_yes_commands_test.go
+++ b/runtime/id_yes_commands_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -93,6 +94,27 @@ func TestYesRepeatsDefaultAndCustomOperandsUntilTimeout(t *testing.T) {
 	}
 }
 
+func TestYesPreservesWholeRecordsAtGNUBoundaries(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	for _, size := range []int{1, 1999, 4095, 4096, 8191, 8192, 16383, 16384} {
+		t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+			script := fmt.Sprintf(
+				"yes \"$(printf '%%%ds' '')\" | head -n2 | uniq > /tmp/yes.out\nwc -l < /tmp/yes.out\nhead -n1 /tmp/yes.out | wc -c\n",
+				size,
+			)
+			result := mustExecSession(t, session, script)
+			if result.ExitCode != 0 {
+				t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+			}
+			want := fmt.Sprintf("1\n%d\n", size+1)
+			if result.Stdout != want {
+				t.Fatalf("Stdout = %q, want %q", result.Stdout, want)
+			}
+		})
+	}
+}
+
 func TestYesRejectsUnknownOptionsAndSupportsHelpVersion(t *testing.T) {
 	rt := newRuntime(t, &Config{})
 
@@ -103,8 +125,9 @@ func TestYesRejectsUnknownOptionsAndSupportsHelpVersion(t *testing.T) {
 	if helpResult.ExitCode != 0 {
 		t.Fatalf("help ExitCode = %d, want 0; stderr=%q", helpResult.ExitCode, helpResult.Stderr)
 	}
-	if !strings.Contains(helpResult.Stdout, "usage: yes [STRING]...") {
-		t.Fatalf("Stdout = %q, want help text", helpResult.Stdout)
+	const wantHelp = "Repeatedly display a line with STRING (or 'y')\n\nUsage: yes [STRING]...\n\nArguments:\n  [STRING]...  [default: y]\n\nOptions:\n  -h, --help     Print help\n  -V, --version  Print version\n"
+	if got := helpResult.Stdout; got != wantHelp {
+		t.Fatalf("Stdout = %q, want %q", got, wantHelp)
 	}
 
 	versionResult, err := rt.Run(context.Background(), &ExecutionRequest{Script: "yes --version\n"})
@@ -114,8 +137,53 @@ func TestYesRejectsUnknownOptionsAndSupportsHelpVersion(t *testing.T) {
 	if versionResult.ExitCode != 0 {
 		t.Fatalf("version ExitCode = %d, want 0; stderr=%q", versionResult.ExitCode, versionResult.Stderr)
 	}
-	if !strings.Contains(versionResult.Stdout, "yes (gbash)") {
-		t.Fatalf("Stdout = %q, want version text", versionResult.Stdout)
+	const wantVersion = "yes (uutils coreutils) 0.7.0\n"
+	if got := versionResult.Stdout; got != wantVersion {
+		t.Fatalf("Stdout = %q, want %q", got, wantVersion)
+	}
+
+	shortHelpResult, err := rt.Run(context.Background(), &ExecutionRequest{Script: "yes -h\n"})
+	if err != nil {
+		t.Fatalf("Run(short-help) error = %v", err)
+	}
+	if shortHelpResult.ExitCode != 0 {
+		t.Fatalf("short-help ExitCode = %d, want 0; stderr=%q", shortHelpResult.ExitCode, shortHelpResult.Stderr)
+	}
+	if got := shortHelpResult.Stdout; got != wantHelp {
+		t.Fatalf("Stdout = %q, want %q", got, wantHelp)
+	}
+
+	shortVersionResult, err := rt.Run(context.Background(), &ExecutionRequest{Script: "yes -V\n"})
+	if err != nil {
+		t.Fatalf("Run(short-version) error = %v", err)
+	}
+	if shortVersionResult.ExitCode != 0 {
+		t.Fatalf("short-version ExitCode = %d, want 0; stderr=%q", shortVersionResult.ExitCode, shortVersionResult.Stderr)
+	}
+	if got := shortVersionResult.Stdout; got != wantVersion {
+		t.Fatalf("Stdout = %q, want %q", got, wantVersion)
+	}
+
+	endOfOptionsResult, err := rt.Run(context.Background(), &ExecutionRequest{Script: "yes -- --help | head -n1\n"})
+	if err != nil {
+		t.Fatalf("Run(end-of-options) error = %v", err)
+	}
+	if endOfOptionsResult.ExitCode != 0 {
+		t.Fatalf("end-of-options ExitCode = %d, want 0; stderr=%q", endOfOptionsResult.ExitCode, endOfOptionsResult.Stderr)
+	}
+	if got, want := endOfOptionsResult.Stdout, "--help\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+
+	inferredVersionResult, err := rt.Run(context.Background(), &ExecutionRequest{Script: "yes --ver\n"})
+	if err != nil {
+		t.Fatalf("Run(inferred-version) error = %v", err)
+	}
+	if inferredVersionResult.ExitCode != 0 {
+		t.Fatalf("inferred-version ExitCode = %d, want 0; stderr=%q", inferredVersionResult.ExitCode, inferredVersionResult.Stderr)
+	}
+	if got := inferredVersionResult.Stdout; got != wantVersion {
+		t.Fatalf("Stdout = %q, want %q", got, wantVersion)
 	}
 
 	invalidResult, err := rt.Run(context.Background(), &ExecutionRequest{Script: "yes --bogus\n"})
@@ -126,6 +194,9 @@ func TestYesRejectsUnknownOptionsAndSupportsHelpVersion(t *testing.T) {
 		t.Fatalf("invalid ExitCode = 0, want non-zero")
 	}
 	if !strings.Contains(invalidResult.Stderr, "unrecognized option") {
+		t.Fatalf("Stderr = %q, want invalid-option error", invalidResult.Stderr)
+	}
+	if !strings.Contains(invalidResult.Stderr, "Try 'yes --help' for more information.") {
 		t.Fatalf("Stderr = %q, want invalid-option error", invalidResult.Stderr)
 	}
 }


### PR DESCRIPTION
## Summary
- reimplement `yes` buffer generation to match uutils whole-record behavior and align its help/version surface with uutils
- fix bare-name multicall compat resolution so nested `sh` uses the shim directory from PATH lookup
- add regression coverage for GNU yes boundary cases, bare-name multicall shells, and `/dev/full` write diagnostics

## Testing
- go test ./...
- make gnu-test GNU_UTILS=yes GNU_KEEP_WORKDIR=1
