### PR TITLE
release: v0.0.8

### DIFF
--- a/contrib/awk/go.mod
+++ b/contrib/awk/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/benhoyt/goawk v1.31.0
-	github.com/ewhauser/gbash v0.0.7
+	github.com/ewhauser/gbash v0.0.8
 )
 
 require (

--- a/contrib/extras/go.mod
+++ b/contrib/extras/go.mod
@@ -3,11 +3,11 @@ module github.com/ewhauser/gbash/contrib/extras
 go 1.26.0
 
 require (
-	github.com/ewhauser/gbash v0.0.7
-	github.com/ewhauser/gbash/contrib/awk v0.0.7
-	github.com/ewhauser/gbash/contrib/jq v0.0.7
-	github.com/ewhauser/gbash/contrib/sqlite3 v0.0.7
-	github.com/ewhauser/gbash/contrib/yq v0.0.7
+	github.com/ewhauser/gbash v0.0.8
+	github.com/ewhauser/gbash/contrib/awk v0.0.8
+	github.com/ewhauser/gbash/contrib/jq v0.0.8
+	github.com/ewhauser/gbash/contrib/sqlite3 v0.0.8
+	github.com/ewhauser/gbash/contrib/yq v0.0.8
 )
 
 require (

--- a/contrib/jq/go.mod
+++ b/contrib/jq/go.mod
@@ -3,7 +3,7 @@ module github.com/ewhauser/gbash/contrib/jq
 go 1.26.0
 
 require (
-	github.com/ewhauser/gbash v0.0.7
+	github.com/ewhauser/gbash v0.0.8
 	github.com/itchyny/gojq v0.12.18
 )
 

--- a/contrib/sqlite3/go.mod
+++ b/contrib/sqlite3/go.mod
@@ -3,7 +3,7 @@ module github.com/ewhauser/gbash/contrib/sqlite3
 go 1.26.0
 
 require (
-	github.com/ewhauser/gbash v0.0.7
+	github.com/ewhauser/gbash v0.0.8
 	github.com/ncruces/go-sqlite3 v0.31.1
 )
 

--- a/contrib/yq/go.mod
+++ b/contrib/yq/go.mod
@@ -3,7 +3,7 @@ module github.com/ewhauser/gbash/contrib/yq
 go 1.26.0
 
 require (
-	github.com/ewhauser/gbash v0.0.7
+	github.com/ewhauser/gbash v0.0.8
 	github.com/mikefarah/yq/v4 v4.52.4
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
 )

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,8 +3,8 @@ module github.com/ewhauser/gbash/examples
 go 1.26.0
 
 require (
-	github.com/ewhauser/gbash v0.0.7
-	github.com/ewhauser/gbash/contrib/sqlite3 v0.0.7
+	github.com/ewhauser/gbash v0.0.8
+	github.com/ewhauser/gbash/contrib/sqlite3 v0.0.8
 	github.com/klauspost/compress v1.18.4
 	github.com/ncruces/go-sqlite3 v0.31.1
 	github.com/openai/openai-go v1.12.0


### PR DESCRIPTION
Automated release preparation for `v0.0.8`.

This PR:
- syncs nested module requirements and local replaces via `make fix-modules`
- validates the release candidate with `make test`, `make lint`, and `make release-check`

Note: the `Prepare Release` workflow successfully pushed `release/v0.0.8` but could not create the PR automatically because repository settings currently disallow GitHub Actions from creating pull requests.