### PR TITLE
Auto-publish merged release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,6 @@ jobs:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           set -euo pipefail
@@ -60,9 +58,11 @@ jobs:
             && [[ "${PR_BASE_REF}" == "main" ]] \
             && [[ "${PR_HEAD_REPO}" == "${REPOSITORY}" ]] \
             && [[ "${PR_HEAD_REF}" == release/v* ]] \
-            && [[ ",${PR_LABELS}," == *",release,"* ]] \
-            && [[ "${PR_AUTHOR}" == "github-actions[bot]" ]] \
             && [[ -n "${PR_MERGE_SHA}" ]]; then
+            # Trust merged in-repo release branches whether the PR was opened by
+            # automation or manually. The publish job still re-verifies that the
+            # merge commit is synchronized for the requested version before it
+            # creates any tags or releases.
             should_publish=true
             version="${PR_HEAD_REF#release/}"
             ref="${PR_MERGE_SHA}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ The supported release path is GitHub Actions driven:
 
 `Prepare Release` derives the next release line by taking the latest root `v*` tag and incrementing the patch number.
 
+If repository settings block GitHub Actions from creating pull requests, `Prepare Release` may still push the `release/vX.Y.Z` branch even though the workflow fails at the final PR-creation step. In that case, open the PR manually from the pushed release branch. `Publish Release` keys off the merged `release/vX.Y.Z` branch name, so the release will still publish automatically after merge.
+
 `make tag-release RELEASE_VERSION=vX.Y.Z` remains available as a local fallback for debugging or manual recovery, but it is no longer the primary release path.
 
 ## Benchmarks


### PR DESCRIPTION
## Summary
- let `Publish Release` trust any merged in-repo `release/vX.Y.Z` branch, even when the PR was opened manually
- keep the existing release-tree verification as the safety gate before tags or releases are created
- document the manual-PR fallback for repos that disallow GitHub Actions from creating PRs

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml .github/workflows/prepare-release.yml`
- simulated the `resolve` guard with the actual `release/v0.0.8` merge metadata and confirmed it now resolves to `should_publish=true`