### PR TITLE
Document public extension packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ Requires Go 1.26+
 
 Install the module with `go get github.com/ewhauser/gbash` and import `github.com/ewhauser/gbash` for the embedding API.
 
-Only `github.com/ewhauser/gbash` is considered stable. Lower-level packages under `github.com/ewhauser/gbash/...` exist for advanced integrations and repository internals, but they may change without notice.
-
 ## Table of Contents
 
+- [Public Packages](#public-packages)
 - [Usage](#usage)
   - [Basic API](#basic-api)
   - [Network-Enabled API](#network-enabled-api)
@@ -29,8 +28,6 @@ Only `github.com/ewhauser/gbash` is considered stable. Lower-level packages unde
 - [Default Sandbox Layout](#default-sandbox-layout)
 - [Development](#development)
 - [License](#license)
-
-## Usage
 
 ### Basic API
 

--- a/commands/doc.go
+++ b/commands/doc.go
@@ -1,8 +1,15 @@
-// Package commands provides low-level command registration and implementation
-// hooks for gbash.
+// Package commands provides the stable command authoring and registry API for
+// gbash.
 //
-// This package is available for advanced integrations such as custom commands
-// and contrib modules, but it is not the stable embedding API. Most callers
-// should construct and run sandboxes through the root
-// `github.com/ewhauser/gbash` package instead.
+// Most embedders should construct and run sandboxes through the root
+// `github.com/ewhauser/gbash` package and only import commands when they need
+// to:
+//
+//   - implement custom commands
+//   - customize a command registry
+//   - reuse gbash's command-spec parsing and invocation helpers
+//
+// The package currently also contains builtin command implementations, but the
+// long-term extension contract is the command API itself rather than this being
+// the permanent home of every builtin implementation.
 package commands

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Package gbash provides the public embedding API for the gbash sandbox.
+// Package gbash provides the primary embedding API for the gbash sandbox.
 //
 // The root package is the intended entry point for most callers. It exposes
 // the runtime, session, execution request/result types, and the opinionated
@@ -11,8 +11,16 @@
 //   - customize the registry, policy, engine, or filesystem with explicit
 //     options when you need lower-level control
 //
-// The root package is the only stable embedding API. More specialized packages
-// such as commands, fs, network, policy, shell, and trace remain available for
-// advanced integrations and extension points, but they are low-level hooks and
-// are not covered by the root package's compatibility promise.
+// Most embedders should only import the root package. Advanced integrations may
+// also import the supported extension packages:
+//
+//   - commands for custom command authorship and registry customization
+//   - fs for custom filesystem backends and factories
+//   - network for sandbox HTTP client customization
+//   - policy for sandbox policy implementations
+//   - shell for alternative shell engine implementations
+//   - trace for structured execution event consumption
+//
+// Packages under internal/ and other undocumented subpackages are not public
+// API.
 package gbash

--- a/fs/doc.go
+++ b/fs/doc.go
@@ -1,7 +1,8 @@
 // Package fs provides the filesystem contracts and virtual filesystem backends
 // used by gbash.
 //
-// This package is a low-level extension surface for custom filesystem
-// integrations. It is not the stable embedding API; most callers should prefer
-// the root `github.com/ewhauser/gbash` package.
+// This is a supported public extension package for callers that need to supply
+// custom filesystem implementations or factories. Most embedders should still
+// prefer the root `github.com/ewhauser/gbash` package and its higher-level
+// filesystem helpers.
 package fs

--- a/network/doc.go
+++ b/network/doc.go
@@ -1,6 +1,8 @@
 // Package network provides the sandboxed HTTP client used by gbash.
 //
-// This package exists for advanced transport customization and testing, but it
-// is not the stable embedding API. Most callers should prefer the root
-// `github.com/ewhauser/gbash` package.
+// This is a supported public extension package for callers that need to
+// customize the HTTP transport, resolver, or request policy used by curl
+// inside the sandbox. Most embedders should prefer the root
+// `github.com/ewhauser/gbash` package and configure network access through its
+// higher-level options.
 package network

--- a/policy/doc.go
+++ b/policy/doc.go
@@ -1,7 +1,9 @@
 // Package policy provides low-level sandbox policy types and enforcement
 // helpers for gbash.
 //
-// This package is intended for advanced policy customization. It is not the
-// stable embedding API; most callers should prefer the root
-// `github.com/ewhauser/gbash` package.
+// This is a supported public extension package for callers that need to
+// provide custom sandbox policy implementations or reuse gbash's path-checking
+// helpers. Most embedders should prefer the root
+// `github.com/ewhauser/gbash` package and its higher-level configuration
+// options.
 package policy

--- a/shell/doc.go
+++ b/shell/doc.go
@@ -1,6 +1,8 @@
 // Package shell provides the low-level shell engine contracts and mvdan/sh
 // integration used by gbash.
 //
-// This package is not the stable embedding API. Most callers should construct
-// and run sandboxes through the root `github.com/ewhauser/gbash` package.
+// This is a supported public extension package for callers that need to
+// provide an alternative shell engine implementation. Most embedders should
+// construct and run sandboxes through the root
+// `github.com/ewhauser/gbash` package.
 package shell

--- a/trace/doc.go
+++ b/trace/doc.go
@@ -1,6 +1,7 @@
 // Package trace provides the structured execution event model used by gbash.
 //
-// This package is available for advanced trace consumption and testing, but it
-// is not the stable embedding API. Most callers should prefer the root
-// `github.com/ewhauser/gbash` package.
+// This is a supported public extension package for callers that need to
+// consume, record, or test against gbash execution events. Most embedders
+// should prefer the root `github.com/ewhauser/gbash` package unless they are
+// integrating with tracing or telemetry systems directly.
 package trace


### PR DESCRIPTION
## Summary
- document the supported public package map in the root package docs and README
- clarify that `gbash` is the primary package while `commands`, `fs`, `network`, `policy`, `shell`, and `trace` are supported extension packages
- describe `commands` as the stable command authoring and registry API while leaving room to move builtin implementations out later

## Testing
- go test ./...
