### PR TITLE
Fix GNU factor and split filter behavior

### DIFF
--- a/commands/factor.go
+++ b/commands/factor.go
@@ -203,7 +203,7 @@ func factorWarnInvalid(inv *Invocation, token []byte) {
 	if inv == nil || inv.Stderr == nil {
 		return
 	}
-	_, _ = fmt.Fprintf(inv.Stderr, "factor: warning: %s: invalid digit found in string\n", factorQuoteBytes(token))
+	_, _ = fmt.Fprintf(inv.Stderr, "factor: %s is not a valid positive integer\n", factorQuoteBytes(token))
 }
 
 func factorParseNumber(token []byte) (*big.Int, error) {
@@ -381,7 +381,7 @@ func factorWriteResult(writer *bufio.Writer, number *big.Int, factors []*big.Int
 	if err := writer.WriteByte('\n'); err != nil {
 		return err
 	}
-	return writer.Flush()
+	return nil
 }
 
 func factorWriteError(inv *Invocation, err error) error {

--- a/commands/split.go
+++ b/commands/split.go
@@ -798,15 +798,14 @@ func runSplitFilter(ctx context.Context, inv *Invocation, filter, fileName strin
 		Env:     env,
 		WorkDir: inv.Cwd,
 		Stdin:   bytes.NewReader(data),
+		Stdout:  inv.Stdout,
+		Stderr:  inv.Stderr,
 	})
 	if err != nil {
 		return &ExitError{Code: 1, Err: err}
 	}
 	if result == nil || result.ExitCode == 0 {
 		return nil
-	}
-	if err := writeExecutionOutputs(inv, result); err != nil {
-		return err
 	}
 	return exitForExecutionResult(result)
 }

--- a/runtime/factor_commands_test.go
+++ b/runtime/factor_commands_test.go
@@ -100,7 +100,7 @@ func TestFactorKeepsGoingAfterInvalidNumbers(t *testing.T) {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 
-	wantErr := "factor: warning: 'not-a-valid-number': invalid digit found in string\n"
+	wantErr := "factor: 'not-a-valid-number' is not a valid positive integer\n"
 	if got := result.Stderr; got != wantErr {
 		t.Fatalf("Stderr = %q, want %q", got, wantErr)
 	}
@@ -126,10 +126,10 @@ func TestFactorMatchesUpstreamStdinTokenizationForBinaryInput(t *testing.T) {
 	}
 
 	wantErr := "" +
-		"factor: warning: '': invalid digit found in string\n" +
-		"factor: warning: '\\377': invalid digit found in string\n" +
-		"factor: warning: 'a&#2': invalid digit found in string\n" +
-		"factor: warning: '\\367\\301': invalid digit found in string\n"
+		"factor: '' is not a valid positive integer\n" +
+		"factor: '\\377' is not a valid positive integer\n" +
+		"factor: 'a&#2' is not a valid positive integer\n" +
+		"factor: '\\367\\301' is not a valid positive integer\n"
 	if got := result.Stderr; got != wantErr {
 		t.Fatalf("Stderr = %q, want %q", got, wantErr)
 	}

--- a/runtime/split_commands_test.go
+++ b/runtime/split_commands_test.go
@@ -1,0 +1,28 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSplitFilterStreamsRoundRobinOutput(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf '1\\n2\\n3\\n4\\n5\\n' | split -nr/2 --filter='cat'\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+
+	want := "1\n3\n5\n2\n4\n"
+	if got := result.Stdout; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("Stderr = %q, want empty stderr", result.Stderr)
+	}
+}


### PR DESCRIPTION
## Summary
- make `factor` match GNU's invalid-input diagnostics and avoid per-line flushes
- stream `split --filter` output instead of discarding successful filter stdout/stderr
- add runtime regressions for the GNU factor and split filter cases

## Verification
- `go test ./runtime -run 'TestFactorKeepsGoingAfterInvalidNumbers|TestFactorMatchesUpstreamStdinTokenizationForBinaryInput|TestSplitFilterStreamsRoundRobinOutput' -count=1`
- `GNU_TESTS='tests/factor/factor.pl' GNU_RESULTS_DIR='.cache/gnu/results/debug-factor-pl-fix' make gnu-test`
- `GNU_TESTS='tests/factor/factor-parallel.sh' GNU_RESULTS_DIR='.cache/gnu/results/debug-factor-parallel-fix' make gnu-test`
