### PR TITLE
Simplify GNU category pass reporting

### DIFF
--- a/cmd/gbash-gnu/manifest.json
+++ b/cmd/gbash-gnu/manifest.json
@@ -66,7 +66,9 @@
     { "patterns": ["tests/misc/false-status.sh"], "commands": ["false"], "kind": "direct" }
   ],
   "skip_patterns": [
+    { "pattern": "tests/chcon/*", "reason": "SELinux command tests are out of scope in v1" },
     { "pattern": "tests/help/*", "reason": "help/version tests are skipped in v1" },
-    { "pattern": "tests/*/selinux*", "reason": "SELinux tests are skipped in v1" }
+    { "pattern": "tests/runcon/*", "reason": "SELinux command tests are out of scope in v1" },
+    { "pattern": "tests/*/selinux*", "reason": "SELinux tests are out of scope in v1" }
   ]
 }

--- a/scripts/compat-report/main.go
+++ b/scripts/compat-report/main.go
@@ -140,6 +140,7 @@ type categoryResult struct {
 	Summary  coverageBucket    `json:"summary"`
 	Tests    []suiteTest       `json:"tests,omitempty"`
 	Counts   string            `json:"-"`
+	RowNote  string            `json:"-"`
 	Segments []progressSegment `json:"-"`
 }
 
