### PR TITLE
ci: publish compat image to ghcr

### DIFF
--- a/.github/workflows/compat-image.yml
+++ b/.github/workflows/compat-image.yml
@@ -1,0 +1,65 @@
+name: Publish Compat Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docker/compat/Dockerfile
+      - go.mod
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: compat-image-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/${{ github.event.repository.name }}-compat
+
+jobs:
+  publish:
+    if: github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute Go version
+        id: go-version
+        run: echo "value=$(awk '/^go / { print $2; exit }' go.mod)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,format=long,prefix=sha-
+
+      - name: Build and push compat image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/compat/Dockerfile
+          push: true
+          platforms: linux/amd64
+          build-args: |
+            GO_VERSION=${{ steps.go-version.outputs.value }}
+          cache-from: type=gha,scope=compat-image
+          cache-to: type=gha,mode=max,scope=compat-image
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   pages: write
   id-token: write
 
@@ -17,6 +18,11 @@ concurrency:
 jobs:
   compat:
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-compat:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     env:
       GNU_BUILD_CACHE_VERSION: v3
       GNU_BUILD_CACHE_TAG: gnu-build-cache-v3
@@ -26,26 +32,6 @@ jobs:
       deployable: ${{ steps.publish-state.outputs.deployable }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install compat test dependencies
-        run: |
-          sudo apt-get update
-          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            acl \
-            libacl1-dev \
-            libexpect-perl \
-            libselinux1-dev \
-            locales-all \
-            valgrind
-          python -m pip install --disable-pip-version-check pyinotify
 
       - name: Compute GNU build cache key
         id: gnu-build-cache-key

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,3 +82,9 @@ Maintainers can refresh the published prepared build archive set with:
 ```bash
 make gnu-build-cache-publish
 ```
+
+The scheduled GitHub compatibility workflow runs inside the published compat image from GitHub Container Registry. Local runs still default to a locally built image, but you can reuse the published container instead:
+
+```bash
+COMPAT_DOCKER_IMAGE=ghcr.io/ewhauser/gbash-compat:latest COMPAT_DOCKER_PULL=1 make compat-docker-run
+```

--- a/scripts/compat-docker-run.sh
+++ b/scripts/compat-docker-run.sh
@@ -6,6 +6,7 @@ REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 
 IMAGE_NAME=${COMPAT_DOCKER_IMAGE:-gbash-compat-local}
 PLATFORM=${COMPAT_DOCKER_PLATFORM:-linux/amd64}
+PULL_MODE=${COMPAT_DOCKER_PULL:-0}
 GNU_CACHE_DIR=${GNU_CACHE_DIR:-.cache/gnu}
 GNU_RESULTS_DIR=${GNU_RESULTS_DIR:-.cache/gnu/results/docker-latest}
 GNU_FORCE_REBUILD=${GNU_FORCE_REBUILD:-0}
@@ -34,9 +35,23 @@ require_repo_path() {
 }
 
 ensure_image() {
+  case "$PULL_MODE" in
+    1|true|TRUE|always)
+      if docker pull "$IMAGE_NAME" >/dev/null 2>&1; then
+        return
+      fi
+      ;;
+  esac
   if docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
     return
   fi
+  case "$PULL_MODE" in
+    1|true|TRUE|always|missing)
+      if docker pull "$IMAGE_NAME"; then
+        return
+      fi
+      ;;
+  esac
   "$SCRIPT_DIR/compat-docker-build.sh"
 }
 


### PR DESCRIPTION
## Summary
- publish the compat Docker image to GitHub Container Registry on default-branch pushes when the Dockerfile inputs change
- run the compat workflow inside the published image instead of reinstalling toolchains on every run
- let local compat runs pull the published image and document that flow

## Testing
- bash -n scripts/compat-docker-run.sh
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/compat.yml .github/workflows/compat-image.yml
