### PR TITLE
Honor stdin cancellation in readAllStdin

### DIFF
--- a/commands/basenc.go
+++ b/commands/basenc.go
@@ -149,7 +149,7 @@ func (c *Basenc) optionsFromMatches(inv *Invocation, matches *ParsedCommand) (ba
 
 func readBasencInput(ctx context.Context, inv *Invocation, name string) ([]byte, error) {
 	if name == "" || name == "-" {
-		data, err := readAllStdin(inv)
+		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return nil, basencReadError(inv, err)
 		}

--- a/commands/checksum_sums.go
+++ b/commands/checksum_sums.go
@@ -378,7 +378,7 @@ func (c *checksumSum) runCheckMode(ctx context.Context, inv *Invocation, opts ch
 
 func (c *checksumSum) readDigestInput(ctx context.Context, inv *Invocation, name string) ([]byte, error) {
 	if name == "-" {
-		return readAllStdin(inv)
+		return readAllStdin(ctx, inv)
 	}
 	info, _, err := statPath(ctx, inv, name)
 	if err != nil {
@@ -393,7 +393,7 @@ func (c *checksumSum) readDigestInput(ctx context.Context, inv *Invocation, name
 
 func (c *checksumSum) readChecksumList(ctx context.Context, inv *Invocation, name string) (data []byte, displayName string, err error) {
 	if name == "-" {
-		data, err = readAllStdin(inv)
+		data, err = readAllStdin(ctx, inv)
 		return data, "standard input", err
 	}
 	info, _, err := statPath(ctx, inv, name)
@@ -546,7 +546,7 @@ func (c *checksumSum) processChecksumLine(ctx context.Context, inv *Invocation, 
 
 func (c *checksumSum) readVerifyTarget(ctx context.Context, inv *Invocation, name string) ([]byte, error) {
 	if name == "-" {
-		return readAllStdin(inv)
+		return readAllStdin(ctx, inv)
 	}
 	info, _, err := statPath(ctx, inv, name)
 	if err != nil {

--- a/commands/cksum.go
+++ b/commands/cksum.go
@@ -522,7 +522,7 @@ func (c *Cksum) runCheckMode(ctx context.Context, inv *Invocation, opts cksumOpt
 
 func (c *Cksum) readDigestInput(ctx context.Context, inv *Invocation, name string) ([]byte, error) {
 	if name == "-" {
-		return readAllStdin(inv)
+		return readAllStdin(ctx, inv)
 	}
 	info, _, err := statPath(ctx, inv, name)
 	if err != nil {
@@ -537,7 +537,7 @@ func (c *Cksum) readDigestInput(ctx context.Context, inv *Invocation, name strin
 
 func (c *Cksum) readChecksumList(ctx context.Context, inv *Invocation, name string) (data []byte, displayName string, err error) {
 	if name == "-" {
-		data, err = readAllStdin(inv)
+		data, err = readAllStdin(ctx, inv)
 		return data, "standard input", err
 	}
 	info, _, err := statPath(ctx, inv, name)
@@ -891,7 +891,7 @@ func ternary[T any](cond bool, yes, no T) T {
 
 func (c *Cksum) readVerifyTarget(ctx context.Context, inv *Invocation, name string) ([]byte, error) {
 	if name == "-" {
-		return readAllStdin(inv)
+		return readAllStdin(ctx, inv)
 	}
 	info, _, err := statPath(ctx, inv, name)
 	if err != nil {

--- a/commands/column.go
+++ b/commands/column.go
@@ -228,7 +228,7 @@ func parseColumnNumber(value string) (int, bool) {
 
 func readColumnContent(ctx context.Context, inv *Invocation, files []string) (string, error) {
 	if len(files) == 0 {
-		data, err := readAllStdin(inv)
+		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return "", err
 		}
@@ -246,7 +246,7 @@ func readColumnContent(ctx context.Context, inv *Invocation, files []string) (st
 		if name == "-" {
 			if !stdinLoaded {
 				var err error
-				stdinData, err = readAllStdin(inv)
+				stdinData, err = readAllStdin(ctx, inv)
 				if err != nil {
 					return "", err
 				}

--- a/commands/comm.go
+++ b/commands/comm.go
@@ -217,7 +217,7 @@ func setCommDelimiter(inv *Invocation, opts *commOptions, value string) error {
 
 func readCommInput(ctx context.Context, inv *Invocation, name string) (data []byte, label string, err error) {
 	if name == "-" {
-		data, err := readAllStdin(inv)
+		data, err := readAllStdin(ctx, inv)
 		return data, name, err
 	}
 	abs, err := allowPath(ctx, inv, "", name)

--- a/commands/command.go
+++ b/commands/command.go
@@ -24,7 +24,6 @@ type LookupCNAMEFunc func(context.Context, string) (string, error)
 type ProcessAliveFunc func(context.Context, int) (bool, error)
 
 type Invocation struct {
-	Context               context.Context
 	Args                  []string
 	Env                   map[string]string
 	Cwd                   string

--- a/commands/cut.go
+++ b/commands/cut.go
@@ -110,7 +110,7 @@ func (c *Cut) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCom
 				continue
 			}
 			stdinRead = true
-			data, err = readAllStdin(inv)
+			data, err = readAllStdin(ctx, inv)
 		default:
 			data, err = readAllFileForCut(ctx, inv, name)
 		}

--- a/commands/dircolors.go
+++ b/commands/dircolors.go
@@ -107,7 +107,7 @@ func (c *Dircolors) RunParsed(ctx context.Context, inv *Invocation, matches *Par
 		fp    = files[0]
 	)
 	if fp == "-" {
-		data, err := readAllStdin(inv)
+		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return &ExitError{Code: 1, Err: err}
 		}

--- a/commands/grep.go
+++ b/commands/grep.go
@@ -112,7 +112,7 @@ func (c *Grep) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCo
 
 	state := &grepRunState{}
 	if len(files) == 0 {
-		data, err := readAllStdin(inv)
+		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return err
 		}

--- a/commands/invocation_capabilities.go
+++ b/commands/invocation_capabilities.go
@@ -21,7 +21,6 @@ type FetchResponse = network.Response
 type FetchFunc func(context.Context, *FetchRequest) (*FetchResponse, error)
 
 type InvocationOptions struct {
-	Context               context.Context
 	Args                  []string
 	Env                   map[string]string
 	Cwd                   string
@@ -57,7 +56,6 @@ func NewInvocation(opts *InvocationOptions) *Invocation {
 	}
 
 	inv := &Invocation{
-		Context:               opts.Context,
 		Args:                  append([]string(nil), opts.Args...),
 		Env:                   cloneEnv(opts.Env),
 		Cwd:                   gbfs.Resolve("/", opts.Cwd),

--- a/commands/io_helpers.go
+++ b/commands/io_helpers.go
@@ -20,12 +20,12 @@ func readAllFile(ctx context.Context, inv *Invocation, name string) (data []byte
 	return data, abs, nil
 }
 
-func readAllStdin(inv *Invocation) ([]byte, error) {
+func readAllStdin(ctx context.Context, inv *Invocation) ([]byte, error) {
 	stdin := io.Reader(strings.NewReader(""))
 	if inv != nil && inv.Stdin != nil {
 		stdin = inv.Stdin
 	}
-	data, err := io.ReadAll(ReaderWithContext(inv.Context, stdin))
+	data, err := io.ReadAll(ReaderWithContext(ctx, stdin))
 	if err != nil {
 		return nil, &ExitError{Code: 1, Err: err}
 	}

--- a/commands/nl.go
+++ b/commands/nl.go
@@ -299,7 +299,7 @@ func normalizeNLSectionDelimiter(value string) []byte {
 func readNLInput(ctx context.Context, inv *Invocation, name string, stdinData *[]byte, stdinLoaded *bool) (data []byte, isDir bool, err error) {
 	if name == "-" {
 		if !*stdinLoaded {
-			data, err = readAllStdin(inv)
+			data, err = readAllStdin(ctx, inv)
 			if err != nil {
 				return nil, false, err
 			}

--- a/commands/paste.go
+++ b/commands/paste.go
@@ -329,7 +329,7 @@ func loadPasteInputs(ctx context.Context, inv *Invocation, names []string, lineE
 	for _, name := range names {
 		if name == "-" {
 			if !stdinLoaded {
-				data, err := readAllStdin(inv)
+				data, err := readAllStdin(ctx, inv)
 				if err != nil {
 					return nil, err
 				}

--- a/commands/sed.go
+++ b/commands/sed.go
@@ -100,7 +100,7 @@ func (c *Sed) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCom
 
 	exitCode := 0
 	if len(files) == 0 {
-		data, err := readAllStdin(inv)
+		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return err
 		}

--- a/commands/sort.go
+++ b/commands/sort.go
@@ -605,7 +605,7 @@ func collectSortInput(ctx context.Context, inv *Invocation, opts *sortOptions, f
 	checkFile = "-"
 
 	if len(inputFiles) == 0 && opts.files0From == "" {
-		data, err := readAllStdin(inv)
+		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return nil, "", 0, err
 		}
@@ -617,7 +617,7 @@ func collectSortInput(ctx context.Context, inv *Invocation, opts *sortOptions, f
 		switch file {
 		case "-":
 			if !stdinRead {
-				read, err := readAllStdin(inv)
+				read, err := readAllStdin(ctx, inv)
 				if err != nil {
 					return nil, "", 0, err
 				}
@@ -655,7 +655,7 @@ func sortInputFiles(ctx context.Context, inv *Invocation, opts *sortOptions, fil
 	var err error
 	source := opts.files0From
 	if source == "-" {
-		data, err = readAllStdin(inv)
+		data, err = readAllStdin(ctx, inv)
 		if err != nil {
 			return nil, err
 		}

--- a/commands/source_helpers.go
+++ b/commands/source_helpers.go
@@ -18,7 +18,7 @@ func readNamedInputs(ctx context.Context, inv *Invocation, names []string, defau
 		if !defaultStdin {
 			return nil, nil
 		}
-		data, err := readAllStdin(inv)
+		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return nil, err
 		}
@@ -38,7 +38,7 @@ func readNamedInputs(ctx context.Context, inv *Invocation, names []string, defau
 	for _, name := range names {
 		if name == "-" {
 			if !stdinLoaded {
-				data, err := readAllStdin(inv)
+				data, err := readAllStdin(ctx, inv)
 				if err != nil {
 					return nil, err
 				}
@@ -82,7 +82,7 @@ func readTwoInputs(ctx context.Context, inv *Invocation, leftName, rightName str
 			return data, err
 		}
 		if !stdinLoaded {
-			data, err := readAllStdin(inv)
+			data, err := readAllStdin(ctx, inv)
 			if err != nil {
 				return nil, err
 			}

--- a/commands/split.go
+++ b/commands/split.go
@@ -139,7 +139,7 @@ func (c *Split) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedC
 	var data []byte
 	var inputAbs string
 	if inputName == "-" {
-		data, err = readAllStdin(inv)
+		data, err = readAllStdin(ctx, inv)
 		if err != nil {
 			return err
 		}

--- a/commands/tail.go
+++ b/commands/tail.go
@@ -133,7 +133,7 @@ func (c *Tail) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCo
 		return err
 	}
 	if len(opts.files) == 0 {
-		data, err := readAllStdin(inv)
+		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return err
 		}
@@ -158,7 +158,7 @@ func (c *Tail) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCo
 				exitCode = 1
 				continue
 			}
-			data, err := readAllStdin(inv)
+			data, err := readAllStdin(ctx, inv)
 			if err != nil {
 				return err
 			}

--- a/commands/tr.go
+++ b/commands/tr.go
@@ -90,7 +90,7 @@ func (c *TR) Spec() CommandSpec {
 	}
 }
 
-func (c *TR) RunParsed(_ context.Context, inv *Invocation, matches *ParsedCommand) error {
+func (c *TR) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCommand) error {
 	opts, sets, err := parseTRMatches(inv, matches)
 	if err != nil {
 		return err
@@ -106,7 +106,7 @@ func (c *TR) RunParsed(_ context.Context, inv *Invocation, matches *ParsedComman
 		return exitf(inv, 1, "tr: %s", err.Error())
 	}
 
-	data, err := readAllStdin(inv)
+	data, err := readAllStdin(ctx, inv)
 	if err != nil {
 		return err
 	}

--- a/commands/wc.go
+++ b/commands/wc.go
@@ -100,7 +100,7 @@ func (c *WC) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 	}
 
 	if len(files) == 0 {
-		data, err := readAllStdin(inv)
+		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return err
 		}
@@ -117,7 +117,7 @@ func (c *WC) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 		)
 		if file == "-" {
 			hasStdinInput = true
-			data, err = readAllStdin(inv)
+			data, err = readAllStdin(ctx, inv)
 		} else {
 			data, _, err = readAllFile(ctx, inv, file)
 		}
@@ -203,7 +203,7 @@ func wcResolveInputs(ctx context.Context, inv *Invocation, opts *wcOptions, file
 	)
 	source := opts.files0From
 	if source == "-" {
-		data, readErr = readAllStdin(inv)
+		data, readErr = readAllStdin(ctx, inv)
 		if readErr != nil {
 			return nil, 0, readErr
 		}

--- a/commands/xargs.go
+++ b/commands/xargs.go
@@ -450,7 +450,7 @@ func xargsWarn(inv *Invocation, format string, args ...any) {
 
 func readXArgsInput(ctx context.Context, inv *Invocation, opts *xargsOptions) ([]byte, error) {
 	if opts.inputFile == "-" {
-		return readAllStdin(inv)
+		return readAllStdin(ctx, inv)
 	}
 	data, _, err := readAllFile(ctx, inv, opts.inputFile)
 	if err != nil {

--- a/shell/mvdan.go
+++ b/shell/mvdan.go
@@ -405,7 +405,6 @@ func (m *MVdan) execHandler(exec *Execution, budget *executionBudget) interp.Exe
 		invocationArgs := append([]string(nil), resolved.args...)
 		invocationArgs = append(invocationArgs, args[1:]...)
 		err = commands.RunCommand(ctx, resolved.command, commands.NewInvocation(&commands.InvocationOptions{
-			Context:      ctx,
 			Args:         invocationArgs,
 			Env:          currentEnv,
 			Cwd:          virtualWD,


### PR DESCRIPTION
## Summary
- thread command context through `commands.Invocation` instead of wrapping stdin at the shell boundary
- make `readAllStdin` stop promptly on timeout cancellation, including endless non-closable readers
- add regressions for both closable and non-closable endless stdin readers

## Why
Compat run [23076996279](https://github.com/ewhauser/gbash/actions/runs/23076996279/job/67039149138) still died on `main` with exit code `143` after `FAIL: tests/split/fail.sh`, which lines up with the next GNU test (`tests/split/filter.sh`) hanging inside:

    timeout 10 split --filter='head -c1 >$FILE.n' -n r/1 -

The previous fix only helped when stdin could be closed. This follow-up fixes the remaining case where `split` keeps reading from an endless reader that does not implement `io.Closer`.

## Verification
- `go test ./runtime ./cmd/gbash ./commands ./internal/compatrun`
- `make lint`
- `GNU_KEEP_WORKDIR=1 GNU_RESULTS_DIR=.cache/gnu/results/local-split-filter-context-3 GNU_TESTS='tests/split/filter.sh' make gnu-test`

That GNU repro still reports a normal macOS test `ERROR` for unrelated compatibility gaps, but it now exits cleanly in about 24s with `execution timed out after 10s` instead of wedging the harness.