### PR TITLE
Skip very expensive GNU tests by default

### DIFF
--- a/cmd/gbash-gnu/gnu_tests.go
+++ b/cmd/gbash-gnu/gnu_tests.go
@@ -388,7 +388,6 @@ func runMakeCheck(ctx context.Context, makeBin, workDir, configShell string, tes
 		"SUBDIRS=.",
 		"VERBOSE=no",
 		"RUN_EXPENSIVE_TESTS=yes",
-		"RUN_VERY_EXPENSIVE_TESTS=yes",
 		"srcdir=" + workDir,
 		"TESTS=" + strings.Join(tests, " "),
 	}

--- a/cmd/gbash-gnu/main_test.go
+++ b/cmd/gbash-gnu/main_test.go
@@ -429,6 +429,39 @@ func TestRunMakeCheckExportsConfigShell(t *testing.T) {
 	}
 }
 
+func TestRunMakeCheckDoesNotForceVeryExpensiveTests(t *testing.T) {
+	workDir := t.TempDir()
+	makeBin := filepath.Join(workDir, "fake-make.sh")
+	argsPath := filepath.Join(workDir, "make-args.txt")
+	logPath := filepath.Join(workDir, "make.log")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > " + shellSingleQuoteForScript(argsPath) + "\n" +
+		"printf 'PASS: tests/factor/t00.sh\\n'\n"
+	if err := os.WriteFile(makeBin, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake make) error = %v", err)
+	}
+
+	result, err := runMakeCheck(context.Background(), makeBin, workDir, "/bin/sh", []string{"tests/factor/t00.sh"}, logPath)
+	if err != nil {
+		t.Fatalf("runMakeCheck() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("runMakeCheck() exit = %d, want 0", result.ExitCode)
+	}
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(make args) error = %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "RUN_EXPENSIVE_TESTS=yes\n") {
+		t.Fatalf("runMakeCheck args = %q, want RUN_EXPENSIVE_TESTS=yes", got)
+	}
+	if strings.Contains(got, "RUN_VERY_EXPENSIVE_TESTS=yes\n") {
+		t.Fatalf("runMakeCheck args = %q, want RUN_VERY_EXPENSIVE_TESTS to be absent", got)
+	}
+}
+
 func TestPrepareProgramDirAddsCompatShellHelpers(t *testing.T) {
 	workDir := t.TempDir()
 	srcDir := filepath.Join(workDir, "src")


### PR DESCRIPTION
## Summary
- stop forcing `RUN_VERY_EXPENSIVE_TESTS=yes` for every GNU Compat run
- keep the normal expensive suite enabled while letting generated factor stress tests skip by default
- add a harness regression to ensure very-expensive tests stay disabled unless explicitly requested

## Verification
- `go test ./cmd/gbash-gnu -run 'TestRunMakeCheck(ExportsConfigShell|DoesNotForceVeryExpensiveTests)' -count=1`
- `GNU_TESTS='tests/factor/t00.sh' GNU_RESULTS_DIR='.cache/gnu/results/debug-factor-t00-skip' make gnu-test`
