### PR TITLE
release: publish docs to pkg.go.dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,11 @@ jobs:
           VERSION: ${{ needs.resolve.outputs.version }}
         run: echo "GitHub release already exists for ${VERSION}; skipping goreleaser."
 
+      - name: Publish Go module docs to pkg.go.dev
+        env:
+          RELEASE_VERSION: ${{ needs.resolve.outputs.version }}
+        run: ./scripts/publish_pkgsite.sh
+
       # npm publish for @ewhauser/gbash-wasm is intentionally disabled for now.
       # Keep the package build in release-check and prepare-release so the package
       # stays releasable, but do not publish from the coordinated release workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,11 @@ The supported release path is GitHub Actions driven:
 1. Run `make release` or dispatch the `Prepare Release` workflow manually.
 2. Review and merge the generated `release/vX.Y.Z` PR into `main`.
 3. Let the `Publish Release` workflow create the root plus contrib tags and publish the root GitHub release automatically, including both `gbash` and `gbash-extras` archives plus a shared checksum file.
+4. The same workflow requests each released Go module version from `proxy.golang.org`, which is the supported way to make the new docs show up on `pkg.go.dev` for the root module and the release-tagged contrib modules.
 
 `Prepare Release` derives the next release line by taking the latest root `v*` tag and incrementing the patch number.
 
-`make tag-release RELEASE_VERSION=vX.Y.Z` remains available as a local fallback for debugging or manual recovery, but it is no longer the primary release path.
+`make tag-release RELEASE_VERSION=vX.Y.Z` remains available as a local fallback for debugging or manual recovery, but it is no longer the primary release path. If you need to re-request documentation indexing for an existing release, run `./scripts/publish_pkgsite.sh vX.Y.Z`.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ go install github.com/ewhauser/gbash/contrib/extras/cmd/gbash-extras@latest
 ```
 
 Prebuilt `gbash` and `gbash-extras` archives are also available on the [GitHub Releases page](https://github.com/ewhauser/gbash/releases).
+Released Go modules are also requested from the public Go proxy during the release workflow so their API docs stay current on [pkg.go.dev](https://pkg.go.dev/github.com/ewhauser/gbash).
 
 ## Quick Start
 

--- a/scripts/publish_pkgsite.sh
+++ b/scripts/publish_pkgsite.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${1:-${RELEASE_VERSION:-}}"
+GOPROXY_URL="${GOPROXY_URL:-https://proxy.golang.org}"
+MAX_ATTEMPTS="${PKG_GO_DEV_MAX_ATTEMPTS:-20}"
+SLEEP_SECONDS="${PKG_GO_DEV_RETRY_DELAY_SECONDS:-15}"
+
+if [[ -z "${VERSION}" ]]; then
+	echo "usage: scripts/publish_pkgsite.sh vX.Y.Z" >&2
+	exit 1
+fi
+
+if [[ "${VERSION}" != v* ]]; then
+	echo "version must look like vX.Y.Z" >&2
+	exit 1
+fi
+
+if ! command -v go >/dev/null 2>&1; then
+	echo "go toolchain is required" >&2
+	exit 1
+fi
+
+module_path_from_go_mod() {
+	local file="$1"
+	local module_path
+
+	module_path="$(sed -n 's/^module //p' "${file}" | head -n 1)"
+	if [[ -z "${module_path}" ]]; then
+		echo "unable to determine module path from ${file}" >&2
+		exit 1
+	fi
+
+	printf '%s\n' "${module_path}"
+}
+
+modules=()
+modules+=("$(module_path_from_go_mod "${ROOT_DIR}/go.mod")")
+while IFS= read -r go_mod; do
+	modules+=("$(module_path_from_go_mod "${ROOT_DIR}/${go_mod}")")
+done < <(
+	cd "${ROOT_DIR}"
+	find contrib -mindepth 2 -maxdepth 2 -type f -name go.mod | sort
+)
+
+temp_dir="$(mktemp -d)"
+cleanup() {
+	rm -rf "${temp_dir}"
+}
+trap cleanup EXIT
+
+printf 'requesting pkg.go.dev indexing for %s via %s\n' "${VERSION}" "${GOPROXY_URL}"
+for module in "${modules[@]}"; do
+	module_version="${module}@${VERSION}"
+	for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+		if output="$(
+			cd "${temp_dir}"
+			GOWORK=off GO111MODULE=on GOPROXY="${GOPROXY_URL}" go list -m "${module_version}" 2>&1
+		)"; then
+			printf '  published %s\n' "${module_version}"
+			break
+		fi
+
+		if ((attempt == MAX_ATTEMPTS)); then
+			printf 'failed to publish %s after %d attempts\n%s\n' "${module_version}" "${MAX_ATTEMPTS}" "${output}" >&2
+			exit 1
+		fi
+
+		printf '  waiting for proxy to serve %s (attempt %d/%d)\n' "${module_version}" "${attempt}" "${MAX_ATTEMPTS}"
+		sleep "${SLEEP_SECONDS}"
+	done
+done


### PR DESCRIPTION
## Summary
- add a release helper that requests each coordinated Go module version from proxy.golang.org with retries
- call that helper from the Publish Release workflow after tags are created so pkg.go.dev indexes the release automatically
- document the new pkg.go.dev publication behavior and the manual recovery command

## Testing
- make release-check
- ./scripts/publish_pkgsite.sh v0.0.10