### PR TITLE
docs: add contrib extras registry example

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,12 @@ Optional commands live in [`contrib/`](./contrib/) as separate Go modules so the
 
 Use `github.com/ewhauser/gbash/contrib/extras` when you want to build a full registry for the contrib command set in one call.
 
+```go
+import "github.com/ewhauser/gbash/contrib/extras"
+
+gb, err := gbash.New(gbash.WithRegistry(extras.FullRegistry()))
+```
+
 See [Custom Commands](#custom-commands) for how to register them.
 
 ## Shell Features


### PR DESCRIPTION
## Summary
- add a short README snippet showing how to use `contrib/extras.FullRegistry()`
- place the example directly under the contrib/extras guidance

## Testing
- not run (docs-only change)