### PR TITLE
runtime: fix flaky interactive stdin by removing per-statement StdIO reset

### DIFF
--- a/shell/mvdan_interactive.go
+++ b/shell/mvdan_interactive.go
@@ -93,9 +93,6 @@ func (m *MVdan) Interact(ctx context.Context, exec *Execution) (*InteractiveResu
 		if err := instrumentLoopBudgets(file, exec.Policy); err != nil {
 			return &InteractiveResult{ExitCode: exitCode}, err
 		}
-		if err := interp.StdIO(input, exec.Stdout, exec.Stderr)(runner); err != nil {
-			return &InteractiveResult{ExitCode: exitCode}, err
-		}
 		runErr := runner.Run(ctx, file)
 		exitCode = ExitCode(runErr)
 		if runner.Exited() {


### PR DESCRIPTION
interp.StdIO with a non-*os.File reader spawns a goroutine that eagerly
drains the reader via io.Copy. Calling it inside the InteractiveSeq loop
raced with the parser for bytes from the shared bufio.Reader, causing
intermittent loss of trailing commands and wrong exit codes.
