### PR TITLE
Optimize session filesystem setup

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -47,11 +47,15 @@ func (f FactoryFunc) New(ctx context.Context) (FileSystem, error) {
 	return f(ctx)
 }
 
+type memoryFactory struct{}
+
+func (memoryFactory) New(context.Context) (FileSystem, error) {
+	return NewMemory(), nil
+}
+
 // Memory returns a factory that creates a fresh in-memory filesystem per session.
 func Memory() Factory {
-	return FactoryFunc(func(context.Context) (FileSystem, error) {
-		return NewMemory(), nil
-	})
+	return memoryFactory{}
 }
 
 // Overlay returns a copy-on-write filesystem factory over lower.
@@ -73,6 +77,12 @@ func Snapshot(source FileSystem) Factory {
 	return FactoryFunc(func(ctx context.Context) (FileSystem, error) {
 		return NewSnapshot(ctx, source)
 	})
+}
+
+// Reusable returns a factory that materializes source once and gives each
+// caller a fresh writable overlay above that shared base.
+func Reusable(source Factory) Factory {
+	return &reusableFactory{source: source}
 }
 
 func Clean(name string) string {

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -248,6 +249,61 @@ func TestSnapshotFSPreservesSourceViewAndRejectsWrites(t *testing.T) {
 	}
 	if realpath, err := snapshot.Realpath(context.Background(), "/data.txt"); err != nil || realpath != "/data.txt" {
 		t.Fatalf("Realpath() = %q, %v; want /data.txt, nil", realpath, err)
+	}
+}
+
+func TestReusableFactoryReusesBaseAndKeepsSessionsIsolated(t *testing.T) {
+	var created atomic.Int32
+	factory := Reusable(FactoryFunc(func(context.Context) (FileSystem, error) {
+		created.Add(1)
+		return seededMemory(t, map[string]string{
+			"/seed.txt": "seed\n",
+		}), nil
+	}))
+
+	first, err := factory.New(context.Background())
+	if err != nil {
+		t.Fatalf("New(first) error = %v", err)
+	}
+	second, err := factory.New(context.Background())
+	if err != nil {
+		t.Fatalf("New(second) error = %v", err)
+	}
+
+	writeTestFile(t, first, "/seed.txt", "first-session\n")
+	writeTestFile(t, first, "/only-first.txt", "first\n")
+
+	if got, want := readTestFile(t, first, "/seed.txt"), "first-session\n"; got != want {
+		t.Fatalf("first /seed.txt = %q, want %q", got, want)
+	}
+	if got, want := readTestFile(t, second, "/seed.txt"), "seed\n"; got != want {
+		t.Fatalf("second /seed.txt = %q, want %q", got, want)
+	}
+	if _, err := second.Stat(context.Background(), "/only-first.txt"); !errors.Is(err, stdfs.ErrNotExist) {
+		t.Fatalf("second Stat(/only-first.txt) error = %v, want not exist", err)
+	}
+	if got, want := created.Load(), int32(1); got != want {
+		t.Fatalf("base factory created %d instances, want %d", got, want)
+	}
+}
+
+func TestMemoryFSCloneIsolated(t *testing.T) {
+	base := seededMemory(t, map[string]string{
+		"/data.txt": "base\n",
+	})
+	clone := base.Clone()
+
+	writeTestFile(t, clone, "/data.txt", "clone\n")
+	writeTestFile(t, clone, "/new.txt", "new\n")
+
+	if got, want := readTestFile(t, clone, "/data.txt"), "clone\n"; got != want {
+		t.Fatalf("clone /data.txt = %q, want %q", got, want)
+	}
+	if got, want := readTestFile(t, base, "/data.txt"), "base\n"; got != want {
+		t.Fatalf("base /data.txt = %q, want %q", got, want)
+	}
+	if _, err := base.Stat(context.Background(), "/new.txt"); !errors.Is(err, stdfs.ErrNotExist) {
+		t.Fatalf("base Stat(/new.txt) error = %v, want not exist", err)
 	}
 }
 

