### PR TITLE
Remove gmsm SM3 dependency from cksum

### DIFF
--- a/commands/cksum.go
+++ b/commands/cksum.go
@@ -17,7 +17,6 @@ import (
 	"strconv"
 	"strings"
 
-	sm3hash "github.com/emmansun/gmsm/sm3"
 	"github.com/ewhauser/gbash/policy"
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/crypto/sha3"
@@ -93,6 +92,7 @@ type cksumCheckStats struct {
 	failedChecksum  int
 	failedOpen      int
 	badFormat       int
+	unsupportedAlgo int
 	totalConsidered int
 }
 
@@ -104,6 +104,7 @@ const (
 	cksumLineFailedChecksum
 	cksumLineFailedOpen
 	cksumLineIgnoredMissing
+	cksumLineUnsupportedAlgorithm
 	cksumLineOK
 )
 
@@ -253,6 +254,9 @@ func (c *Cksum) optionsFromMatches(inv *Invocation, matches *ParsedCommand) (cks
 	}
 
 	if algo != nil {
+		if !algo.isSupported() {
+			return cksumOptions{}, exitf(inv, 1, "cksum: %s is not supported", algo.tagLabel())
+		}
 		finalAlgo, err := sanitizeCksumLength(inv, *algo, lengthValue)
 		if err != nil {
 			return cksumOptions{}, err
@@ -398,6 +402,10 @@ func parseCksumAlgorithm(value string) (cksumAlgorithm, error) {
 
 func (a cksumAlgorithm) isLegacy() bool {
 	return a.family == cksumSysv || a.family == cksumBsd || a.family == cksumCRC || a.family == cksumCRC32B
+}
+
+func (a cksumAlgorithm) isSupported() bool {
+	return a.family != cksumSM3
 }
 
 func (a cksumAlgorithm) tagLabel() string {
@@ -681,9 +689,6 @@ func computeCksumDigest(algo cksumAlgorithm, data []byte) (digest []byte, size i
 		}
 		_, _ = h.Write(data)
 		return h.Sum(nil), len(data), nil
-	case cksumSM3:
-		sum := sm3hash.Sum(data)
-		return sum[:], len(data), nil
 	case cksumShake128:
 		outBits := algo.bits
 		if outBits == 0 {
@@ -765,6 +770,9 @@ func (c *Cksum) verifyChecksumList(ctx context.Context, inv *Invocation, opts ck
 			stats.failedOpen++
 		case cksumLineIgnoredMissing:
 			stats.totalConsidered++
+		case cksumLineUnsupportedAlgorithm:
+			stats.totalConsidered++
+			stats.unsupportedAlgo++
 		case cksumLineOK:
 			stats.totalConsidered++
 			stats.correct++
@@ -795,6 +803,13 @@ func (c *Cksum) verifyChecksumList(ctx context.Context, inv *Invocation, opts ck
 			}
 			_, _ = fmt.Fprintf(inv.Stderr, "cksum: WARNING: %d %s\n", stats.failedOpen, unit)
 		}
+		if stats.unsupportedAlgo > 0 {
+			unit := "checksum line uses"
+			if stats.unsupportedAlgo != 1 {
+				unit = "checksum lines use"
+			}
+			_, _ = fmt.Fprintf(inv.Stderr, "cksum: WARNING: %d %s unsupported algorithms\n", stats.unsupportedAlgo, unit)
+		}
 	}
 	if opts.ignoreMissing && stats.correct == 0 {
 		if verbosity > cksumVerbosityStatus {
@@ -809,6 +824,9 @@ func (c *Cksum) verifyChecksumList(ctx context.Context, inv *Invocation, opts ck
 		return &ExitError{Code: 1}
 	}
 	if stats.failedOpen > 0 && !opts.ignoreMissing {
+		return &ExitError{Code: 1}
+	}
+	if stats.unsupportedAlgo > 0 {
 		return &ExitError{Code: 1}
 	}
 	return nil
@@ -832,6 +850,10 @@ func (c *Cksum) processChecksumLine(ctx context.Context, inv *Invocation, opts c
 	}
 
 	name := checksumUnescapeFilename(line.filename)
+	if !line.algo.isSupported() {
+		_, _ = fmt.Fprintf(inv.Stderr, "cksum: %s: %s is not supported\n", name, line.algo.tagLabel())
+		return cksumLineUnsupportedAlgorithm
+	}
 	data, err := c.readVerifyTarget(ctx, inv, name)
 	if err != nil {
 		if policy.IsDenied(err) {

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,3 @@ require (
 )
 
 require golang.org/x/sys v0.42.0
-
-require github.com/emmansun/gmsm v0.41.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
-github.com/emmansun/gmsm v0.41.1 h1:mD1MqmaXTEqt+9UVmDpRYvcEMIa5vuslFEnw7IWp6/w=
-github.com/emmansun/gmsm v0.41.1/go.mod h1:FD1EQk4XcSMkahZFzNwFoI/uXzAlODB9JVsJ9G5N7Do=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -12,6 +10,7 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
 golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/runtime/cksum_command_test.go
+++ b/runtime/cksum_command_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	sm3hash "github.com/emmansun/gmsm/sm3"
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/crypto/sha3"
 )
@@ -41,7 +40,6 @@ func TestCksumModernOutputModesAndLengths(t *testing.T) {
 	data := []byte("mode-data")
 	writeSessionFile(t, session, "/tmp/input.txt", data)
 
-	sm3sum := sm3hash.Sum(data)
 	shake128 := sha3.NewShake128()
 	_, _ = shake128.Write(data)
 	shakeOut := make([]byte, 20)
@@ -56,7 +54,6 @@ func TestCksumModernOutputModesAndLengths(t *testing.T) {
 		{"md5-tagged", "cksum -a md5 /tmp/input.txt\n", fmt.Sprintf("MD5 (/tmp/input.txt) = %s\n", md5Hex(data))},
 		{"md5-untagged-binary", "cksum -a md5 --untagged --binary /tmp/input.txt\n", fmt.Sprintf("%s */tmp/input.txt\n", md5Hex(data))},
 		{"md5-base64", "cksum -a md5 --base64 /tmp/input.txt\n", fmt.Sprintf("MD5 (/tmp/input.txt) = %s\n", base64.StdEncoding.EncodeToString(mustHexDecode(t, md5Hex(data))))},
-		{"sm3", "cksum -a sm3 /tmp/input.txt\n", fmt.Sprintf("SM3 (/tmp/input.txt) = %x\n", sm3sum)},
 		{"sha2-256", "cksum -a sha2 -l 256 /tmp/input.txt\n", fmt.Sprintf("SHA256 (/tmp/input.txt) = %s\n", sha256Hex(data))},
 		{"blake2b-128", "cksum -a blake2b -l 128 /tmp/input.txt\n", fmt.Sprintf("BLAKE2b-128 (/tmp/input.txt) = %s\n", b2HexSized(data, 16))},
 		{"shake128-156", "cksum -a shake128 -l 156 /tmp/input.txt\n", fmt.Sprintf("SHAKE128 (/tmp/input.txt) = %x\n", shakeOut)},
@@ -82,6 +79,7 @@ func TestCksumCheckModeAndValidation(t *testing.T) {
 	writeSessionFile(t, session, "/tmp/md5.sum", fmt.Appendf(nil, "MD5 (/tmp/input.txt) = %s\n", md5Hex(data)))
 	writeSessionFile(t, session, "/tmp/sha256.sum", fmt.Appendf(nil, "%s  /tmp/input.txt\n", sha256Hex(data)))
 	writeSessionFile(t, session, "/tmp/sha256b64.sum", fmt.Appendf(nil, "SHA256 (/tmp/input.txt) = %s\n", base64.StdEncoding.EncodeToString(mustHexDecode(t, sha256Hex(data)))))
+	writeSessionFile(t, session, "/tmp/sm3.sum", []byte("SM3 (/tmp/input.txt) = 0000000000000000000000000000000000000000000000000000000000000000\n"))
 
 	tests := []struct {
 		name   string
@@ -95,6 +93,8 @@ func TestCksumCheckModeAndValidation(t *testing.T) {
 		{"base64", "cksum --check /tmp/sha256b64.sum\n", "/tmp/input.txt: OK\n", "", true},
 		{"text-without-untagged", "cksum --algorithm=md5 --text /tmp/input.txt\n", "", "cksum: --text mode is only supported with --untagged\n", false},
 		{"legacy-check", "cksum --algorithm=crc --check /tmp/input.txt\n", "", "cksum: --check is not supported with --algorithm={bsd,sysv,crc,crc32b}\n", false},
+		{"sm3-unsupported", "cksum --algorithm=sm3 /tmp/input.txt\n", "", "cksum: SM3 is not supported\n", false},
+		{"sm3-check-unsupported", "cksum --check /tmp/sm3.sum\n", "", "cksum: /tmp/input.txt: SM3 is not supported\ncksum: WARNING: 1 checksum line uses unsupported algorithms\n", false},
 		{"sha2-missing-length", "cksum --algorithm=sha2 /tmp/input.txt\n", "", "cksum: --algorithm=sha2 requires specifying --length 224, 256, 384, or 512\n", false},
 		{"raw-multiple", "cksum --algorithm=md5 --raw /tmp/input.txt /tmp/input.txt\n", "", "cksum: the --raw option is not supported with multiple files\n", false},
 		{"blake2b-length", "cksum --algorithm=blake2b --length=513 /tmp/input.txt\n", "", "cksum: invalid length: '513'\ncksum: maximum digest length for 'BLAKE2b' is 512 bits\n", false},


### PR DESCRIPTION
## Summary
- reject SM3 requests in `cksum` instead of depending on `github.com/emmansun/gmsm`
- fail `--check` when checksum files contain unsupported SM3 entries
- remove the `gmsm` module from `go.mod` and `go.sum`

## Testing
- go test ./...
