### PR TITLE
Improve warm exec performance and add CLI startup benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: lint test build fuzz fuzz-run fuzz-shard fuzz-smoke fuzz-full bench-smoke bench-full gnu-test gnu-test-setup gnu-build-cache-fetch gnu-build-cache-publish compat-docker-build compat-docker-run release-check release-snapshot
 
 GO_PACKAGES := ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...
-BENCH_PACKAGES := ./runtime ./contrib/jq
+BENCH_PACKAGES := ./runtime ./cmd/gbash ./contrib/jq
 
 FUZZTIME ?= 10s
 FUZZ_SMOKE_TIME ?= 3s
@@ -10,7 +10,7 @@ BENCH_SMOKE_COUNT ?= 8
 BENCH_SMOKE_TIME ?= 100ms
 BENCH_FULL_COUNT ?= 10
 BENCH_FULL_TIME ?= 200ms
-BENCH_SMOKE_REGEX ?= Benchmark(NewSession|RuntimeRunSimpleScript|SessionExecWarmSimpleScript|WorkflowCodebaseExploration|CommandRGRecursive|CommandJQTransform)$$
+BENCH_SMOKE_REGEX ?= Benchmark(NewSession|RuntimeRunSimpleScript|SessionExecWarmSimpleScript|WorkflowCodebaseExploration|CommandRGRecursive|CLIBinary|CommandJQTransform)$$
 GNU_CACHE_DIR ?= .cache/gnu
 GNU_GBASH_BIN ?= $(GNU_CACHE_DIR)/bin/gbash
 GNU_RESULTS_DIR ?=

