### PR TITLE
Simplify GNU harness command shims

### DIFF
--- a/cmd/gbash-gnu/gnu_tests.go
+++ b/cmd/gbash-gnu/gnu_tests.go
@@ -143,7 +143,6 @@ func runMakeCheck(ctx context.Context, makeBin, workDir, configShell string, tes
 	cmd.Env = append(os.Environ(),
 		"CONFIG_SHELL="+configShell,
 		"GBASH_COMPAT_RESOLVER_MODE=registry-then-host-fallback",
-		"GBASH_COMPAT_RESERVED_COMMANDS_FILE="+filepath.Join(workDir, "build-aux", "gbash-harness", "gnu-programs.txt"),
 	)
 	output, err := cmd.CombinedOutput()
 	if writeErr := os.WriteFile(logPath, output, 0o644); writeErr != nil {

--- a/cmd/gbash-gnu/harness.go
+++ b/cmd/gbash-gnu/harness.go
@@ -1,28 +1,14 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/ewhauser/gbash/internal/compatshims"
 )
-
-func listGNUPrograms(ctx context.Context, workDir string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, filepath.Join(workDir, "build-aux", "gen-lists-of-programs.sh"), "--list-progs")
-	cmd.Dir = workDir
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("list GNU programs: %w", err)
-	}
-	lines := strings.Fields(string(out))
-	sort.Strings(lines)
-	return lines, nil
-}
 
 func prepareProgramDir(workDir, gbashBin string, programs []string) error {
 	srcDir := filepath.Join(workDir, "src")
@@ -34,14 +20,7 @@ func prepareProgramDir(workDir, gbashBin string, programs []string) error {
 	if err := compatshims.SymlinkCommands(srcDir, gbashBin, programs); err != nil {
 		return err
 	}
-	helperShells := compatHelperShells()
-	if err := compatshims.SymlinkCommands(srcDir, gbashBin, helperShells); err != nil {
-		return err
-	}
-	if err := compatshims.SymlinkCommands(srcDir, gbashBin, []string{"ginstall"}); err != nil {
-		return err
-	}
-	return writeGNUProgramList(workDir, programs)
+	return nil
 }
 
 func compatHelperShells() []string {
@@ -54,14 +33,6 @@ func compatConfigShellPath(workDir string) (string, error) {
 		return "", fmt.Errorf("prepare compat config shell: %w", err)
 	}
 	return path, nil
-}
-
-func writeGNUProgramList(workDir string, programs []string) error {
-	hookDir := filepath.Join(workDir, "build-aux", "gbash-harness")
-	if err := os.MkdirAll(hookDir, 0o755); err != nil {
-		return err
-	}
-	return writeLines(filepath.Join(hookDir, "gnu-programs.txt"), programs)
 }
 
 func disableCheckRebuild(workDir string) error {
@@ -77,14 +48,30 @@ func disableCheckRebuild(workDir string) error {
 	return os.WriteFile(makefilePath, []byte(updated), 0o644)
 }
 
-func writeLines(path string, lines []string) error {
-	sorted := append([]string(nil), lines...)
-	sort.Strings(sorted)
-	data := strings.Join(sorted, "\n")
-	if data != "" {
-		data += "\n"
+func utilityShimNames(utilities []utilityManifest) []string {
+	seen := make(map[string]struct{}, len(utilities)+3)
+	out := make([]string, 0, len(utilities)+3)
+
+	for _, name := range append(compatHelperShells(), "ginstall") {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
 	}
-	return os.WriteFile(path, []byte(data), 0o644)
+	for _, utility := range utilities {
+		name := strings.TrimSpace(utility.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func shellSingleQuoteForScript(value string) string {

--- a/cmd/gbash-gnu/main_test.go
+++ b/cmd/gbash-gnu/main_test.go
@@ -392,16 +392,10 @@ func TestRunMakeCheckExportsConfigShell(t *testing.T) {
 	makeBin := filepath.Join(workDir, "fake-make.sh")
 	envPath := filepath.Join(workDir, "config-shell.txt")
 	resolverModePath := filepath.Join(workDir, "resolver-mode.txt")
-	reservedPath := filepath.Join(workDir, "reserved-path.txt")
 	logPath := filepath.Join(workDir, "make.log")
-	hookDir := filepath.Join(workDir, "build-aux", "gbash-harness")
-	if err := os.MkdirAll(hookDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(hookDir) error = %v", err)
-	}
 	script := "#!/bin/sh\n" +
 		"printf '%s\\n' \"$CONFIG_SHELL\" > " + shellSingleQuoteForScript(envPath) + "\n" +
 		"printf '%s\\n' \"$GBASH_COMPAT_RESOLVER_MODE\" > " + shellSingleQuoteForScript(resolverModePath) + "\n" +
-		"printf '%s\\n' \"$GBASH_COMPAT_RESERVED_COMMANDS_FILE\" > " + shellSingleQuoteForScript(reservedPath) + "\n" +
 		"printf 'PASS: tests/misc/example.sh\\n'\n"
 	if err := os.WriteFile(makeBin, []byte(script), 0o755); err != nil {
 		t.Fatalf("WriteFile(fake make) error = %v", err)
@@ -427,11 +421,6 @@ func TestRunMakeCheckExportsConfigShell(t *testing.T) {
 	} else if got := string(data); got != "registry-then-host-fallback\n" {
 		t.Fatalf("GBASH_COMPAT_RESOLVER_MODE = %q, want %q", got, "registry-then-host-fallback\\n")
 	}
-	if data, err := os.ReadFile(reservedPath); err != nil {
-		t.Fatalf("ReadFile(reserved path) error = %v", err)
-	} else if got := string(data); got != filepath.Join(workDir, "build-aux", "gbash-harness", "gnu-programs.txt")+"\n" {
-		t.Fatalf("GBASH_COMPAT_RESERVED_COMMANDS_FILE = %q", got)
-	}
 }
 
 func TestPrepareProgramDirAddsCompatShellHelpers(t *testing.T) {
@@ -445,7 +434,10 @@ func TestPrepareProgramDirAddsCompatShellHelpers(t *testing.T) {
 		t.Fatalf("WriteFile(gbashBin) error = %v", err)
 	}
 
-	err := prepareProgramDir(workDir, gbashBin, []string{"sort", "futuregnu"})
+	err := prepareProgramDir(workDir, gbashBin, utilityShimNames([]utilityManifest{
+		{Name: "sort"},
+		{Name: "futuregnu"},
+	}))
 	if err != nil {
 		t.Fatalf("prepareProgramDir() error = %v", err)
 	}
@@ -460,12 +452,17 @@ func TestPrepareProgramDirAddsCompatShellHelpers(t *testing.T) {
 			t.Fatalf("%q is not a symlink", path)
 		}
 	}
-	data, err := os.ReadFile(filepath.Join(workDir, "build-aux", "gbash-harness", "gnu-programs.txt"))
-	if err != nil {
-		t.Fatalf("ReadFile(gnu-programs.txt) error = %v", err)
-	}
-	if got := string(data); got != "futuregnu\nsort\n" {
-		t.Fatalf("gnu-programs.txt = %q, want sorted reserved program list", got)
+}
+
+func TestUtilityShimNamesIncludesHelpersAndDeduplicates(t *testing.T) {
+	got := utilityShimNames([]utilityManifest{
+		{Name: "sort"},
+		{Name: "ginstall"},
+		{Name: "sort"},
+	})
+	want := []string{"bash", "ginstall", "sh", "sort"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("utilityShimNames() = %#v, want %#v", got, want)
 	}
 }
 func TestPrepareWorkDirPreservesFileTimes(t *testing.T) {

--- a/cmd/gbash-gnu/run.go
+++ b/cmd/gbash-gnu/run.go
@@ -171,11 +171,7 @@ func prepareExecutionWorkDir(ctx context.Context, mf *manifest, makeBin, cacheDi
 	return workDir, nil
 }
 
-func prepareExecutionPlan(ctx context.Context, mf *manifest, env *executionEnv, opts *options) (*executionPlan, error) {
-	programs, err := listGNUPrograms(ctx, env.workDir)
-	if err != nil {
-		return nil, err
-	}
+func prepareExecutionPlan(_ context.Context, mf *manifest, env *executionEnv, opts *options) (*executionPlan, error) {
 	selectedUtilities, err := selectUtilities(mf, opts.utils)
 	if err != nil {
 		return nil, err
@@ -185,7 +181,7 @@ func prepareExecutionPlan(ctx context.Context, mf *manifest, env *executionEnv, 
 	if len(explicitTests) != 0 {
 		runTargets = []utilityManifest{{Name: "explicit-tests"}}
 	}
-	if err := prepareProgramDir(env.workDir, env.gbashBin, programs); err != nil {
+	if err := prepareProgramDir(env.workDir, env.gbashBin, utilityShimNames(selectedUtilities)); err != nil {
 		return nil, err
 	}
 	configShell, err := compatConfigShellPath(env.workDir)

--- a/commands/install.go
+++ b/commands/install.go
@@ -2,14 +2,23 @@ package commands
 
 import "context"
 
-type Install struct{}
+type Install struct {
+	name string
+}
 
 func NewInstall() *Install {
-	return &Install{}
+	return &Install{name: "install"}
+}
+
+func NewGInstall() *Install {
+	return &Install{name: "ginstall"}
 }
 
 func (c *Install) Name() string {
-	return "install"
+	if c == nil || c.name == "" {
+		return "install"
+	}
+	return c.name
 }
 
 func (c *Install) Run(_ context.Context, inv *Invocation) error {

--- a/commands/registry.go
+++ b/commands/registry.go
@@ -206,6 +206,7 @@ func DefaultRegistry() *Registry {
 		NewChmod(),
 		NewChown(),
 		NewInstall(),
+		NewGInstall(),
 		NewKill(),
 		NewMkdir(),
 		NewLogname(),

--- a/internal/compatrun/runner_test.go
+++ b/internal/compatrun/runner_test.go
@@ -302,6 +302,54 @@ func TestRunnerHostFallbackInheritsCWDAndStreamingIO(t *testing.T) {
 	}
 }
 
+func TestRunnerHostFallbackAllowsRegistryCommandNamesOutsideShimDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	fsys, err := compatfs.New()
+	if err != nil {
+		t.Fatalf("compatfs.New() error = %v", err)
+	}
+	commandDir := makeCommandDir(t, tmp, []string{"bash", "sh"})
+	hostDir := filepath.Join(tmp, "host-bin")
+	hostPath := commandDir + string(os.PathListSeparator) + hostDir
+	if err := os.MkdirAll(hostDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(hostDir) error = %v", err)
+	}
+	writeExecutableFile(t, filepath.Join(hostDir, "sed"), "#!/bin/sh\nprintf 'host-sed\\n'\n")
+
+	runner, err := New(&Config{
+		FS:                fsys,
+		BaseEnv:           map[string]string{"HOME": tmp, "PATH": hostPath},
+		DefaultDir:        tmp,
+		BuiltinCommandDir: commandDir,
+		ResolverMode:      shell.ResolverRegistryThenHostFallback,
+		HostExecutor:      shell.NewOSHostExecutor(),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result, err := runner.Exec(context.Background(), &commands.ExecutionRequest{
+		Script: "sed\n",
+		Env: map[string]string{
+			"HOME": tmp,
+			"PATH": hostPath,
+		},
+		ReplaceEnv: true,
+		WorkDir:    tmp,
+	})
+	if err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "host-sed\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
 func TestRunnerHostFallbackDeniesReservedGNUCommands(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)

--- a/shell/mvdan.go
+++ b/shell/mvdan.go
@@ -494,11 +494,6 @@ func hostFallbackDenied(exec *Execution, name string) bool {
 	if interp.IsBuiltin(base) && shouldRewriteBuiltin(base) {
 		return true
 	}
-	if exec.Registry != nil {
-		if _, ok := exec.Registry.Lookup(base); ok {
-			return true
-		}
-	}
 	_, reserved := exec.ReservedCommands[base]
 	return reserved
 }
@@ -665,6 +660,9 @@ func lookupCommandPath(ctx context.Context, exec *Execution, dir, name, source, 
 	if err != nil || info.IsDir() {
 		return nil, false, nil
 	}
+	if !registryPathAllowed(exec, fullPath) {
+		return nil, false, nil
+	}
 
 	resolvedName := path.Base(fullPath)
 	cmd, ok := exec.Registry.Lookup(resolvedName)
@@ -737,6 +735,18 @@ func handlerState(ctx context.Context, exec *Execution) resolvedHandlerState {
 		Dir:    exec.Dir,
 		Stderr: exec.Stderr,
 	}
+}
+
+func registryPathAllowed(exec *Execution, fullPath string) bool {
+	if exec == nil {
+		return true
+	}
+	builtinDir := builtinCommandDir(exec)
+	if builtinDir == "/" {
+		return true
+	}
+	fullPath = gbfs.Clean(fullPath)
+	return strings.HasPrefix(fullPath, builtinDir+"/")
 }
 
 func optionalHandlerCtx(ctx context.Context) (_ interp.HandlerContext, ok bool) {


### PR DESCRIPTION
## Summary
- limit registry command resolution to paths under the GNU shim directory so the test shell still runs inside gbash while non-shim helpers can host-fallback
- shrink the GNU harness to only symlink the selected utilities plus bash/sh/ginstall instead of mirroring the full GNU program set
- add a ginstall registry alias and tests covering shim-name selection and host fallback outside the shim dir

## Testing
- go test ./cmd/gbash-gnu ./cmd/gbash ./internal/compatrun ./shell ./commands
- go run ./cmd/gbash-gnu --cache-dir /tmp/gbash-gnu-smoke --gbash-bin /tmp/gbash-gnu-smoke/bin/gbash --utils printf --results-dir /tmp/gbash-gnu-smoke/results-printf
  - GNU coreutils 9.10 printf: 6 pass, 1 skip, 0 fail
