### PR TITLE
Update compat report for current summary schema

### DIFF
--- a/scripts/compat-report/main.go
+++ b/scripts/compat-report/main.go
@@ -32,6 +32,8 @@ type options struct {
 type runSummary struct {
 	GNUVersion     string          `json:"gnu_version"`
 	GeneratedAt    string          `json:"generated_at"`
+	WorkDir        string          `json:"work_dir,omitempty"`
+	ResultsDir     string          `json:"results_dir,omitempty"`
 	Overall        testSummary     `json:"overall"`
 	UtilitySummary utilityTotals   `json:"utility_summary"`
 	Utilities      []utilityResult `json:"utilities"`
@@ -63,10 +65,23 @@ type utilityTotals struct {
 }
 
 type utilityResult struct {
-	Name    string      `json:"name"`
-	Skipped []string    `json:"skipped,omitempty"`
-	Summary testSummary `json:"summary"`
-	LogFile string      `json:"log_file,omitempty"`
+	Name         string       `json:"name"`
+	Tests        []string     `json:"tests,omitempty"`
+	Skipped      []string     `json:"skipped,omitempty"`
+	TestResults  []testResult `json:"test_results,omitempty"`
+	ExtraResults []testResult `json:"extra_results,omitempty"`
+	Summary      testSummary  `json:"summary"`
+	ExitCode     int          `json:"exit_code"`
+	Passed       bool         `json:"passed"`
+	LogFile      string       `json:"log_file,omitempty"`
+	LogPath      string       `json:"log_path,omitempty"`
+	Reason       string       `json:"reason,omitempty"`
+}
+
+type testResult struct {
+	Name       string   `json:"name"`
+	Status     string   `json:"status"`
+	ReportedAs []string `json:"reported_as,omitempty"`
 }
 
 type indexView struct {

--- a/scripts/compat-report/main_test.go
+++ b/scripts/compat-report/main_test.go
@@ -12,6 +12,8 @@ func TestWriteReportWritesIndexAndBadge(t *testing.T) {
 	summary := runSummary{
 		GNUVersion:  "9.10",
 		GeneratedAt: "2026-03-11T18:30:00Z",
+		WorkDir:     "/tmp/coreutils-work",
+		ResultsDir:  "/tmp/compat-results",
 		Overall: testSummary{
 			SelectedTotal:   3,
 			Pass:            1,
@@ -96,10 +98,12 @@ func TestLoadSummaryReadsHarnessJSON(t *testing.T) {
 	if err := os.WriteFile(summaryPath, []byte(`{
   "gnu_version": "9.10",
   "generated_at": "2026-03-11T18:30:00Z",
+  "work_dir": "/tmp/coreutils-work",
+  "results_dir": "/tmp/compat-results",
   "overall": { "selected_total": 1, "pass": 1, "fail": 0, "skip": 0, "xfail": 0, "xpass": 0, "error": 0, "unreported": 0, "runnable_total": 1, "pass_pct_selected": 100, "pass_pct_runnable": 100 },
   "utility_summary": { "total": 1, "passed": 1, "failed": 0, "no_runnable_tests": 0, "pass_pct_total": 100, "pass_pct_runnable": 100 },
   "utilities": [
-    { "name": "basename", "log_file": "basename.log", "summary": { "selected_total": 1, "pass": 1, "fail": 0, "skip": 0, "xfail": 0, "xpass": 0, "error": 0, "unreported": 0, "runnable_total": 1, "pass_pct_selected": 100, "pass_pct_runnable": 100 } }
+    { "name": "basename", "tests": ["tests/misc/basename.pl"], "test_results": [{ "name": "tests/misc/basename.pl", "status": "pass", "reported_as": ["tests/misc/basename.pl"] }], "summary": { "selected_total": 1, "pass": 1, "fail": 0, "skip": 0, "xfail": 0, "xpass": 0, "error": 0, "unreported": 0, "runnable_total": 1, "pass_pct_selected": 100, "pass_pct_runnable": 100 }, "exit_code": 0, "passed": true, "log_file": "basename.log", "log_path": "/tmp/compat-results/basename.log" }
   ]
 }`), 0o644); err != nil {
 		t.Fatalf("WriteFile(summary.json) error = %v", err)
@@ -112,20 +116,25 @@ func TestLoadSummaryReadsHarnessJSON(t *testing.T) {
 	if summary.GNUVersion != "9.10" {
 		t.Fatalf("GNUVersion = %q, want 9.10", summary.GNUVersion)
 	}
+	if summary.WorkDir != "/tmp/coreutils-work" || summary.ResultsDir != "/tmp/compat-results" {
+		t.Fatalf("work/results dirs = (%q, %q), want current harness paths", summary.WorkDir, summary.ResultsDir)
+	}
 	if len(summary.Utilities) != 1 || summary.Utilities[0].Name != "basename" {
 		t.Fatalf("utilities = %#v, want one basename utility", summary.Utilities)
 	}
 }
 
-func TestLoadSummaryRejectsRemovedInactiveFields(t *testing.T) {
+func TestLoadSummaryRejectsUnknownFields(t *testing.T) {
 	summaryPath := filepath.Join(t.TempDir(), "summary.json")
 	if err := os.WriteFile(summaryPath, []byte(`{
   "gnu_version": "9.10",
   "generated_at": "2026-03-11T18:30:00Z",
+  "work_dir": "/tmp/coreutils-work",
+  "results_dir": "/tmp/compat-results",
   "overall": { "selected_total": 0, "pass": 0, "fail": 0, "skip": 0, "xfail": 0, "xpass": 0, "error": 0, "unreported": 0, "runnable_total": 0, "pass_pct_selected": 0, "pass_pct_runnable": 0 },
   "utility_summary": { "total": 0, "passed": 0, "failed": 0, "no_runnable_tests": 0, "pass_pct_total": 0, "pass_pct_runnable": 0 },
   "utilities": [
-    { "name": "basename", "inactive": true, "summary": { "selected_total": 0, "pass": 0, "fail": 0, "skip": 0, "xfail": 0, "xpass": 0, "error": 0, "unreported": 0, "runnable_total": 0, "pass_pct_selected": 0, "pass_pct_runnable": 0 } }
+    { "name": "basename", "summary": { "selected_total": 0, "pass": 0, "fail": 0, "skip": 0, "xfail": 0, "xpass": 0, "error": 0, "unreported": 0, "runnable_total": 0, "pass_pct_selected": 0, "pass_pct_runnable": 0 }, "exit_code": 0, "passed": false, "unexpected": true }
   ]
 }`), 0o644); err != nil {
 		t.Fatalf("WriteFile(summary.json) error = %v", err)


### PR DESCRIPTION
## Summary
- update `scripts/compat-report` to decode the current GNU harness summary schema
- accept `work_dir`, `results_dir`, and the current utility fields emitted by `cmd/gbash-gnu`
- refresh report tests to use the current summary shape while still rejecting unknown fields

## Testing
- go test ./scripts/compat-report/...
