### PR TITLE
Use gb variable name in gbash.New examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ import (
 )
 
 func main() {
-	rt, err := gbash.New()
+	gb, err := gbash.New()
 	if err != nil {
 		panic(err)
 	}
 
-	result, err := rt.Run(context.Background(), &gbash.ExecutionRequest{
+	result, err := gb.Run(context.Background(), &gbash.ExecutionRequest{
 		Script: "echo hello\npwd\n",
 	})
 	if err != nil {
@@ -87,14 +87,14 @@ import (
 )
 
 func main() {
-	rt, err := gbash.New(
+	gb, err := gbash.New(
 		gbash.WithHTTPAccess("https://api.example.com/v1/"),
 	)
 	if err != nil {
 		panic(err)
 	}
 
-	result, err := rt.Run(context.Background(), &gbash.ExecutionRequest{
+	result, err := gb.Run(context.Background(), &gbash.ExecutionRequest{
 		Script: "curl -o /tmp/status.json https://api.example.com/v1/status\ncat /tmp/status.json\n",
 	})
 	if err != nil {
@@ -124,12 +124,12 @@ import (
 func main() {
 	ctx := context.Background()
 
-	rt, err := gbash.New()
+	gb, err := gbash.New()
 	if err != nil {
 		panic(err)
 	}
 
-	session, err := rt.NewSession(ctx)
+	session, err := gb.NewSession(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -239,7 +239,7 @@ The zero value of `gbash.Config` still gives you an in-memory sandbox rooted at 
 For the closest parity with `just-bash`'s real-directory overlay:
 
 ```go
-rt, err := gbash.New(
+gb, err := gbash.New(
 	gbash.WithWorkspace("/path/to/project"),
 )
 ```
@@ -249,7 +249,7 @@ That mounts the host directory read-only at `/home/agent/project`, starts the se
 If you need to change the mount point or host-file read cap, drop down to the explicit filesystem helper:
 
 ```go
-rt, err := gbash.New(
+gb, err := gbash.New(
 	gbash.WithFileSystem(gbash.HostDirectoryFileSystem("/path/to/project", gbash.HostDirectoryOptions{
 		MountPoint: "/home/agent/project",
 	})),
@@ -263,7 +263,7 @@ rt, err := gbash.New(
 Network access is disabled by default. When you set `Config.Network` or provide `Config.NetworkClient`, the runtime registers `curl` automatically. Otherwise `curl` is not present in the sandbox at all.
 
 ```go
-rt, err := gbash.New(
+gb, err := gbash.New(
 	gbash.WithNetwork(&gbash.NetworkConfig{
 		AllowedURLPrefixes: []string{"https://api.example.com/v1/"},
 		AllowedMethods:     []gbash.Method{gbash.MethodGet, gbash.MethodHead},

--- a/examples/adk-bash-chat/bash_tool.go
+++ b/examples/adk-bash-chat/bash_tool.go
@@ -40,7 +40,7 @@ type bashToolResult struct {
 }
 
 type persistentBashTool struct {
-	rt         *gbash.Runtime
+	gb         *gbash.Runtime
 	fixtureDir string
 
 	mu      sync.Mutex
@@ -73,13 +73,13 @@ func newPersistentBashTool(ctx context.Context) (*persistentBashTool, error) {
 		return nil, fmt.Errorf("register sqlite3 command: %w", err)
 	}
 
-	rt, err := gbash.New(gbash.WithRegistry(registry))
+	gb, err := gbash.New(gbash.WithRegistry(registry))
 	if err != nil {
 		return nil, fmt.Errorf("create runtime: %w", err)
 	}
 
 	bt := &persistentBashTool{
-		rt:         rt,
+		gb:         gb,
 		fixtureDir: mustFixtureDir(),
 	}
 	if err := bt.resetLocked(ctx); err != nil {
@@ -130,7 +130,7 @@ func (t *persistentBashTool) Reset(ctx context.Context) error {
 }
 
 func (t *persistentBashTool) resetLocked(ctx context.Context) error {
-	session, err := t.rt.NewSession(ctx)
+	session, err := t.gb.NewSession(ctx)
 	if err != nil {
 		return fmt.Errorf("create sandbox session: %w", err)
 	}

--- a/examples/custom-zstd/main.go
+++ b/examples/custom-zstd/main.go
@@ -32,12 +32,12 @@ func main() {
 		os.Exit(2)
 	}
 
-	rt, err := gbash.New(gbash.WithRegistry(registry))
+	gb, err := gbash.New(gbash.WithRegistry(registry))
 	if err != nil {
 		fail(fmt.Errorf("create runtime: %w", err))
 	}
 
-	result, err := rt.Run(ctx, &gbash.ExecutionRequest{
+	result, err := gb.Run(ctx, &gbash.ExecutionRequest{
 		Name:   "custom-zstd",
 		Script: string(script),
 	})

--- a/examples/openai-tool-call/main.go
+++ b/examples/openai-tool-call/main.go
@@ -163,12 +163,12 @@ func executeBashTool(ctx context.Context, arguments string) (string, error) {
 		return "", errors.New("bash tool call did not include a script")
 	}
 
-	rt, err := gbash.New()
+	gb, err := gbash.New()
 	if err != nil {
 		return "", fmt.Errorf("create runtime: %w", err)
 	}
 
-	result, err := rt.Run(ctx, &gbash.ExecutionRequest{
+	result, err := gb.Run(ctx, &gbash.ExecutionRequest{
 		Script: args.Script,
 	})
 	if err != nil {

--- a/examples/sqlite-backed-fs/main.go
+++ b/examples/sqlite-backed-fs/main.go
@@ -31,7 +31,7 @@ func run(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, args []
 		return 1, err
 	}
 
-	rt, err := gbash.New(gbash.WithFileSystem(
+	gb, err := gbash.New(gbash.WithFileSystem(
 		gbash.CustomFileSystem(
 			sqliteFSFactory{dbPath: opts.dbPath},
 			opts.workDir,
@@ -42,7 +42,7 @@ func run(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, args []
 	}
 
 	if opts.repl || (opts.script == "" && stdinIsTTY(stdin)) {
-		return runInteractiveShell(ctx, rt, stdin, stdout, stderr, opts.workDir)
+		return runInteractiveShell(ctx, gb, stdin, stdout, stderr, opts.workDir)
 	}
 
 	script := opts.script
@@ -54,7 +54,7 @@ func run(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, args []
 		script = string(data)
 	}
 
-	result, err := rt.Run(ctx, &gbash.ExecutionRequest{
+	result, err := gb.Run(ctx, &gbash.ExecutionRequest{
 		Name:   "sqlite-backed-fs",
 		Script: script,
 	})

--- a/examples/sqlite-backed-fs/repl.go
+++ b/examples/sqlite-backed-fs/repl.go
@@ -21,8 +21,8 @@ type interactiveState struct {
 	env     map[string]string
 }
 
-func runInteractiveShell(ctx context.Context, rt *gbash.Runtime, stdin io.Reader, stdout, stderr io.Writer, workDir string) (int, error) {
-	session, err := rt.NewSession(ctx)
+func runInteractiveShell(ctx context.Context, gb *gbash.Runtime, stdin io.Reader, stdout, stderr io.Writer, workDir string) (int, error) {
+	session, err := gb.NewSession(ctx)
 	if err != nil {
 		return 1, fmt.Errorf("init session: %w", err)
 	}


### PR DESCRIPTION
## Summary
- rename the runtime variable from `rt` to `gb` in README examples that use `gbash.New()`
- apply the same naming update across the example programs under `examples/`
- keep the persistent ADK bash tool example internally consistent by renaming its stored runtime field as well

## Testing
- go test ./examples/...
