### PR TITLE
Own execution types in root package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,157 +1,36 @@
-# commands/ Helper Reference
+# Repository Guidelines
 
-This document describes the shared helper files in `commands/` that are meant to be reused across command implementations. When implementing a new command, prefer these helpers over writing one-off equivalents.
+## Project Overview
+`gbash` is a Go workspace for a deterministic shell runtime. `contrib/` houses optional heavyweight modules (`sqlite3`, `jq`, `yq`, `extras`). Read `SPEC.md` before changing runtime boundaries or sandbox behavior.
 
-## Core Framework
+## Build & Test
+Use Go 1.26+. The full workspace build/test command spans multiple modules:
 
-### command.go
-Defines the `Command` interface, `Invocation` struct, and `ExitError` type that every command uses.
+```sh
+go build ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...
+go test ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...
+```
 
-- `Command` — interface: `Name() string`, `Run(ctx, *Invocation) error`
-- `CommandFunc` — function type for simple commands
-- `DefineCommand(name, fn)` — factory for wrapping a function as a `Command`
-- `Invocation` — runtime context: `Args`, `Env`, `Cwd`, `Stdin`/`Stdout`/`Stderr`, `FS`, `Fetch`, `Exec`, `Limits`
-- `ExitError{Code, Err}` — error with exit code; use `ExitCode(err)` to extract
-- `Exitf(inv, code, format, args...)` — write to stderr and return an `ExitError`
-- `openRead(ctx, inv, name)` — open a file for reading, returns `(gbfs.File, absPath, error)`
-- `readDir(ctx, inv, name)` — list directory entries
-- `statPath` / `lstatPath` — stat with path resolution
-- `statMaybe` / `lstatMaybe` — stat that returns `(info, abs, exists, error)` instead of erroring on not-found
+## Key Project Rules
+- Unknown commands must never fall through to the host OS.
+- Match the registry pattern in `commands/` when adding new built-in commands.
+- For runtime changes, test exit codes, stdout/stderr, and sandboxed filesystem effects.
+- If a change touches shell semantics or policy, add a regression test in `runtime/` or the relevant package.
 
-### command_spec.go
-Declarative metadata, parsing, and help/version rendering for command implementations. Prefer this for all new commands and for migrations away from ad hoc flag parsing.
+## SPEC Sync
+`SPEC.md` is the product and architecture contract. Update it in the same turn when:
+- adding/removing built-in commands
+- changing sandbox guarantees, policy defaults, or filesystem abstractions
+- changing `mvdan/sh` integration strategy
+- expanding scope, roadmap, or introducing new public packages/interfaces
 
-- `SpecProvider` — optional interface: `Spec() CommandSpec`
-- `ParsedRunner` — optional interface: `RunParsed(ctx, inv, matches) error`
-- `CommandSpec` — command metadata: `Name`, `About`, `Usage`, `AfterHelp`, `Options`, `Args`, `Parse`, `HelpRenderer`, `VersionRenderer`
-- `OptionSpec` — option definition: short/long names, help text, parsing aliases, visible help aliases, arity, repeatability, and optional-value behavior
-- `ArgSpec` — positional argument metadata: requiredness, repeatability, help text, and defaults
-- `ParseConfig` — parser behavior toggles: long-option inference, grouped shorts, attached values, `--` handling, negative-number positional mode, and auto help/version
-- `ParsedCommand` — parsed accessors for options and positionals: `Has`, `Count`, `Value`, `Values`, `Arg`, `Args`, `Positionals`, `OptionOrder`
-- `RunCommand(ctx, cmd, inv)` — executes a command through the spec layer when it implements `SpecProvider` + `ParsedRunner`, otherwise falls back to `Run`
-- `ParseCommandSpec(inv, spec)` — parse `inv.Args` against a `CommandSpec`
-- `RenderCommandHelp` / `RenderCommandVersion` — shared default renderers for utility help/version output; prefer the shared help path over command-specific full help text
+Read the relevant `SPEC.md` sections before editing code, and update them once the design is clear. When in doubt, prefer a small SPEC update over silent drift.
 
