### PR TITLE
Fix Windows build for cat and stat

### DIFF
--- a/commands/cat.go
+++ b/commands/cat.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/ewhauser/gbash/policy"
-	"golang.org/x/sys/unix"
 )
 
 type Cat struct{}
@@ -249,14 +248,6 @@ func catHostOffset(file catHostHandle) int64 {
 		return 0
 	}
 	return offset
-}
-
-func catHostAppendMode(file catHostHandle) bool {
-	flags, err := unix.FcntlInt(file.Fd(), unix.F_GETFL, 0)
-	if err != nil {
-		return false
-	}
-	return flags&unix.O_APPEND != 0
 }
 
 func readCatInput(ctx context.Context, inv *Invocation, name string) (data []byte, label string, err error) {

--- a/commands/cat_appendmode_unix.go
+++ b/commands/cat_appendmode_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package commands
+
+import "golang.org/x/sys/unix"
+
+func catHostAppendMode(file catHostHandle) bool {
+	flags, err := unix.FcntlInt(file.Fd(), unix.F_GETFL, 0)
+	if err != nil {
+		return false
+	}
+	return flags&unix.O_APPEND != 0
+}

--- a/commands/cat_appendmode_windows.go
+++ b/commands/cat_appendmode_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package commands
+
+func catHostAppendMode(file catHostHandle) bool {
+	// Windows host handles do not expose their open flags through the standard
+	// library, so fall back to non-append behavior for external redirections.
+	return false
+}

--- a/commands/stat.go
+++ b/commands/stat.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	stdfs "io/fs"
 	"strings"
-	"syscall"
 )
 
 type Stat struct{}
@@ -138,19 +137,19 @@ func renderStatFormat(ctx context.Context, inv *Invocation, abs string, info std
 }
 
 func statDevice(info stdfs.FileInfo) uint64 {
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok || stat == nil {
+	dev, _, ok := testDeviceAndInode(info)
+	if !ok {
 		return 0
 	}
-	return uint64(stat.Dev)
+	return dev
 }
 
 func statInode(info stdfs.FileInfo) uint64 {
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok || stat == nil {
+	_, ino, ok := testDeviceAndInode(info)
+	if !ok {
 		return 0
 	}
-	return uint64(stat.Ino)
+	return ino
 }
 
 var _ Command = (*Stat)(nil)


### PR DESCRIPTION
## Summary
- move cat append-mode detection into platform-specific files so Windows no longer compiles Unix-only fcntl code
- stop stat from asserting against syscall.Stat_t and reuse the existing reflective device/inode lookup
- keep the release path green for Windows targets again

## Verification
- GOOS=windows GOARCH=amd64 go build ./...
- go test ./...
- make release-snapshot