--- a/fs/memory.go
+++ b/fs/memory.go
@@ -51,6 +51,38 @@ func NewMemory() *MemoryFS {
 	}
 }
 
+// Clone returns an isolated copy of the in-memory filesystem state.
+func (m *MemoryFS) Clone() *MemoryFS {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	nodes := make(map[string]*memoryNode, len(m.nodes))
+	for name, node := range m.nodes {
+		cloned := &memoryNode{
+			mode:    node.mode,
+			target:  node.target,
+			modTime: node.modTime,
+			uid:     node.uid,
+			gid:     node.gid,
+		}
+		if len(node.data) > 0 {
+			cloned.data = append([]byte(nil), node.data...)
+		}
+		if node.children != nil {
+			cloned.children = make(map[string]struct{}, len(node.children))
+			for child := range node.children {
+				cloned.children[child] = struct{}{}
+			}
+		}
+		nodes[name] = cloned
+	}
+
+	return &MemoryFS{
+		cwd:   m.cwd,
+		nodes: nodes,
+	}
+}
+
 func (m *MemoryFS) Symlink(_ context.Context, target, linkName string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/fs/reusable.go
+++ b/fs/reusable.go
@@ -1,0 +1,41 @@
+package fs
+
+import (
+	"context"
+	"sync"
+)
+
+type reusableFactory struct {
+	source Factory
+
+	mu   sync.Mutex
+	base FileSystem
+}
+
+func (f *reusableFactory) New(ctx context.Context) (FileSystem, error) {
+	f.mu.Lock()
+	base := f.base
+	f.mu.Unlock()
+
+	if base == nil {
+		created, err := reusableSource(f.source).New(ctx)
+		if err != nil {
+			return nil, err
+		}
+		f.mu.Lock()
+		if f.base == nil {
+			f.base = created
+		}
+		base = f.base
+		f.mu.Unlock()
+	}
+
+	return NewOverlay(base), nil
+}
+
+func reusableSource(source Factory) Factory {
+	if source != nil {
+		return source
+	}
+	return Memory()
+}

--- a/runtime/bench_helpers_test.go
+++ b/runtime/bench_helpers_test.go
@@ -15,7 +15,7 @@ func newSeededRuntime(tb testing.TB, files map[string]string) *Runtime {
 
 	return newRuntime(tb, &Config{
 		FileSystem: CustomFileSystem(
-			gbfs.Overlay(gbfs.Snapshot(base.FileSystem())),
+			gbfs.Reusable(gbfs.Snapshot(base.FileSystem())),
 			defaultHomeDir,
 		),
 	})

--- a/runtime/layout_test.go
+++ b/runtime/layout_test.go
@@ -2,9 +2,13 @@ package runtime
 
 import (
 	"context"
+	"io"
+	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	gbfs "github.com/ewhauser/gbash/fs"
 	"github.com/ewhauser/gbash/policy"
 )
 
@@ -44,6 +48,21 @@ func TestDefaultSandboxLayout(t *testing.T) {
 	}
 	if containsLine(lines, "__jb_cd_resolve") {
 		t.Fatalf("Stdout should not expose internal command stubs: %q", result.Stdout)
+	}
+}
+
+func TestNewSessionHasPreparedDefaultLayout(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	session, err := rt.NewSession(context.Background())
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	if _, err := session.FileSystem().Stat(context.Background(), "/bin/echo"); err != nil {
+		t.Fatalf("Stat(/bin/echo) error = %v", err)
+	}
+	if _, err := session.FileSystem().Stat(context.Background(), defaultHomeDir); err != nil {
+		t.Fatalf("Stat(%q) error = %v", defaultHomeDir, err)
 	}
 }
 
@@ -141,4 +160,69 @@ func TestPwdHonorsLogicalAndPhysicalModes(t *testing.T) {
 	if got := result.Stdout; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
+}
+
+func TestEnsureCommandStubDoesNotCloneExistingLowerStub(t *testing.T) {
+	ctx := context.Background()
+	lower := gbfs.NewMemory()
+	file, err := lower.OpenFile(ctx, "/bin/echo", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("OpenFile(/bin/echo) error = %v", err)
+	}
+	if _, err := file.Write([]byte("lower-v1\n")); err != nil {
+		t.Fatalf("Write(/bin/echo) error = %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close(/bin/echo) error = %v", err)
+	}
+
+	countingLower := &openCountingFS{FileSystem: lower}
+	overlay := gbfs.NewOverlay(countingLower)
+	if err := ensureCommandStub(ctx, overlay, "/bin", "echo"); err != nil {
+		t.Fatalf("ensureCommandStub() error = %v", err)
+	}
+
+	file, err = lower.OpenFile(ctx, "/bin/echo", os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("OpenFile(/bin/echo rewrite) error = %v", err)
+	}
+	if _, err := file.Write([]byte("lower-v2\n")); err != nil {
+		t.Fatalf("Write(/bin/echo rewrite) error = %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close(/bin/echo rewrite) error = %v", err)
+	}
+
+	if got, want := readLayoutTestFile(t, overlay, "/bin/echo"), "lower-v2\n"; got != want {
+		t.Fatalf("overlay /bin/echo = %q, want %q", got, want)
+	}
+	if got := countingLower.opens.Load(); got != 0 {
+		t.Fatalf("lower Open() count = %d, want 0", got)
+	}
+}
+
+type openCountingFS struct {
+	gbfs.FileSystem
+	opens atomic.Int32
+}
+
+func (fs *openCountingFS) Open(ctx context.Context, name string) (gbfs.File, error) {
+	fs.opens.Add(1)
+	return fs.FileSystem.Open(ctx, name)
+}
+
+func readLayoutTestFile(t *testing.T, fsys gbfs.FileSystem, name string) string {
+	t.Helper()
+
+	file, err := fsys.Open(context.Background(), name)
+	if err != nil {
+		t.Fatalf("Open(%q) error = %v", name, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("ReadAll(%q) error = %v", name, err)
+	}
+	return string(data)
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -26,7 +26,8 @@ type Config struct {
 }
 
 type Runtime struct {
-	cfg Config
+	cfg            Config
+	sessionFactory sessionFactory
 }
 
 type Session struct {
@@ -45,6 +46,7 @@ func New(opts ...Option) (*Runtime, error) {
 	if err != nil {
 		return nil, err
 	}
+	defaultSessionFS := resolved.FileSystem.Factory == nil
 	resolved.FileSystem = resolved.FileSystem.resolved()
 	if resolved.Registry == nil {
 		resolved.Registry = commands.DefaultRegistry()
@@ -86,17 +88,32 @@ func New(opts ...Option) (*Runtime, error) {
 	}
 	resolved.BaseEnv = mergeEnv(defaultBaseEnv(), resolved.BaseEnv)
 
-	return &Runtime{cfg: resolved}, nil
+	factory := sessionFactory(plainSessionFactory{base: resolved.FileSystem.Factory})
+	if defaultSessionFS {
+		factory = &preparedMemorySessionFactory{
+			base:     resolved.FileSystem.Factory,
+			env:      resolved.BaseEnv,
+			workDir:  resolved.FileSystem.WorkingDir,
+			commands: resolved.Registry.Names(),
+		}
+	}
+
+	return &Runtime{
+		cfg:            resolved,
+		sessionFactory: factory,
+	}, nil
 }
 
 func (r *Runtime) NewSession(ctx context.Context) (*Session, error) {
-	fsys, err := r.cfg.FileSystem.Factory.New(ctx)
+	fsys, err := r.sessionFactory.New(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := initializeSandboxLayout(ctx, fsys, r.cfg.BaseEnv, r.cfg.FileSystem.WorkingDir, r.cfg.Registry.Names()); err != nil {
-		return nil, err
+	if !r.sessionFactory.layoutReady() {
+		if err := initializeSandboxLayout(ctx, fsys, r.cfg.BaseEnv, r.cfg.FileSystem.WorkingDir, r.cfg.Registry.Names()); err != nil {
+			return nil, err
+		}
 	}
 
 	return &Session{

--- a/runtime/session_factory.go
+++ b/runtime/session_factory.go
@@ -1,0 +1,72 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	gbfs "github.com/ewhauser/gbash/fs"
+)
+
+type sessionFactory interface {
+	New(ctx context.Context) (gbfs.FileSystem, error)
+	layoutReady() bool
+}
+
+type plainSessionFactory struct {
+	base gbfs.Factory
+}
+
+func (f plainSessionFactory) New(ctx context.Context) (gbfs.FileSystem, error) {
+	return f.base.New(ctx)
+}
+
+func (plainSessionFactory) layoutReady() bool {
+	return false
+}
+
+type preparedMemorySessionFactory struct {
+	base     gbfs.Factory
+	env      map[string]string
+	workDir  string
+	commands []string
+
+	mu    sync.Mutex
+	ready *gbfs.MemoryFS
+}
+
+func (f *preparedMemorySessionFactory) New(ctx context.Context) (gbfs.FileSystem, error) {
+	f.mu.Lock()
+	ready := f.ready
+	f.mu.Unlock()
+
+	if ready == nil {
+		baseFactory := f.base
+		if baseFactory == nil {
+			baseFactory = gbfs.Memory()
+		}
+		created, err := baseFactory.New(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if err := initializeSandboxLayout(ctx, created, f.env, f.workDir, f.commands); err != nil {
+			return nil, err
+		}
+		base, ok := created.(*gbfs.MemoryFS)
+		if !ok {
+			return nil, fmt.Errorf("default session base is %T, want *fs.MemoryFS", created)
+		}
+		f.mu.Lock()
+		if f.ready == nil {
+			f.ready = base
+		}
+		ready = f.ready
+		f.mu.Unlock()
+	}
+
+	return ready.Clone(), nil
+}
+
+func (*preparedMemorySessionFactory) layoutReady() bool {
+	return true
+}


### PR DESCRIPTION
## Summary
- cache the prepared default in-memory sandbox once and clone it per session instead of rebuilding layout and stubs on every NewSession
- add fs.Reusable(...) for safe reusable immutable lower layers and use it for the seeded runtime benchmark path
- add isolation and regression coverage for MemoryFS.Clone() and the lower-layer command-stub clone trap

## Validation
- go test ./fs ./runtime ./commands ./contrib/jq
- go test -run ^$ -bench ^Benchmark(NewSession|WorkflowCodebaseExploration|WorkflowRefactorPreparation|CommandTarGzipRoundTrip)$ -benchmem -count=1 -benchtime=300ms ./runtime
- go test -run ^$ -bench . -benchmem -count=1 -benchtime=300ms ./runtime ./contrib/jq

## Benchmark deltas
- BenchmarkNewSession: 334202 ns/op, 208641 B/op, 6264 allocs/op -> 24234 ns/op, 65128 B/op, 541 allocs/op
- BenchmarkWorkflowCodebaseExploration: 11302501 ns/op, 22458620 B/op, 112997 allocs/op -> 6829420 ns/op, 3726551 B/op, 84002 allocs/op
- BenchmarkWorkflowRefactorPreparation: 20096528 ns/op, 45291971 B/op, 206151 allocs/op -> 15586830 ns/op, 22424668 B/op, 169354 allocs/op
- BenchmarkCommandTarGzipRoundTrip: 21931744 ns/op, 45594704 B/op, 150542 allocs/op -> 18951146 ns/op, 27073339 B/op, 130311 allocs/op