-Implementation rule:
-- New command implementations should prefer `Spec() CommandSpec` plus `RunParsed(...)` instead of walking `inv.Args` manually.
-- Command help should follow the shared extended help system modeled after uutils/clap: express help through `Usage`, `AfterHelp`, `Args`, `Options`, `Parse.AutoHelp`, `Parse.AutoVersion`, and `OptionSpec.HelpAliases` before considering `HelpRenderer`.
-- Do not hand-write full help blocks for commands when the shared renderer can express the output. Use `HelpRenderer` only for real compatibility cases that cannot be represented declaratively.
-- Keep parsing aliases and visible help aliases distinct: use `Aliases` for accepted option names and `HelpAliases` for extra rows that should appear in rendered help.
-- Command-specific version rendering should use `VersionRenderer` only for real uutils compatibility quirks.
-- Legacy manual parsers should be converted to this new method
+## Skills
+- **command** — Guide for adding or modifying built-in commands. Located at `.agents/skills/command/`.
+- **implement-coreutils-command** — Port a command from uutils/coreutils Rust repo into Go. Located at `.agents/skills/implement-coreutils-command/`.
+- **release** — Tag-driven GitHub release workflow with GoReleaser. Located at `.agents/skills/release/`.
+- **upstream-diff** — Diff against upstream [vercel-labs/just-bash](https://github.com/vercel-labs/just-bash) to find missing commands/flags. Located at `.claude/skills/upstream-diff/`.
 
-### invocation_capabilities.go
-Creates `Invocation` instances and provides `CommandFS`, the policy-enforced filesystem wrapper.
-
-- `NewInvocation(opts)` — builds an `Invocation` from `InvocationOptions`
-- `CommandFS` — wraps `gbfs.FileSystem` with transparent policy checks; exposes `Resolve`, `Open`, `OpenFile`, `Stat`, `Lstat`, `ReadDir`, `Readlink`, `Realpath`, `Symlink`, `Link`, `Chown`, `Chmod`, `Chtimes`, `MkdirAll`, `Remove`, `Rename`, `Getwd`, `Chdir`
-- `FetchFunc` — type alias for the network fetch callback
-
-### execution.go
-Data types for subprocess execution.
-
-- `ExecutionRequest` — input: `Script`, `Args`, `Env`, `WorkDir`, `Timeout`, `Stdin`/`Stdout`/`Stderr`
-- `ExecutionResult` — output: `ExitCode`, `Stdout`, `Stderr`, timing, trace events
-
-### registry.go
-Thread-safe command registry with lazy loading.
-
-- `Registry` — `Register(cmd)`, `RegisterLazy(name, loader)`, `Lookup(name)`, `Names()`
-- `DefaultRegistry()` — returns a registry pre-loaded with all built-in commands
-
-## I/O Helpers
-
-### io_helpers.go
-Basic read-all utilities. The most widely used helper (~24 commands).
-
-- `readAllFile(ctx, inv, name) (data, absPath, error)` — read an entire file
-- `readAllStdin(inv) (data, error)` — read all of stdin
-
-### source_helpers.go
-Multi-input handling for commands that accept multiple files and/or stdin.
-
-- `namedInput{Name, Abs, Data, FromStdin}` — a single input source with metadata
-- `readNamedInputs(ctx, inv, names, defaultStdin) ([]namedInput, error)` — reads multiple files; caches stdin so it's only read once; falls back to stdin when `names` is empty and `defaultStdin` is true
-- `readTwoInputs(ctx, inv, left, right) (leftData, rightData, error)` — specialized for two-input commands (e.g. `diff`, `comm`); errors if both are stdin
-
-### redirected_io.go
-File wrapper that tracks redirect metadata (path, flags, offset).
-
-- `RedirectMetadata` — interface: `RedirectPath()`, `RedirectFlags()`, `RedirectOffset()`
-- `WrapRedirectedFile(file, path, flag) io.ReadWriteCloser` — wraps a `gbfs.File` with offset tracking
-
-## Text Processing
-
-### text_helpers.go
-Line splitting with newline stripping.
-
-- `textLines(data) []string` — splits bytes into lines with trailing `\n` removed
-
-### head_tail.go
-Shared option parsing and line/byte extraction for `head` and `tail`.
-
-- `headTailOptions` — parsed config: `lines`, `bytes`, `hasBytes`, `fromLine`, `quiet`, `verbose`, `files`
-- `parseHeadTailArgs(inv, cmdName, allowFromLine)` — parses `-n`, `-c`, `-q`, `-v`, legacy `-NUM` syntax, and size suffixes (K, M, G, T, P, E, b)
-- `splitLines(data) [][]byte` — splits on `\n`, preserving line endings
-- `lastLines(data, count)` / `linesFrom(data, start)` / `lastBytes(data, count)` — extraction helpers
-
-## File Operations
-
-### file_helpers.go
-File copying, writing, and destination resolution.
-
-- `ensureParentDirExists(ctx, inv, targetAbs)` — validates parent directory exists
-- `copyFileContents(ctx, inv, srcAbs, dstAbs, perm)` — copy a single file
-- `copyTree(ctx, inv, srcAbs, dstAbs)` — recursive directory copy
-- `writeFileContents(ctx, inv, targetAbs, data, perm)` — write bytes to a file
-- `resolveDestination(ctx, inv, sourceAbs, destArg, multipleSources)` — resolves destination path, handling the "dest is a directory" logic that `cp`, `mv`, and `ln` share
-
-### path_helpers.go
-Directory traversal and file metadata formatting.
-
-- `fileTypeName(info) string` — returns `"symbolic link"`, `"directory"`, or `"regular file"`
-- `formatModeOctal(mode) string` — e.g. `"0755"`
-- `formatModeLong(mode) string` — e.g. `"drwxr-xr-x"`
-- `humanizeBytes(size) string` — e.g. `"4.0K"`, `"12M"`
-
-### permission_helpers.go
-Full ownership/permission engine for `chown` and `chgrp`.
-
-- `permissionIdentityDB` — cached user/group name-to-ID mappings from `/etc/passwd` and `/etc/group`
-- `loadPermissionIdentityDB(ctx, inv)` — builds the DB (env vars + passwd/group files)
-- `parsePermissionOwnerSpec(inv, db, spec)` — parses `"user:group"` specs into UID/GID
-- `walkPermissionTarget(ctx, inv, target, opts, visit)` — recursive walk with symlink traversal modes (`-H`, `-L`, `-P`), cycle detection, and `--preserve-root` support
-- `permissionSuccessMessage` / `permissionFailureMessage` — verbosity-controlled output formatting
-
-## Subprocess Execution
-
-### subexec_helpers.go
-Command resolution and execution through the host shell.
-
-- `executeCommand(ctx, inv, opts)` — resolves and executes an external command via the `Exec` callback
-- `executeCommandOptions` — config: `Argv`, `Env`, `WorkDir`, `Timeout`, `Stdin`/`Stdout`/`Stderr`
-- `resolveCommand(ctx, inv, env, dir, name)` — find first match in PATH
-- `resolveAllCommands(ctx, inv, env, dir, name)` — find all matches in PATH (for `which -a`)
-- `commandSearchDirs(env, dir) []string` — parse and deduplicate PATH entries
-- `shellJoinArgs(args) string` / `shellSingleQuote(value) string` — safe shell quoting
-- `writeExecutionOutputs(inv, result)` — write captured stdout/stderr to the invocation streams
-- `exitForExecutionResult(result) error` — convert result to `ExitError`
-- `sortedEnvPairs(env) []string` — format env map as sorted `KEY=VALUE` pairs
-
-## Encoding & Parsing
-
-### basenc_helpers.go
-Shared boilerplate for `base32` and `base64`.
-
-- `parseBaseEncWrap(name, value, inv) (int, error)` — parse `--wrap` size
-- `readSingleBaseEncInput(ctx, inv, name, args) ([]byte, error)` — read single input (file or stdin) with extra-operand check
-- `writeBaseEncOutput(w, encoded, wrap) error` — write encoded string with line wrapping
-
-### duration_helpers.go
-Duration parsing and escape-sequence decoding.
-
-- `parseFlexibleDuration(value) (time.Duration, error)` — parses `"30"`, `"5s"`, `"2m"`, `"1h"`, `"7d"`; defaults to seconds
-- `decodeDelimiterValue(value) (string, error)` — decodes `\n`, `\t`, `\0`, `\\` escape sequences
-
-### checksum_sums.go
-Shared implementation for `md5sum`, `sha1sum`, and `sha256sum`. Not a helper file per se, but a shared `checksumSum` struct that all three commands instantiate with different hash functions.
+## Commits & PRs
+Use short, imperative subjects scoped to one change (e.g., `runtime: normalize command-not-found errors`). PRs should explain user-visible behavior, note any SPEC updates, and include trace/CLI output when changing execution behavior.

--- a/api.go
+++ b/api.go
@@ -32,22 +32,6 @@ type Session struct {
 	inner *internalruntime.Session
 }
 
-// ExecutionRequest describes a single shell execution.
-//
-// Callers usually populate [ExecutionRequest.Script] and optionally provide
-// stdin, environment overrides, or a working directory override.
-type ExecutionRequest = internalruntime.ExecutionRequest
-
-// ExecutionResult captures the output, exit status, timing, and trace events
-// produced by a shell execution.
-type ExecutionResult = internalruntime.ExecutionResult
-
-// InteractiveRequest describes an interactive shell session.
-type InteractiveRequest = internalruntime.InteractiveRequest
-
-// InteractiveResult captures the final exit status from an interactive shell session.
-type InteractiveResult = internalruntime.InteractiveResult
-
 // Method identifies an HTTP method that is allowed by the sandbox network
 // policy.
 type Method = network.Method
@@ -335,7 +319,8 @@ func (r *Runtime) Run(ctx context.Context, req *ExecutionRequest) (*ExecutionRes
 	if r == nil || r.inner == nil {
 		return nil, fmt.Errorf("gbash: runtime is nil")
 	}
-	return r.inner.Run(ctx, req)
+	result, err := r.inner.Run(ctx, req.runtimeRequest())
+	return executionResultFromRuntime(result), err
 }
 
 // Exec runs a script inside the existing session.
@@ -347,7 +332,8 @@ func (s *Session) Exec(ctx context.Context, req *ExecutionRequest) (*ExecutionRe
 	if s == nil || s.inner == nil {
 		return nil, fmt.Errorf("gbash: session is nil")
 	}
-	return s.inner.Exec(ctx, req)
+	result, err := s.inner.Exec(ctx, req.runtimeRequest())
+	return executionResultFromRuntime(result), err
 }
 
 // Interact runs an interactive shell session inside the existing session.
@@ -355,7 +341,8 @@ func (s *Session) Interact(ctx context.Context, req *InteractiveRequest) (*Inter
 	if s == nil || s.inner == nil {
 		return nil, fmt.Errorf("gbash: session is nil")
 	}
-	return s.inner.Interact(ctx, req)
+	result, err := s.inner.Interact(ctx, req.runtimeRequest())
+	return interactiveResultFromRuntime(result), err
 }
 
 // FileSystem returns the live sandbox filesystem for the session.

--- a/cmd/gbash/cli.go
+++ b/cmd/gbash/cli.go
@@ -160,7 +160,21 @@ func runBashInvocation(ctx context.Context, rt *gbash.Runtime, parsed *commands.
 		return 1, fmt.Errorf("read script: %w", readErr)
 	}
 
-	result, err := rt.Run(ctx, parsed.BuildExecutionRequest(nil, "", execStdin, script))
+	req := &gbash.ExecutionRequest{
+		Name:            parsed.ExecutionName,
+		Interpreter:     parsed.Name,
+		PassthroughArgs: append([]string(nil), parsed.RawArgs...),
+		Script:          script,
+		Args:            append([]string(nil), parsed.Args...),
+		StartupOptions:  append([]string(nil), parsed.StartupOptions...),
+		Interactive:     parsed.Interactive,
+		Stdin:           execStdin,
+	}
+	if len(req.PassthroughArgs) == 0 {
+		req.PassthroughArgs = []string{"-s"}
+	}
+
+	result, err := rt.Run(ctx, req)
 	if result != nil {
 		_, _ = io.WriteString(stdout, result.Stdout)
 		_, _ = io.WriteString(stderr, result.Stderr)

--- a/commands/AGENTS.md
+++ b/commands/AGENTS.md
@@ -1,0 +1,157 @@
+# commands/ Helper Reference
+
+This document describes the shared helper files in `commands/` that are meant to be reused across command implementations. When implementing a new command, prefer these helpers over writing one-off equivalents.
+
+## Core Framework
+
+### command.go
+Defines the `Command` interface, `Invocation` struct, and `ExitError` type that every command uses.
+
+- `Command` — interface: `Name() string`, `Run(ctx, *Invocation) error`
+- `CommandFunc` — function type for simple commands
+- `DefineCommand(name, fn)` — factory for wrapping a function as a `Command`
+- `Invocation` — runtime context: `Args`, `Env`, `Cwd`, `Stdin`/`Stdout`/`Stderr`, `FS`, `Fetch`, `Exec`, `Limits`
+- `ExitError{Code, Err}` — error with exit code; use `ExitCode(err)` to extract
+- `Exitf(inv, code, format, args...)` — write to stderr and return an `ExitError`
+- `openRead(ctx, inv, name)` — open a file for reading, returns `(gbfs.File, absPath, error)`
+- `readDir(ctx, inv, name)` — list directory entries
+- `statPath` / `lstatPath` — stat with path resolution
+- `statMaybe` / `lstatMaybe` — stat that returns `(info, abs, exists, error)` instead of erroring on not-found
+
+### command_spec.go
+Declarative metadata, parsing, and help/version rendering for command implementations. Prefer this for all new commands and for migrations away from ad hoc flag parsing.
+
+- `SpecProvider` — optional interface: `Spec() CommandSpec`
+- `ParsedRunner` — optional interface: `RunParsed(ctx, inv, matches) error`
+- `CommandSpec` — command metadata: `Name`, `About`, `Usage`, `AfterHelp`, `Options`, `Args`, `Parse`, `HelpRenderer`, `VersionRenderer`
+- `OptionSpec` — option definition: short/long names, help text, parsing aliases, visible help aliases, arity, repeatability, and optional-value behavior
+- `ArgSpec` — positional argument metadata: requiredness, repeatability, help text, and defaults
+- `ParseConfig` — parser behavior toggles: long-option inference, grouped shorts, attached values, `--` handling, negative-number positional mode, and auto help/version
+- `ParsedCommand` — parsed accessors for options and positionals: `Has`, `Count`, `Value`, `Values`, `Arg`, `Args`, `Positionals`, `OptionOrder`
+- `RunCommand(ctx, cmd, inv)` — executes a command through the spec layer when it implements `SpecProvider` + `ParsedRunner`, otherwise falls back to `Run`
+- `ParseCommandSpec(inv, spec)` — parse `inv.Args` against a `CommandSpec`
+- `RenderCommandHelp` / `RenderCommandVersion` — shared default renderers for utility help/version output; prefer the shared help path over command-specific full help text
+
+Implementation rule:
+- New command implementations should prefer `Spec() CommandSpec` plus `RunParsed(...)` instead of walking `inv.Args` manually.
+- Command help should follow the shared extended help system modeled after uutils/clap: express help through `Usage`, `AfterHelp`, `Args`, `Options`, `Parse.AutoHelp`, `Parse.AutoVersion`, and `OptionSpec.HelpAliases` before considering `HelpRenderer`.
+- Do not hand-write full help blocks for commands when the shared renderer can express the output. Use `HelpRenderer` only for real compatibility cases that cannot be represented declaratively.
+- Keep parsing aliases and visible help aliases distinct: use `Aliases` for accepted option names and `HelpAliases` for extra rows that should appear in rendered help.
+- Command-specific version rendering should use `VersionRenderer` only for real uutils compatibility quirks.
+- Legacy manual parsers should be converted to this new method
+
+### invocation_capabilities.go
+Creates `Invocation` instances and provides `CommandFS`, the policy-enforced filesystem wrapper.
+
+- `NewInvocation(opts)` — builds an `Invocation` from `InvocationOptions`
+- `CommandFS` — wraps `gbfs.FileSystem` with transparent policy checks; exposes `Resolve`, `Open`, `OpenFile`, `Stat`, `Lstat`, `ReadDir`, `Readlink`, `Realpath`, `Symlink`, `Link`, `Chown`, `Chmod`, `Chtimes`, `MkdirAll`, `Remove`, `Rename`, `Getwd`, `Chdir`
+- `FetchFunc` — type alias for the network fetch callback
+
+### execution.go
+Data types for subprocess execution.
+
+- `ExecutionRequest` — input: `Script`, `Args`, `Env`, `WorkDir`, `Timeout`, `Stdin`/`Stdout`/`Stderr`
+- `ExecutionResult` — output: `ExitCode`, `Stdout`, `Stderr`, timing, trace events
+
+### registry.go
+Thread-safe command registry with lazy loading.
+
+- `Registry` — `Register(cmd)`, `RegisterLazy(name, loader)`, `Lookup(name)`, `Names()`
+- `DefaultRegistry()` — returns a registry pre-loaded with all built-in commands
+
+## I/O Helpers
+
+### io_helpers.go
+Basic read-all utilities. The most widely used helper (~24 commands).
+
+- `readAllFile(ctx, inv, name) (data, absPath, error)` — read an entire file
+- `readAllStdin(inv) (data, error)` — read all of stdin
+
+### source_helpers.go
+Multi-input handling for commands that accept multiple files and/or stdin.
+
+- `namedInput{Name, Abs, Data, FromStdin}` — a single input source with metadata
+- `readNamedInputs(ctx, inv, names, defaultStdin) ([]namedInput, error)` — reads multiple files; caches stdin so it's only read once; falls back to stdin when `names` is empty and `defaultStdin` is true
+- `readTwoInputs(ctx, inv, left, right) (leftData, rightData, error)` — specialized for two-input commands (e.g. `diff`, `comm`); errors if both are stdin
+
+### redirected_io.go
+File wrapper that tracks redirect metadata (path, flags, offset).
+
+- `RedirectMetadata` — interface: `RedirectPath()`, `RedirectFlags()`, `RedirectOffset()`
+- `WrapRedirectedFile(file, path, flag) io.ReadWriteCloser` — wraps a `gbfs.File` with offset tracking
+
+## Text Processing
+
+### text_helpers.go
+Line splitting with newline stripping.
+
+- `textLines(data) []string` — splits bytes into lines with trailing `\n` removed
+
+### head_tail.go
+Shared option parsing and line/byte extraction for `head` and `tail`.
+
+- `headTailOptions` — parsed config: `lines`, `bytes`, `hasBytes`, `fromLine`, `quiet`, `verbose`, `files`
+- `parseHeadTailArgs(inv, cmdName, allowFromLine)` — parses `-n`, `-c`, `-q`, `-v`, legacy `-NUM` syntax, and size suffixes (K, M, G, T, P, E, b)
+- `splitLines(data) [][]byte` — splits on `\n`, preserving line endings
+- `lastLines(data, count)` / `linesFrom(data, start)` / `lastBytes(data, count)` — extraction helpers
+
+## File Operations
+
+### file_helpers.go
+File copying, writing, and destination resolution.
+
+- `ensureParentDirExists(ctx, inv, targetAbs)` — validates parent directory exists
+- `copyFileContents(ctx, inv, srcAbs, dstAbs, perm)` — copy a single file
+- `copyTree(ctx, inv, srcAbs, dstAbs)` — recursive directory copy
+- `writeFileContents(ctx, inv, targetAbs, data, perm)` — write bytes to a file
+- `resolveDestination(ctx, inv, sourceAbs, destArg, multipleSources)` — resolves destination path, handling the "dest is a directory" logic that `cp`, `mv`, and `ln` share
+
+### path_helpers.go
+Directory traversal and file metadata formatting.
+
+- `fileTypeName(info) string` — returns `"symbolic link"`, `"directory"`, or `"regular file"`
+- `formatModeOctal(mode) string` — e.g. `"0755"`
+- `formatModeLong(mode) string` — e.g. `"drwxr-xr-x"`
+- `humanizeBytes(size) string` — e.g. `"4.0K"`, `"12M"`
+
+### permission_helpers.go
+Full ownership/permission engine for `chown` and `chgrp`.
+
+- `permissionIdentityDB` — cached user/group name-to-ID mappings from `/etc/passwd` and `/etc/group`
+- `loadPermissionIdentityDB(ctx, inv)` — builds the DB (env vars + passwd/group files)
+- `parsePermissionOwnerSpec(inv, db, spec)` — parses `"user:group"` specs into UID/GID
+- `walkPermissionTarget(ctx, inv, target, opts, visit)` — recursive walk with symlink traversal modes (`-H`, `-L`, `-P`), cycle detection, and `--preserve-root` support
+- `permissionSuccessMessage` / `permissionFailureMessage` — verbosity-controlled output formatting
+
+## Subprocess Execution
+
+### subexec_helpers.go
+Command resolution and execution through the host shell.
+
+- `executeCommand(ctx, inv, opts)` — resolves and executes an external command via the `Exec` callback
+- `executeCommandOptions` — config: `Argv`, `Env`, `WorkDir`, `Timeout`, `Stdin`/`Stdout`/`Stderr`
+- `resolveCommand(ctx, inv, env, dir, name)` — find first match in PATH
+- `resolveAllCommands(ctx, inv, env, dir, name)` — find all matches in PATH (for `which -a`)
+- `commandSearchDirs(env, dir) []string` — parse and deduplicate PATH entries
+- `shellJoinArgs(args) string` / `shellSingleQuote(value) string` — safe shell quoting
+- `writeExecutionOutputs(inv, result)` — write captured stdout/stderr to the invocation streams
+- `exitForExecutionResult(result) error` — convert result to `ExitError`
+- `sortedEnvPairs(env) []string` — format env map as sorted `KEY=VALUE` pairs
+
+## Encoding & Parsing
+
+### basenc_helpers.go
+Shared boilerplate for `base32` and `base64`.
+
+- `parseBaseEncWrap(name, value, inv) (int, error)` — parse `--wrap` size
+- `readSingleBaseEncInput(ctx, inv, name, args) ([]byte, error)` — read single input (file or stdin) with extra-operand check
+- `writeBaseEncOutput(w, encoded, wrap) error` — write encoded string with line wrapping
+
+### duration_helpers.go
+Duration parsing and escape-sequence decoding.
+
+- `parseFlexibleDuration(value) (time.Duration, error)` — parses `"30"`, `"5s"`, `"2m"`, `"1h"`, `"7d"`; defaults to seconds
+- `decodeDelimiterValue(value) (string, error)` — decodes `\n`, `\t`, `\0`, `\\` escape sequences
+
+### checksum_sums.go
+Shared implementation for `md5sum`, `sha1sum`, and `sha256sum`. Not a helper file per se, but a shared `checksumSum` struct that all three commands instantiate with different hash functions.

--- a/execution_types.go
+++ b/execution_types.go
@@ -1,0 +1,170 @@
+package gbash
+
+import (
+	"io"
+	"time"
+
+	internalruntime "github.com/ewhauser/gbash/internal/runtime"
+	"github.com/ewhauser/gbash/trace"
+)
+
+// ExecutionRequest describes a single shell execution.
+//
+// Callers usually populate [ExecutionRequest.Script] and optionally provide
+// stdin, environment overrides, or a working directory override.
+type ExecutionRequest struct {
+	Name            string
+	Interpreter     string
+	PassthroughArgs []string
+	Script          string
+	Args            []string
+	StartupOptions  []string
+	Env             map[string]string
+	WorkDir         string
+	Timeout         time.Duration
+	ReplaceEnv      bool
+	Interactive     bool
+	Stdin           io.Reader
+	Stdout          io.Writer
+	Stderr          io.Writer
+}
+
+// ExecutionResult captures the output, exit status, timing, and trace events
+// produced by a shell execution.
+type ExecutionResult struct {
+	ExitCode        int
+	ShellExited     bool
+	Stdout          string
+	Stderr          string
+	ControlStderr   string
+	FinalEnv        map[string]string
+	StartedAt       time.Time
+	FinishedAt      time.Time
+	Duration        time.Duration
+	Events          []trace.Event
+	StdoutTruncated bool
+	StderrTruncated bool
+}
+
+// InteractiveRequest describes an interactive shell session.
+type InteractiveRequest struct {
+	Name           string
+	Args           []string
+	StartupOptions []string
+	Env            map[string]string
+	WorkDir        string
+	ReplaceEnv     bool
+	Stdin          io.Reader
+	Stdout         io.Writer
+	Stderr         io.Writer
+}
+
+// InteractiveResult captures the final exit status from an interactive shell session.
+type InteractiveResult struct {
+	ExitCode int
+}
+
+func (req *ExecutionRequest) runtimeRequest() *internalruntime.ExecutionRequest {
+	if req == nil {
+		return &internalruntime.ExecutionRequest{}
+	}
+	return &internalruntime.ExecutionRequest{
+		Name:            req.Name,
+		Interpreter:     req.Interpreter,
+		PassthroughArgs: cloneStrings(req.PassthroughArgs),
+		Script:          req.Script,
+		Args:            cloneStrings(req.Args),
+		StartupOptions:  cloneStrings(req.StartupOptions),
+		Env:             copyStringMap(req.Env),
+		WorkDir:         req.WorkDir,
+		Timeout:         req.Timeout,
+		ReplaceEnv:      req.ReplaceEnv,
+		Interactive:     req.Interactive,
+		Stdin:           req.Stdin,
+		Stdout:          req.Stdout,
+		Stderr:          req.Stderr,
+	}
+}
+
+func executionResultFromRuntime(result *internalruntime.ExecutionResult) *ExecutionResult {
+	if result == nil {
+		return nil
+	}
+	return &ExecutionResult{
+		ExitCode:        result.ExitCode,
+		ShellExited:     result.ShellExited,
+		Stdout:          result.Stdout,
+		Stderr:          result.Stderr,
+		ControlStderr:   result.ControlStderr,
+		FinalEnv:        copyStringMap(result.FinalEnv),
+		StartedAt:       result.StartedAt,
+		FinishedAt:      result.FinishedAt,
+		Duration:        result.Duration,
+		Events:          cloneTraceEvents(result.Events),
+		StdoutTruncated: result.StdoutTruncated,
+		StderrTruncated: result.StderrTruncated,
+	}
+}
+
+func (req *InteractiveRequest) runtimeRequest() *internalruntime.InteractiveRequest {
+	if req == nil {
+		return &internalruntime.InteractiveRequest{}
+	}
+	return &internalruntime.InteractiveRequest{
+		Name:           req.Name,
+		Args:           cloneStrings(req.Args),
+		StartupOptions: cloneStrings(req.StartupOptions),
+		Env:            copyStringMap(req.Env),
+		WorkDir:        req.WorkDir,
+		ReplaceEnv:     req.ReplaceEnv,
+		Stdin:          req.Stdin,
+		Stdout:         req.Stdout,
+		Stderr:         req.Stderr,
+	}
+}
+
+func interactiveResultFromRuntime(result *internalruntime.InteractiveResult) *InteractiveResult {
+	if result == nil {
+		return nil
+	}
+	return &InteractiveResult{ExitCode: result.ExitCode}
+}
+
+func cloneStrings(src []string) []string {
+	if len(src) == 0 {
+		return nil
+	}
+	return append([]string(nil), src...)
+}
+
+func cloneTraceEvents(src []trace.Event) []trace.Event {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]trace.Event, len(src))
+	for i := range src {
+		out[i] = cloneTraceEvent(&src[i])
+	}
+	return out
+}
+
+func cloneTraceEvent(event *trace.Event) trace.Event {
+	if event == nil {
+		return trace.Event{}
+	}
+	out := *event
+	if event.Command != nil {
+		command := *event.Command
+		command.Argv = cloneStrings(command.Argv)
+		out.Command = &command
+	}
+	if event.File != nil {
+		file := *event.File
+		out.File = &file
+	}
+	if event.Policy != nil {
+		policy := *event.Policy
+		out.Policy = &policy
+	}
+	return out
+}