--- a/cmd/gbash/benchmarks_test.go
+++ b/cmd/gbash/benchmarks_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func BenchmarkCLIBinary(b *testing.B) {
+	binaryPath := buildCLIBenchmarkBinary(b)
+
+	cases := []struct {
+		name       string
+		args       []string
+		stdin      string
+		wantStdout string
+	}{
+		{
+			name:       "EmptyScript",
+			stdin:      "",
+			wantStdout: "",
+		},
+		{
+			name:       "SimpleScript",
+			stdin:      "echo hi\n",
+			wantStdout: "hi\n",
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			stdout, stderr, err := runCLIBenchmarkProcess(binaryPath, tc.args, tc.stdin, nil, nil)
+			if err != nil {
+				b.Fatalf("verify run error = %v; stderr=%q", err, stderr)
+			}
+			if got := stdout; got != tc.wantStdout {
+				b.Fatalf("verify stdout = %q, want %q", got, tc.wantStdout)
+			}
+			if got := stderr; got != "" {
+				b.Fatalf("verify stderr = %q, want empty stderr", got)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, _, err := runCLIBenchmarkProcess(binaryPath, tc.args, tc.stdin, io.Discard, io.Discard); err != nil {
+					b.Fatalf("run error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+func buildCLIBenchmarkBinary(tb testing.TB) string {
+	tb.Helper()
+
+	tmp := tb.TempDir()
+	name := "gbash"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	binaryPath := filepath.Join(tmp, name)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cmd := osexec.CommandContext(ctx, "go", "build", "-o", binaryPath, ".")
+	cmd.Dir = benchmarkCLIWorkDir(tb)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		tb.Fatalf("go build timed out: %v", ctx.Err())
+	}
+	if err != nil {
+		tb.Fatalf("go build error = %v\n%s", err, output)
+	}
+	return binaryPath
+}
+
+func benchmarkCLIWorkDir(tb testing.TB) string {
+	tb.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		tb.Fatalf("Getwd() error = %v", err)
+	}
+	return dir
+}
+
+func runCLIBenchmarkProcess(binaryPath string, args []string, stdinText string, stdoutSink, stderrSink io.Writer) (stdout, stderr string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := osexec.CommandContext(ctx, binaryPath, args...)
+	cmd.Stdin = bytes.NewBufferString(stdinText)
+
+	var stdoutBuf bytes.Buffer
+	var stderrBuf bytes.Buffer
+
+	if stdoutSink == nil {
+		cmd.Stdout = &stdoutBuf
+	} else {
+		cmd.Stdout = stdoutSink
+	}
+	if stderrSink == nil {
+		cmd.Stderr = &stderrBuf
+	} else {
+		cmd.Stderr = stderrSink
+	}
+
+	err = cmd.Run()
+	if ctx.Err() != nil {
+		return stdoutBuf.String(), stderrBuf.String(), ctx.Err()
+	}
+	return stdoutBuf.String(), stderrBuf.String(), err
+}

--- a/runtime/layout.go
+++ b/runtime/layout.go
@@ -58,21 +58,29 @@ func initializeSandboxLayout(ctx context.Context, fsys gbfs.FileSystem, env map[
 }
 
 func layoutDirectories(env map[string]string, workDir string) []string {
+	return layoutDirectoriesForValues(env["HOME"], env["PATH"], workDir)
+}
+
+func layoutDirectoriesForValues(home, pathValue, workDir string) []string {
 	dirs := []string{
 		defaultTempDir,
 		workDir,
 	}
 
-	if home := strings.TrimSpace(env["HOME"]); home != "" {
+	if home := strings.TrimSpace(home); home != "" {
 		dirs = append(dirs, gbfs.Clean(home))
 	}
 
-	dirs = append(dirs, commandDirectories(env)...)
+	dirs = append(dirs, commandDirectoriesForPath(pathValue)...)
 	return uniqueSortedPaths(dirs)
 }
 
 func commandDirectories(env map[string]string) []string {
-	pathValue := strings.TrimSpace(env["PATH"])
+	return commandDirectoriesForPath(env["PATH"])
+}
+
+func commandDirectoriesForPath(pathValue string) []string {
+	pathValue = strings.TrimSpace(pathValue)
 	if pathValue == "" {
 		return nil
 	}

--- a/runtime/layout_state.go
+++ b/runtime/layout_state.go
@@ -1,0 +1,210 @@
+package runtime
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+
+	gbfs "github.com/ewhauser/gbash/fs"
+	"github.com/ewhauser/gbash/trace"
+)
+
+type sandboxLayoutState struct {
+	mu          sync.Mutex
+	dirty       bool
+	initialized bool
+	home        string
+	path        string
+	workDir     string
+	commands    []string
+	dirs        map[string]struct{}
+	stubs       map[string]struct{}
+}
+
+func newSandboxLayoutState(env map[string]string, workDir string) *sandboxLayoutState {
+	return &sandboxLayoutState{
+		initialized: true,
+		home:        strings.TrimSpace(env["HOME"]),
+		path:        strings.TrimSpace(env["PATH"]),
+		workDir:     gbfs.Clean(workDir),
+	}
+}
+
+func (s *sandboxLayoutState) ensure(ctx context.Context, fsys gbfs.FileSystem, env map[string]string, workDir string, commands []string) error {
+	if s == nil {
+		return initializeSandboxLayout(ctx, fsys, env, workDir, commands)
+	}
+
+	home := strings.TrimSpace(env["HOME"])
+	pathValue := strings.TrimSpace(env["PATH"])
+	workDir = gbfs.Clean(workDir)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.initialized && !s.dirty &&
+		s.home == home &&
+		s.path == pathValue &&
+		s.workDir == workDir {
+		if len(s.commands) == 0 {
+			s.commands = append(s.commands[:0], commands...)
+			return nil
+		}
+		if slices.Equal(s.commands, commands) {
+			return nil
+		}
+	}
+	if s.dirty {
+		s.dirty = false
+		s.dirs = nil
+		s.stubs = nil
+	}
+
+	layoutDirs := layoutDirectoriesForValues(home, pathValue, workDir)
+	commandDirs := commandDirectoriesForPath(pathValue)
+	commandNames := publicCommandNames(commands)
+	if s.dirs == nil {
+		s.dirs = make(map[string]struct{}, len(layoutDirs))
+	}
+	if s.stubs == nil {
+		s.stubs = make(map[string]struct{}, len(commandDirs)*len(commandNames))
+	}
+
+	for _, dir := range layoutDirs {
+		if _, ok := s.dirs[dir]; ok {
+			continue
+		}
+		if err := fsys.MkdirAll(ctx, dir, 0o755); err != nil {
+			return err
+		}
+		s.dirs[dir] = struct{}{}
+	}
+
+	for _, dir := range commandDirs {
+		for _, name := range commandNames {
+			fullPath := gbfs.Resolve(dir, name)
+			if _, ok := s.stubs[fullPath]; ok {
+				continue
+			}
+			if err := ensureCommandStub(ctx, fsys, dir, name); err != nil {
+				return err
+			}
+			s.stubs[fullPath] = struct{}{}
+		}
+	}
+
+	s.initialized = true
+	s.home = home
+	s.path = pathValue
+	s.workDir = workDir
+	s.commands = append(s.commands[:0], commands...)
+
+	return nil
+}
+
+func (s *sandboxLayoutState) seedTrackedPathsLocked() {
+	layoutDirs := layoutDirectoriesForValues(s.home, s.path, s.workDir)
+	commandDirs := commandDirectoriesForPath(s.path)
+	commandNames := publicCommandNames(s.commands)
+	s.dirs = make(map[string]struct{}, len(layoutDirs))
+	for _, dir := range layoutDirs {
+		s.dirs[dir] = struct{}{}
+	}
+	s.stubs = make(map[string]struct{}, len(commandDirs)*len(commandNames))
+	for _, dir := range commandDirs {
+		for _, name := range commandNames {
+			s.stubs[gbfs.Resolve(dir, name)] = struct{}{}
+		}
+	}
+}
+
+func (s *sandboxLayoutState) invalidateForEvents(events []trace.Event) {
+	if s == nil || len(events) == 0 {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.dirty || !s.initialized {
+		return
+	}
+	if len(s.commands) == 0 {
+		for i := range events {
+			event := events[i]
+			if event.Kind != trace.EventFileMutation || event.File == nil {
+				continue
+			}
+			if s.mutationAffectsUnseededLayout(event.File.Path) ||
+				s.mutationAffectsUnseededLayout(event.File.FromPath) ||
+				s.mutationAffectsUnseededLayout(event.File.ToPath) {
+				s.dirty = true
+				return
+			}
+		}
+		return
+	}
+	if s.dirs == nil || s.stubs == nil {
+		s.seedTrackedPathsLocked()
+	}
+	for i := range events {
+		event := events[i]
+		if event.Kind != trace.EventFileMutation || event.File == nil {
+			continue
+		}
+		if s.mutationAffectsLayout(event.File.Path) ||
+			s.mutationAffectsLayout(event.File.FromPath) ||
+			s.mutationAffectsLayout(event.File.ToPath) {
+			s.dirty = true
+			return
+		}
+	}
+}
+
+func (s *sandboxLayoutState) mutationAffectsUnseededLayout(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+
+	cleanPath := gbfs.Clean(path)
+	for _, dir := range layoutDirectoriesForValues(s.home, s.path, s.workDir) {
+		if layoutMutationTouchesPath(cleanPath, dir) {
+			return true
+		}
+	}
+	for _, dir := range commandDirectoriesForPath(s.path) {
+		if layoutMutationTouchesPath(cleanPath, dir) || strings.HasPrefix(cleanPath, dir+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *sandboxLayoutState) mutationAffectsLayout(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+
+	cleanPath := gbfs.Clean(path)
+	for dir := range s.dirs {
+		if layoutMutationTouchesPath(cleanPath, dir) {
+			return true
+		}
+	}
+	for stub := range s.stubs {
+		if layoutMutationTouchesPath(cleanPath, stub) {
+			return true
+		}
+	}
+	return false
+}
+
+func layoutMutationTouchesPath(mutationPath, trackedPath string) bool {
+	if mutationPath == trackedPath {
+		return true
+	}
+	return strings.HasPrefix(trackedPath, mutationPath+"/")
+}

--- a/runtime/layout_state_test.go
+++ b/runtime/layout_state_test.go
@@ -1,0 +1,69 @@
+package runtime
+
+import (
+	"context"
+	stdfs "io/fs"
+	"sync/atomic"
+	"testing"
+
+	gbfs "github.com/ewhauser/gbash/fs"
+)
+
+func TestSessionExecSkipsLayoutReinitializationWhenUnchanged(t *testing.T) {
+	ctx := context.Background()
+	var tracked *statCountingFS
+
+	rt := newRuntime(t, &Config{
+		FileSystem: CustomFileSystem(gbfs.FactoryFunc(func(context.Context) (gbfs.FileSystem, error) {
+			tracked = &statCountingFS{FileSystem: gbfs.NewMemory()}
+			return tracked, nil
+		}), defaultHomeDir),
+	})
+
+	session, err := rt.NewSession(ctx)
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+
+	tracked.stats.Store(0)
+	result, err := session.Exec(ctx, &ExecutionRequest{Script: ""})
+	if err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got := tracked.stats.Load(); got != 0 {
+		t.Fatalf("Stat() calls = %d, want 0", got)
+	}
+}
+
+func TestSessionExecRebuildsLayoutAfterCommandStubMutation(t *testing.T) {
+	session := newSession(t, nil)
+
+	result := mustExecSession(t, session, "rm /bin/echo\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("first ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+
+	result = mustExecSession(t, session, "echo restored\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("second ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "restored\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+	if _, err := session.FileSystem().Stat(context.Background(), "/bin/echo"); err != nil {
+		t.Fatalf("Stat(/bin/echo) error = %v", err)
+	}
+}
+
+type statCountingFS struct {
+	gbfs.FileSystem
+	stats atomic.Int32
+}
+
+func (fs *statCountingFS) Stat(ctx context.Context, name string) (stdfs.FileInfo, error) {
+	fs.stats.Add(1)
+	return fs.FileSystem.Stat(ctx, name)
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -35,6 +35,7 @@ type Session struct {
 	id     string
 	fs     gbfs.FileSystem
 	bootAt time.Time
+	layout *sandboxLayoutState
 	mu     sync.Mutex
 }
 
@@ -121,6 +122,7 @@ func (r *Runtime) NewSession(ctx context.Context) (*Session, error) {
 		id:     nextTraceID("sess"),
 		fs:     fsys,
 		bootAt: time.Now().UTC(),
+		layout: newSandboxLayoutState(r.cfg.BaseEnv, r.cfg.FileSystem.WorkingDir),
 	}, nil
 }
 

--- a/runtime/session.go
+++ b/runtime/session.go
@@ -39,7 +39,7 @@ func (s *Session) exec(ctx context.Context, req *ExecutionRequest) (*ExecutionRe
 		execEnv["GBASH_SESSION_BOOT_AT"] = s.bootAt.Format(time.RFC3339)
 	}
 
-	if err := initializeSandboxLayout(ctx, s.fs, execEnv, workDir, s.cfg.Registry.Names()); err != nil {
+	if err := s.layout.ensure(ctx, s.fs, execEnv, workDir, s.cfg.Registry.Names()); err != nil {
 		return nil, err
 	}
 	if err := s.fs.Chdir(workDir); err != nil {
@@ -84,6 +84,9 @@ func (s *Session) exec(ctx context.Context, req *ExecutionRequest) (*ExecutionRe
 	})
 	finished := time.Now().UTC()
 
+	events := recorder.Snapshot()
+	s.layout.invalidateForEvents(events)
+
 	result := &ExecutionResult{
 		ExitCode:        shell.ExitCode(runErr),
 		Stdout:          stdout.String(),
@@ -91,7 +94,7 @@ func (s *Session) exec(ctx context.Context, req *ExecutionRequest) (*ExecutionRe
 		StartedAt:       started,
 		FinishedAt:      finished,
 		Duration:        finished.Sub(started),
-		Events:          recorder.Snapshot(),
+		Events:          events,
 		StdoutTruncated: stdout.Truncated(),
 		StderrTruncated: stderr.Truncated(),
 	}


### PR DESCRIPTION
## Summary
- add a real `cmd/gbash` cold-start benchmark that measures launching a fresh `gbash` binary
- cache prepared sandbox layout state across `Session.Exec` calls and invalidate it when layout-affecting file mutations occur
- include the new CLI benchmark in the bench make targets

## Benchmark notes
Machine: Apple M3 Max, darwin/arm64

Runtime benchmark deltas from local profiling:
- `BenchmarkSessionExecWarmSimpleScript`: about `154µs / 103.7KB / 2494 allocs` -> about `63µs / 58.8KB / 579 allocs`
- `BenchmarkRuntimeRunSimpleScript`: about `179-187µs / ~3032 allocs` -> about `110-115µs / ~1382 allocs`
- `BenchmarkNewSession`: roughly flat at `22-24µs`

New cold-start CLI benchmark:
- `BenchmarkCLIBinary/EmptyScript`: about `5.1-5.4ms/op`
- `BenchmarkCLIBinary/SimpleScript`: about `5.3ms/op`

## Validation
- `go test ./runtime ./cmd/gbash`
- `go test ./cmd/gbash -run=^$ -bench '^BenchmarkCLIBinary$' -benchmem -count=3 -benchtime=200ms`
