### PR TITLE
Use host bash in compat mode

### DIFF
--- a/cmd/gbash/cli_test.go
+++ b/cmd/gbash/cli_test.go
@@ -39,6 +39,50 @@ func TestRunCLIPrintsVersion(t *testing.T) {
 	}
 }
 
+func TestRunCLIMulticallBashSupportsVersion(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), filepath.Join(tmp, "bash"), []string{"--version"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "bash") {
+		t.Fatalf("stdout = %q, want bash version text", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
+func TestRunCLIMulticallBashUsesHostBashForTrapCompatibility(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), filepath.Join(tmp, "bash"), []string{"-c", `trap "" PIPE; trap - PIPE; echo ok`}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if got, want := stdout.String(), "ok\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
 func TestRunCLICompatExecPassesStdin(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)

--- a/cmd/gbash/compat_exec_posix.go
+++ b/cmd/gbash/compat_exec_posix.go
@@ -34,6 +34,8 @@ func runCompatInvocation(ctx context.Context, argv0 string, inv compatInvocation
 	}
 
 	env := environMap(os.Environ())
+	// GNU coreutils tests rely on bash-specific signal trap behavior.
+	env["GBASH_USE_HOST_BASH"] = "1"
 	env["PATH"] = prependCommandDir(commandDir, env["PATH"])
 	runner, err := compatrun.New(&compatrun.Config{
 		Registry:          registry,

--- a/commands/bash.go
+++ b/commands/bash.go
@@ -2,8 +2,11 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"os"
+	osexec "os/exec"
 )
 
 type Bash struct {
@@ -49,9 +52,26 @@ func (c *Bash) Spec() CommandSpec {
 	}
 }
 
+func (c *Bash) NormalizeInvocation(inv *Invocation) *Invocation {
+	if !c.shouldUseHostShell(inv) || inv == nil || len(inv.Args) == 0 {
+		return inv
+	}
+	switch inv.Args[0] {
+	case "--help", "--version":
+		clone := *inv
+		clone.Args = append([]string{"--"}, inv.Args...)
+		return &clone
+	default:
+		return inv
+	}
+}
+
 func (c *Bash) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCommand) error {
 	if inv.Exec == nil {
 		return fmt.Errorf("%s: subexec callback missing", c.name)
+	}
+	if c.shouldUseHostShell(inv) {
+		return c.runHostShell(ctx, inv)
 	}
 
 	if matches.Has("command") {
@@ -115,6 +135,51 @@ func (c *Bash) executeInlineScript(ctx context.Context, inv *Invocation, script 
 	return exitForExecutionResult(result)
 }
 
+func (c *Bash) shouldUseHostShell(inv *Invocation) bool {
+	if c.name != "bash" || inv == nil {
+		return false
+	}
+	return inv.Env["GBASH_USE_HOST_BASH"] == "1"
+}
+
+func (c *Bash) runHostShell(ctx context.Context, inv *Invocation) error {
+	shellPath, err := c.hostShellPath()
+	if err != nil {
+		return err
+	}
+
+	args := append([]string(nil), inv.Args...)
+	if len(args) == 0 {
+		args = []string{"-s"}
+	}
+
+	cmd := osexec.CommandContext(ctx, shellPath, args...)
+	cmd.Dir = inv.Cwd
+	cmd.Env = sortedEnvPairs(inv.Env)
+	cmd.Stdin = inv.Stdin
+	cmd.Stdout = inv.Stdout
+	cmd.Stderr = inv.Stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *osexec.ExitError
+		if errors.As(err, &exitErr) {
+			return &ExitError{Code: exitErr.ExitCode()}
+		}
+		return &ExitError{Code: exitCodeForError(err), Err: err}
+	}
+	return nil
+}
+
+func (c *Bash) hostShellPath() (string, error) {
+	for _, candidate := range []string{"/bin/bash", "/usr/bin/bash"} {
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("%s: host bash not available", c.name)
+}
+
 var _ Command = (*Bash)(nil)
 var _ SpecProvider = (*Bash)(nil)
 var _ ParsedRunner = (*Bash)(nil)
+var _ ParseInvocationNormalizer = (*Bash)(nil)


### PR DESCRIPTION
## Summary
- use host bash for compat-mode `bash` invocations so GNU tests get real bash signal and trap semantics
- keep the compat command dir first on `PATH` so coreutils under test still resolve to `gbash`
- add CLI coverage for `bash --version` and `trap` compatibility in compat mode

## Testing
- `go test ./cmd/gbash -run 'TestRunCLI(PrintsVersion|MulticallBashSupportsVersion|MulticallBashUsesHostBashForTrapCompatibility)'`\n- `go test ./runtime -run 'TestBashRunsNestedCommandString|TestShRunsScriptFromStdin'`\n- direct `compat exec bash --version`\n- direct `compat exec bash -c 'trap "" PIPE; trap - PIPE; echo ok'`