### PR TITLE
Harden compat harness session isolation

### DIFF
--- a/cmd/gbash-gnu/process_group_posix.go
+++ b/cmd/gbash-gnu/process_group_posix.go
@@ -12,7 +12,7 @@ func configureIsolatedProcessGroup(cmd *exec.Cmd) {
 	if cmd == nil {
 		return
 	}
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 }
 
 func terminateIsolatedProcessGroup(cmd *exec.Cmd) error {

--- a/cmd/gbash-gnu/process_group_posix_test.go
+++ b/cmd/gbash-gnu/process_group_posix_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 )
 
-func TestConfigureIsolatedProcessGroupSetsSetpgid(t *testing.T) {
+func TestConfigureIsolatedProcessGroupStartsNewSession(t *testing.T) {
 	cmd := exec.Command("sh", "-c", "true")
 
 	configureIsolatedProcessGroup(cmd)
 
-	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
-		t.Fatalf("configureIsolatedProcessGroup() did not enable Setpgid")
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setsid {
+		t.Fatalf("configureIsolatedProcessGroup() did not enable Setsid")
 	}
 }

--- a/scripts/gnu-build-cache.sh
+++ b/scripts/gnu-build-cache.sh
@@ -55,6 +55,17 @@ need_tool() {
   }
 }
 
+run_isolated_session() {
+  # Some GNU tests exercise signal handling and can terminate their caller's
+  # process group when the command under test fails. Keep the harness tree out
+  # of the workflow shell's session so CI can still capture the exit status.
+  if command -v setsid >/dev/null 2>&1; then
+    setsid "$@"
+    return
+  fi
+  "$@"
+}
+
 compute_sha256() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1" | awk '{print $1}'
@@ -199,7 +210,7 @@ run_harness() {
 
   (
     cd "$REPO_ROOT"
-    "${cmd[@]}"
+    run_isolated_session "${cmd[@]}"
   )
 }
 


### PR DESCRIPTION
## Summary
- start GNU `make check` in a new POSIX session instead of only a new process group
- run the outer `gbash-gnu` compat harness under `setsid` when available so GNU test signals cannot terminate the workflow shell
- update the POSIX isolation test to assert `Setsid`

## Context
- addresses the compat CI failure in [actions/runs/23073255377](https://github.com/ewhauser/gbash/actions/runs/23073255377), where the harness step exited 143 and left orphaned `bash` processes
- this should let the workflow capture failing harness exit codes and continue to artifact/report steps instead of having the runner shell die with the harness subtree

## Testing
- `go test ./cmd/gbash-gnu ./cmd/gbash ./internal/compatrun`
- `bash -n scripts/gnu-build-cache.sh`