@@ -174,6 +175,7 @@ type coverageDebtSummary struct {
 
 type indexView struct {
 	Summary        runSummary
+	InScopePassPct float64
 	SelectedDetail string
 	RunnableDetail string
 }
@@ -267,9 +269,11 @@ func writeReport(outputDir string, summary *runSummary) error {
 
 func renderIndex(summary *runSummary) ([]byte, error) {
 	var buf bytes.Buffer
+	inScopeTotal := suiteInScopeTotal(summary)
 	view := indexView{
 		Summary:        *summary,
-		SelectedDetail: fmt.Sprintf("%d selected, %d filtered, %d passing", summary.Suite.SelectedTotal, summary.Suite.FilteredTotal, summary.Suite.Pass),
+		InScopePassPct: suiteInScopePassPct(summary),
+		SelectedDetail: fmt.Sprintf("%d in scope, %d out of scope, %d passing", inScopeTotal, summary.Suite.FilteredTotal, summary.Suite.Pass),
 		RunnableDetail: fmt.Sprintf("%d runnable, %d passing, %d skipped, %d failing", summary.Suite.RunnableTotal, summary.Suite.Pass, summary.Suite.Skip+summary.Suite.XFail, summary.Suite.Fail+summary.Suite.Error+summary.Suite.XPass+summary.Suite.Unreported),
 	}
 	if err := indexTemplate.ExecuteTemplate(&buf, "index.html.tmpl", view); err != nil {
@@ -281,6 +285,7 @@ func renderIndex(summary *runSummary) ([]byte, error) {
 func prepareSummaryView(summary *runSummary) {
 	for i := range summary.Categories {
 		summary.Categories[i].Counts = bucketCounts(&summary.Categories[i].Summary)
+		summary.Categories[i].RowNote = bucketRowNote(&summary.Categories[i].Summary)
 		summary.Categories[i].Segments = bucketSegments(&summary.Categories[i].Summary)
 	}
 }
@@ -296,8 +301,8 @@ func renderBadge(summary *runSummary) ([]byte, error) {
 
 func buildBadgeView(summary *runSummary) badgeView {
 	label := "compat"
-	message := formatPercent(summary.Suite.PassPctSelected)
-	if summary.Suite.SelectedTotal == 0 {
+	message := formatPercent(suiteInScopePassPct(summary))
+	if suiteInScopeTotal(summary) == 0 {
 		message = "n/a"
 	}
 	labelWidth := badgeTextWidth(label)
@@ -319,13 +324,14 @@ func badgeTextWidth(text string) int {
 }
 
 func badgeColor(summary *runSummary) string {
-	if summary.Suite.SelectedTotal == 0 {
+	passPct := suiteInScopePassPct(summary)
+	if suiteInScopeTotal(summary) == 0 {
 		return "#9f9f9f"
 	}
 	switch {
-	case summary.Suite.PassPctSelected >= 90:
+	case passPct >= 90:
 		return "#4c1"
-	case summary.Suite.PassPctSelected >= 70:
+	case passPct >= 70:
 		return "#dfb317"
 	default:
 		return "#e05d44"
@@ -333,7 +339,14 @@ func badgeColor(summary *runSummary) string {
 }
 
 func bucketCounts(bucket *coverageBucket) string {
-	return fmt.Sprintf("%d / %d / %d", bucket.Pass, bucket.Skip+bucket.FilteredTotal+bucket.XFail, bucket.Fail+bucket.Error+bucket.XPass+bucket.Unreported)
+	return fmt.Sprintf("%d / %d / %d", bucket.Pass, bucket.Skip+bucket.XFail, bucket.Fail+bucket.Error+bucket.XPass+bucket.Unreported)
+}
+
+func bucketRowNote(bucket *coverageBucket) string {
+	if bucket.FilteredTotal == 0 {
+		return fmt.Sprintf("%d tests", bucket.SelectedTotal)
+	}
+	return fmt.Sprintf("%d tests, %d out of scope", bucket.SelectedTotal, bucket.FilteredTotal)
 }
 
 func bucketSegments(bucket *coverageBucket) []progressSegment {
@@ -346,7 +359,8 @@ func bucketSegments(bucket *coverageBucket) []progressSegment {
 		count int
 	}{
 		{class: "good", count: bucket.Pass},
-		{class: "warn", count: bucket.Skip + bucket.FilteredTotal + bucket.XFail},
+		{class: "oos", count: bucket.FilteredTotal},
+		{class: "warn", count: bucket.Skip + bucket.XFail},
 		{class: "bad", count: bucket.Fail + bucket.Error + bucket.XPass + bucket.Unreported},
 	}
 	out := make([]progressSegment, 0, len(segments))
@@ -364,7 +378,7 @@ func bucketSegments(bucket *coverageBucket) []progressSegment {
 
 func testStatusClass(status string, filtered bool) string {
 	if filtered {
-		return "warn"
+		return "oos"
 	}
 	switch status {
 	case "pass":
@@ -390,6 +404,22 @@ func formatPercent(value float64) string {
 	formatted := fmt.Sprintf("%.2f", value)
 	formatted = strings.TrimRight(strings.TrimRight(formatted, "0"), ".")
 	return formatted + "%"
+}
+
+func suiteInScopeTotal(summary *runSummary) int {
+	total := summary.Suite.SelectedTotal - summary.Suite.FilteredTotal
+	if total < 0 {
+		return 0
+	}
+	return total
+}
+
+func suiteInScopePassPct(summary *runSummary) float64 {
+	total := suiteInScopeTotal(summary)
+	if total == 0 {
+		return 0
+	}
+	return math.Round((float64(summary.Suite.Pass)/float64(total))*10000) / 100
 }
 
 func fatalf(format string, args ...any) {

--- a/scripts/compat-report/main_test.go
+++ b/scripts/compat-report/main_test.go
@@ -27,7 +27,7 @@ func TestWriteReportWritesIndexAndBadge(t *testing.T) {
 				{Path: "tests/misc/basename.pl", Category: "misc", Status: "pass", Attributions: []testAttribution{{Command: "basename", Kind: "direct"}}},
 				{Path: "tests/cat/cat-self.sh", Category: "cat", Status: "skip", Attributions: []testAttribution{{Command: "cat", Kind: "direct"}}},
 				{Path: "tests/misc/dirname.pl", Category: "misc", Status: "fail", Attributions: []testAttribution{{Command: "dirname", Kind: "direct"}}},
-				{Path: "tests/help/help-version.sh", Category: "help", Status: "filtered", Filtered: true},
+				{Path: "tests/help/help-version.sh", Category: "help", Status: "filtered", Filtered: true, FilterReason: "help/version tests are out of scope"},
 			},
 		},
 		Categories: []categoryResult{
@@ -50,7 +50,7 @@ func TestWriteReportWritesIndexAndBadge(t *testing.T) {
 				Name:    "help",
 				Summary: coverageBucket{SelectedTotal: 1, FilteredTotal: 1, PassPctSelected: 0, PassPctRunnable: 0},
 				Tests: []suiteTest{
-					{Path: "tests/help/help-version.sh", Category: "help", Status: "filtered", Filtered: true},
+					{Path: "tests/help/help-version.sh", Category: "help", Status: "filtered", Filtered: true, FilterReason: "help/version tests are out of scope"},
 				},
 			},
 		},
@@ -104,12 +104,15 @@ func TestWriteReportWritesIndexAndBadge(t *testing.T) {
 	index := string(indexData)
 	for _, needle := range []string{
 		"GNU Test Coverage",
-		"Selected Test Pass",
+		"In-Scope Test Pass",
 		"Coverage per category",
 		"summary.json",
 		"tests/misc/dirname.pl",
 		"1 / 0 / 1",
-		"50%",
+		"33.33%",
+		"1 out of scope",
+		"out of scope",
+		"help/version tests are out of scope",
 	} {
 		if !strings.Contains(index, needle) {
 			t.Fatalf("index.html missing %q", needle)
@@ -132,8 +135,8 @@ func TestWriteReportWritesIndexAndBadge(t *testing.T) {
 		t.Fatalf("ReadFile(badge.svg) error = %v", err)
 	}
 	badge := string(badgeData)
-	if !strings.Contains(badge, "compat") || !strings.Contains(badge, "25%") {
-		t.Fatalf("badge.svg content = %q, want compat and 25%%", badge)
+	if !strings.Contains(badge, "compat") || !strings.Contains(badge, "33.33%") {
+		t.Fatalf("badge.svg content = %q, want compat and 33.33%%", badge)
 	}
 }
 

--- a/scripts/compat-report/templates/index.html.tmpl
+++ b/scripts/compat-report/templates/index.html.tmpl
@@ -139,6 +139,7 @@ details.group summary::-webkit-details-marker {
   height: 100%;
 }
 .progress-segment.good { background: var(--good); }
+.progress-segment.oos { background: rgba(183, 191, 217, 0.36); }
 .progress-segment.warn { background: var(--warn); }
 .progress-segment.bad { background: var(--bad); }
 .group-body {
@@ -174,9 +175,15 @@ details.group summary::-webkit-details-marker {
   text-align: center;
 }
 .good { color: var(--good); background: rgba(71, 194, 113, 0.14); }
+.oos { color: #d6dceb; background: rgba(183, 191, 217, 0.18); }
 .warn { color: var(--warn); background: rgba(216, 202, 134, 0.14); }
 .bad { color: var(--bad); background: rgba(255, 75, 92, 0.14); }
 .na { color: var(--muted); background: rgba(183, 191, 217, 0.14); }
+.test-note {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
 @media (max-width: 920px) {
   .summary-row {
     grid-template-columns: 1fr;
@@ -195,8 +202,8 @@ details.group summary::-webkit-details-marker {
 
     <section class="summary">
       <article class="summary-card">
-        <div class="summary-label">Selected Test Pass</div>
-        <div class="summary-value">{{ formatPercent .Summary.Suite.PassPctSelected }}</div>
+        <div class="summary-label">In-Scope Test Pass</div>
+        <div class="summary-value">{{ formatPercent .InScopePassPct }}</div>
         <div class="summary-detail">{{ .SelectedDetail }}</div>
       </article>
       <article class="summary-card">
@@ -213,7 +220,7 @@ details.group summary::-webkit-details-marker {
 
     <section class="panel">
       <h2>Coverage per category</h2>
-      <p class="section-copy">Click categories to see the names of the tests. Green indicates a passing test, yellow indicates a skipped or filtered test, and red indicates a failed, errored, or unreported test.</p>
+      <p class="section-copy">Click categories to see the names of the tests. Green indicates a passing test, yellow indicates a skipped test, grey indicates an out-of-scope test excluded from the overall pass rate, and red indicates a failed, errored, or unreported test.</p>
 
       <div class="details-list">
         {{- range .Summary.Categories }}
@@ -227,7 +234,7 @@ details.group summary::-webkit-details-marker {
                 <span class="progress-segment {{ .Class }}" style="width: {{ .Width }}"></span>
                 {{- end }}
               </div>
-              <span class="row-note">{{ .Summary.SelectedTotal }} tests{{ if gt .Summary.FilteredTotal 0 }}, {{ .Summary.FilteredTotal }} filtered{{ end }}</span>
+              <span class="row-note">{{ .RowNote }}</span>
             </div>
           </summary>
           <div class="group-body">
@@ -241,8 +248,8 @@ details.group summary::-webkit-details-marker {
               <tbody>
                 {{- range .Tests }}
                 <tr>
-                  <td class="mono">{{ .Path }}</td>
-                  <td><span class="pill {{ testStatusClass .Status .Filtered }}">{{ if .Filtered }}filtered{{ else }}{{ .Status }}{{ end }}</span></td>
+                  <td class="mono">{{ .Path }}{{ if .Filtered }}<div class="test-note">{{ .FilterReason }}</div>{{ end }}</td>
+                  <td><span class="pill {{ testStatusClass .Status .Filtered }}">{{ if .Filtered }}out of scope{{ else }}{{ .Status }}{{ end }}</span></td>
                 </tr>
                 {{- end }}
               </tbody>


### PR DESCRIPTION
## Summary
- simplify the published GNU compatibility report to show one overall pass rate plus pass rates for each GNU test category
- exclude skipped and out-of-scope tests from the overall and per-category percentage denominators
- mark `chcon` and `runcon` test categories as out of scope in the GNU manifest, alongside the existing SELinux-specific test filters

## Verification
- `go test ./cmd/gbash-gnu ./scripts/compat-report -count=1`
- `make lint`

## Local report
- rendered locally from `.cache/gnu/results/new-schema-e2e/summary.json` to `.cache/gnu/results/new-schema-e2e-report-category-pct/index.html`
- SELinux command behavior preview rendered to `.cache/gnu/results/new-schema-e2e-report-selinux-derived/index.html`