--- a/internal/runtime/execution_types.go
+++ b/internal/runtime/execution_types.go
@@ -1,0 +1,172 @@
+package runtime
+
+import (
+	"io"
+	"maps"
+	"time"
+
+	"github.com/ewhauser/gbash/commands"
+	"github.com/ewhauser/gbash/trace"
+)
+
+type ExecutionRequest struct {
+	Name            string
+	Interpreter     string
+	PassthroughArgs []string
+	Script          string
+	Args            []string
+	StartupOptions  []string
+	Env             map[string]string
+	WorkDir         string
+	Timeout         time.Duration
+	ReplaceEnv      bool
+	Interactive     bool
+	Stdin           io.Reader
+	Stdout          io.Writer
+	Stderr          io.Writer
+}
+
+type ExecutionResult struct {
+	ExitCode        int
+	ShellExited     bool
+	Stdout          string
+	Stderr          string
+	ControlStderr   string
+	FinalEnv        map[string]string
+	StartedAt       time.Time
+	FinishedAt      time.Time
+	Duration        time.Duration
+	Events          []trace.Event
+	StdoutTruncated bool
+	StderrTruncated bool
+}
+
+type InteractiveRequest struct {
+	Name           string
+	Args           []string
+	StartupOptions []string
+	Env            map[string]string
+	WorkDir        string
+	ReplaceEnv     bool
+	Stdin          io.Reader
+	Stdout         io.Writer
+	Stderr         io.Writer
+}
+
+type InteractiveResult struct {
+	ExitCode int
+}
+
+func executionRequestFromCommand(req *commands.ExecutionRequest) *ExecutionRequest {
+	if req == nil {
+		return &ExecutionRequest{}
+	}
+	return &ExecutionRequest{
+		Name:            req.Name,
+		Interpreter:     req.Interpreter,
+		PassthroughArgs: cloneStrings(req.PassthroughArgs),
+		Script:          req.Script,
+		Args:            cloneStrings(req.Args),
+		StartupOptions:  cloneStrings(req.StartupOptions),
+		Env:             copyStringMap(req.Env),
+		WorkDir:         req.WorkDir,
+		Timeout:         req.Timeout,
+		ReplaceEnv:      req.ReplaceEnv,
+		Interactive:     req.Interactive,
+		Stdin:           req.Stdin,
+		Stdout:          req.Stdout,
+		Stderr:          req.Stderr,
+	}
+}
+
+func (result *ExecutionResult) commandResult() *commands.ExecutionResult {
+	if result == nil {
+		return nil
+	}
+	return &commands.ExecutionResult{
+		ExitCode:        result.ExitCode,
+		ShellExited:     result.ShellExited,
+		Stdout:          result.Stdout,
+		Stderr:          result.Stderr,
+		ControlStderr:   result.ControlStderr,
+		FinalEnv:        copyStringMap(result.FinalEnv),
+		StartedAt:       result.StartedAt,
+		FinishedAt:      result.FinishedAt,
+		Duration:        result.Duration,
+		Events:          cloneTraceEvents(result.Events),
+		StdoutTruncated: result.StdoutTruncated,
+		StderrTruncated: result.StderrTruncated,
+	}
+}
+
+func interactiveRequestFromCommand(req *commands.InteractiveRequest) *InteractiveRequest {
+	if req == nil {
+		return &InteractiveRequest{}
+	}
+	return &InteractiveRequest{
+		Name:           req.Name,
+		Args:           cloneStrings(req.Args),
+		StartupOptions: cloneStrings(req.StartupOptions),
+		Env:            copyStringMap(req.Env),
+		WorkDir:        req.WorkDir,
+		ReplaceEnv:     req.ReplaceEnv,
+		Stdin:          req.Stdin,
+		Stdout:         req.Stdout,
+		Stderr:         req.Stderr,
+	}
+}
+
+func (result *InteractiveResult) commandResult() *commands.InteractiveResult {
+	if result == nil {
+		return nil
+	}
+	return &commands.InteractiveResult{ExitCode: result.ExitCode}
+}
+
+func copyStringMap(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(src))
+	maps.Copy(out, src)
+	return out
+}
+
+func cloneStrings(src []string) []string {
+	if len(src) == 0 {
+		return nil
+	}
+	return append([]string(nil), src...)
+}
+
+func cloneTraceEvents(src []trace.Event) []trace.Event {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]trace.Event, len(src))
+	for i := range src {
+		out[i] = cloneTraceEvent(&src[i])
+	}
+	return out
+}
+
+func cloneTraceEvent(event *trace.Event) trace.Event {
+	if event == nil {
+		return trace.Event{}
+	}
+	out := *event
+	if event.Command != nil {
+		command := *event.Command
+		command.Argv = cloneStrings(command.Argv)
+		out.Command = &command
+	}
+	if event.File != nil {
+		file := *event.File
+		out.File = &file
+	}
+	if event.Policy != nil {
+		policy := *event.Policy
+		out.Policy = &policy
+	}
+	return out
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -39,11 +39,6 @@ type Session struct {
 	mu     sync.Mutex
 }
 
-type ExecutionRequest = commands.ExecutionRequest
-type ExecutionResult = commands.ExecutionResult
-type InteractiveRequest = commands.InteractiveRequest
-type InteractiveResult = commands.InteractiveResult
-
 func New(opts ...Option) (*Runtime, error) {
 	resolved, err := resolveConfig(opts)
 	if err != nil {

--- a/internal/runtime/session.go
+++ b/internal/runtime/session.go
@@ -190,11 +190,13 @@ func (s *Session) interact(ctx context.Context, req *InteractiveRequest) (*Inter
 }
 
 func (s *Session) subexecCallback(ctx context.Context, req *commands.ExecutionRequest) (*commands.ExecutionResult, error) {
-	return s.exec(ctx, req)
+	result, err := s.exec(ctx, executionRequestFromCommand(req))
+	return result.commandResult(), err
 }
 
 func (s *Session) interactCallback(ctx context.Context, req *commands.InteractiveRequest) (*commands.InteractiveResult, error) {
-	return s.interact(ctx, req)
+	result, err := s.interact(ctx, interactiveRequestFromCommand(req))
+	return result.commandResult(), err
 }
 
 func (s *Session) FileSystem() gbfs.FileSystem {


### PR DESCRIPTION
## Summary
- make the root package own its execution and interactive request/result types
- remove the remaining internal runtime aliases to command-layer execution structs
- build CLI execution requests directly from parsed bash invocations instead of adapting command-layer requests

## Testing
- go test ./...
- go test ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./contrib/awk/... ./examples/...
