### PR TITLE
Exclude placeholder commands from GNU harness support set

### DIFF
--- a/cmd/gbash-gnu/harness.go
+++ b/cmd/gbash-gnu/harness.go
@@ -81,7 +81,15 @@ func compatConfigShellPath(workDir string) (string, error) {
 
 func implementedGNUProgramSet() map[string]struct{} {
 	supported := make(map[string]struct{})
-	for _, name := range gbcommands.DefaultRegistry().Names() {
+	registry := gbcommands.DefaultRegistry()
+	for _, name := range registry.Names() {
+		cmd, ok := registry.Lookup(name)
+		if !ok {
+			continue
+		}
+		if _, placeholder := cmd.(*gbcommands.NotImplemented); placeholder {
+			continue
+		}
 		supported[name] = struct{}{}
 	}
 	return supported

--- a/cmd/gbash-gnu/main_test.go
+++ b/cmd/gbash-gnu/main_test.go
@@ -528,6 +528,15 @@ func TestImplementedGNUProgramSetIncludesHelperCommands(t *testing.T) {
 	}
 }
 
+func TestImplementedGNUProgramSetExcludesNotImplementedPlaceholders(t *testing.T) {
+	supported := implementedGNUProgramSet()
+	for _, name := range []string{"b2sum", "sha224sum", "truncate"} {
+		if _, ok := supported[name]; ok {
+			t.Fatalf("implementedGNUProgramSet() unexpectedly included placeholder %q", name)
+		}
+	}
+}
+
 func TestPrepareWorkDirPreservesFileTimes(t *testing.T) {
 	cacheDir := t.TempDir()
 	sourceDir := filepath.Join(t.TempDir(), "source")


### PR DESCRIPTION
## Summary
- exclude `commands.NotImplemented` placeholders from the GNU harness supported-program set
- keep placeholder utilities on explicit unsupported stubs instead of symlinking them to `gbash`
- add a regression test covering placeholder names like `b2sum`, `sha224sum`, and `truncate`

## Problem
The GNU harness was treating every registry entry as supported. That included placeholder commands reserved only to avoid host fallback. For tests like `tests/cksum/b2sum.sh`, that let the harness count a pass even though `b2sum` itself is not implemented, because the upstream script can skip the direct `b2sum` branch and still pass through `cksum -a blake2b`.

## Testing
- `go test ./cmd/gbash-gnu -run 'ImplementedGNUProgramSet|PrepareProgramDir|RunMakeCheck'`
- `go test ./cmd/gbash ./internal/compatrun ./commands -run 'Compat|HostFallback|NotImplemented|DefaultRegistryIncludesGNUCompatibilityPlaceholders'`
