### PR TITLE
website: add Performance > Benchmarks page

### DIFF
--- a/.agents/skills/update-benchmarks/SKILL.md
+++ b/.agents/skills/update-benchmarks/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: update-benchmarks
+description: >
+  Update the website benchmark data by running the bench-compare harness and transforming results for the website.
+  Use when the user asks to refresh benchmarks, update benchmark data, rerun performance comparisons,
+  or regenerate the benchmarks page. Also use when the user mentions benchmark numbers are stale or out of date.
+---
+
+# Update Benchmarks
+
+Refreshes the benchmark data displayed on the website's Performance > Benchmarks page.
+
+## Steps
+
+### 1. Run the benchmark harness
+
+```bash
+make bench-compare BENCH_COMPARE_RUNS=50 JSON_OUT=/tmp/bench-compare.json
+```
+
+The default is 100 runs but 50 is sufficient for stable medians. The user may request a different count.
+
+### 2. Collect machine info
+
+Gather the current machine's specs for the test environment table:
+
+```bash
+# Model identifier
+sysctl -n hw.model                    # e.g. Mac15,8
+# Chip name
+sysctl -n machdep.cpu.brand_string    # e.g. Apple M3 Max
+# Core counts
+sysctl -n hw.perflevel0.physicalcpu   # performance cores
+sysctl -n hw.perflevel1.physicalcpu   # efficiency cores
+# Memory
+sysctl -n hw.memsize                  # bytes, divide by 1073741824 for GB
+# OS version
+sw_vers -productName && sw_vers -productVersion  # e.g. macOS 15.5
+# Go version
+go version                            # e.g. go1.26.1 darwin/arm64
+```
+
+### 3. Transform JSON for the website
+
+Use Python to strip individual trial data (keeping only stats) and inject the machine info:
+
+```python
+import json
+
+with open("/tmp/bench-compare.json") as f:
+    data = json.load(f)
+
+for scenario in data["scenarios"]:
+    for result in scenario["results"]:
+        del result["trials"]
+
+data["machine"] = {
+    "model": "<from step 2>",
+    "chip": "<from step 2>",
+    "cores": "<N> (<P> performance + <E> efficiency)",
+    "memory": "<N> GB",
+    "os": "<name> <version>",
+    "go_version": "<go version output>"
+}
+
+with open("website/content/performance/benchmark-data.json", "w") as f:
+    json.dump(data, f, indent=2)
+```
+
+### 4. Verify the build
+
+```bash
+cd website && npm run build
+```
+
+Confirm `/docs/performance/benchmarks` appears in the route list.
+
+## Key files
+
+- `scripts/bench-compare/main.go` — the benchmark harness
+- `website/content/performance/benchmark-data.json` — transformed JSON consumed by the website
+- `website/app/components/docs/BenchmarkChart.tsx` — React component rendering the data
+- `website/content/performance/benchmarks.mdx` — the benchmarks page content
+- `Makefile` — `bench-compare` target and its variables (`BENCH_COMPARE_RUNS`, `JUST_BASH_SPEC`, `JSON_OUT`)

--- a/website/app/components/docs/BenchmarkChart.tsx
+++ b/website/app/components/docs/BenchmarkChart.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import benchmarkData from "@/content/performance/benchmark-data.json";
+
+interface Stats {
+  min_nanos: number;
+  median_nanos: number;
+  p95_nanos: number;
+}
+
+interface RuntimeResult {
+  name: string;
+  artifact_size_bytes: number;
+  success_count: number;
+  failure_count: number;
+  stats: Stats;
+}
+
+interface Scenario {
+  name: string;
+  description: string;
+  command: string;
+  expected_stdout: string;
+  workspace: boolean;
+  fixture?: { root: string; file_count: number; total_bytes: number };
+  results: RuntimeResult[];
+}
+
+interface BenchmarkReport {
+  generated_at: string;
+  runs: number;
+  just_bash_spec: string;
+  machine: {
+    model: string;
+    chip: string;
+    cores: string;
+    memory: string;
+    os: string;
+    go_version: string;
+  };
+  scenarios: Scenario[];
+}
+
+const data = benchmarkData as BenchmarkReport;
+
+function formatNanos(nanos: number): string {
+  if (nanos >= 1_000_000_000) return `${(nanos / 1_000_000_000).toFixed(2)}s`;
+  if (nanos >= 1_000_000) return `${(nanos / 1_000_000).toFixed(1)}ms`;
+  if (nanos >= 1_000) return `${(nanos / 1_000).toFixed(1)}µs`;
+  return `${nanos}ns`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GiB`;
+  if (bytes >= 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${bytes} B`;
+}
+
+function ScenarioTable({ scenario }: { scenario: Scenario }) {
+  return (
+    <div className="mb-8">
+      <h3 className="text-lg font-semibold text-[var(--fg-primary)]">
+        {scenario.name.replace(/_/g, " ")}
+      </h3>
+      <p className="text-sm text-[var(--fg-secondary)] mt-1">
+        {scenario.description}
+      </p>
+      <p className="mt-1 mb-3">
+        <code className="text-xs text-[var(--accent)]">
+          {scenario.command}
+        </code>
+        {scenario.fixture && (
+          <span className="text-xs text-[var(--fg-secondary)] ml-2">
+            ({scenario.fixture.file_count} files,{" "}
+            {formatBytes(scenario.fixture.total_bytes)})
+          </span>
+        )}
+      </p>
+      <div className="overflow-x-auto">
+        <table>
+          <thead>
+            <tr>
+              <th>Runtime</th>
+              <th>Min</th>
+              <th>Median</th>
+              <th>p95</th>
+              <th>Artifact Size</th>
+            </tr>
+          </thead>
+          <tbody>
+            {scenario.results.map((r) => (
+              <tr key={r.name}>
+                <td>{r.name}</td>
+                <td>{formatNanos(r.stats.min_nanos)}</td>
+                <td>{formatNanos(r.stats.median_nanos)}</td>
+                <td>{formatNanos(r.stats.p95_nanos)}</td>
+                <td>{formatBytes(r.artifact_size_bytes)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function ArtifactSizeTable() {
+  const results = data.scenarios[0].results;
+  return (
+    <div className="mb-8">
+      <h3 className="text-lg font-semibold text-[var(--fg-primary)]">
+        Artifact Size
+      </h3>
+      <p className="text-sm text-[var(--fg-secondary)] mt-1 mb-3">
+        Total distributable size per runtime.
+      </p>
+      <div className="overflow-x-auto">
+        <table>
+          <thead>
+            <tr>
+              <th>Runtime</th>
+              <th>Size</th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((r) => (
+              <tr key={r.name}>
+                <td>{r.name}</td>
+                <td>{formatBytes(r.artifact_size_bytes)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function MachineInfo() {
+  const m = data.machine;
+  return (
+    <div className="mb-8">
+      <h3 className="text-lg font-semibold text-[var(--fg-primary)]">
+        Test Environment
+      </h3>
+      <div className="overflow-x-auto">
+        <table>
+          <tbody>
+            {[
+              ["Machine", m.model],
+              ["Chip", m.chip],
+              ["Cores", m.cores],
+              ["Memory", m.memory],
+              ["OS", m.os],
+              ["Go", m.go_version],
+              ["Runs per scenario", `${data.runs}`],
+              [
+                "Generated",
+                new Date(data.generated_at).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                }),
+              ],
+            ].map(([label, value]) => (
+              <tr key={label}>
+                <td className="font-medium">{label}</td>
+                <td>{value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default function BenchmarkChart() {
+  return (
+    <div>
+      <MachineInfo />
+      {data.scenarios.map((scenario) => (
+        <ScenarioTable key={scenario.name} scenario={scenario} />
+      ))}
+      <ArtifactSizeTable />
+    </div>
+  );
+}

--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -7,6 +7,7 @@ const pages: Record<string, () => Promise<{ default: React.ComponentType; metada
   "getting-started": () => import("@/content/getting-started/index.mdx"),
   "getting-started/installation": () => import("@/content/getting-started/installation.mdx"),
   "getting-started/quick-start": () => import("@/content/getting-started/quick-start.mdx"),
+  "performance/benchmarks": () => import("@/content/performance/benchmarks.mdx"),
 };
 
 interface Props {

--- a/website/app/lib/docs-navigation.ts
+++ b/website/app/lib/docs-navigation.ts
@@ -13,6 +13,10 @@ export const docsNavigation: NavItem[] = [
       { title: "Quick Start", href: "/docs/getting-started/quick-start" },
     ],
   },
+  {
+    title: "Performance",
+    items: [{ title: "Benchmarks", href: "/docs/performance/benchmarks" }],
+  },
 ];
 
 export function flattenNav(items: NavItem[]): NavItem[] {

--- a/website/content/performance/benchmark-data.json
+++ b/website/content/performance/benchmark-data.json
@@ -1,0 +1,148 @@
+{
+  "generated_at": "2026-03-14T20:11:18Z",
+  "runs": 50,
+  "just_bash_spec": "just-bash@2.13.0",
+  "scenarios": [
+    {
+      "name": "startup_echo",
+      "description": "Process start plus one simple command.",
+      "command": "echo benchmark",
+      "expected_stdout": "benchmark\n",
+      "workspace": false,
+      "results": [
+        {
+          "name": "gbash",
+          "artifact_size_bytes": 13623154,
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 6147792,
+            "median_nanos": 6468917,
+            "p95_nanos": 6983709
+          }
+        },
+        {
+          "name": "GNU bash",
+          "artifact_size_bytes": 896880,
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 5762291,
+            "median_nanos": 6377917,
+            "p95_nanos": 6768209
+          }
+        },
+        {
+          "name": "gbash-extras",
+          "artifact_size_bytes": 33271922,
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 8348417,
+            "median_nanos": 8843916,
+            "p95_nanos": 58970750
+          }
+        },
+        {
+          "name": "gbash-node-wasm",
+          "artifact_size_bytes": 18546233,
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 136729083,
+            "median_nanos": 149648084,
+            "p95_nanos": 165961708
+          }
+        },
+        {
+          "name": "just-bash",
+          "artifact_size_bytes": 137506692,
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 685543250,
+            "median_nanos": 719597229,
+            "p95_nanos": 864608875
+          }
+        }
+      ]
+    },
+    {
+      "name": "workspace_inventory",
+      "description": "Process start plus a pipe-free workspace inventory.",
+      "command": "set -- $(find . -type f); echo $#",
+      "expected_stdout": "300\n",
+      "workspace": true,
+      "fixture": {
+        "root": "/var/folders/9p/g5cvvwmj6253tvhh89thzjxh0000gp/T/gbash-bench-compare-3109534130/workspace",
+        "file_count": 300,
+        "total_bytes": 17100
+      },
+      "results": [
+        {
+          "name": "gbash",
+          "artifact_size_bytes": 13623154,
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 16631958,
+            "median_nanos": 18633812,
+            "p95_nanos": 21777083
+          }
+        },
+        {
+          "name": "GNU bash",
+          "artifact_size_bytes": 896880,
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 15938958,
+            "median_nanos": 17219125,
+            "p95_nanos": 18863917
+          }
+        },
+        {
+          "name": "gbash-extras",
+          "artifact_size_bytes": 33271922,
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 19538250,
+            "median_nanos": 20630833,
+            "p95_nanos": 21955875
+          }
+        },
+        {
+          "name": "gbash-node-wasm",
+          "artifact_size_bytes": 18546233,
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 217318666,
+            "median_nanos": 233262791,
+            "p95_nanos": 283151667
+          }
+        },
+        {
+          "name": "just-bash",
+          "artifact_size_bytes": 137506692,
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 730709125,
+            "median_nanos": 782657604,
+            "p95_nanos": 959050208
+          }
+        }
+      ]
+    }
+  ],
+  "machine": {
+    "model": "MacBook Pro (Mac15,8)",
+    "chip": "Apple M3 Max",
+    "cores": "16 (12 performance + 4 efficiency)",
+    "memory": "64 GB",
+    "os": "macOS 15.5",
+    "go_version": "go1.26.1 darwin/arm64"
+  }
+}

--- a/website/content/performance/benchmarks.mdx
+++ b/website/content/performance/benchmarks.mdx
@@ -1,0 +1,38 @@
+# Benchmarks
+
+Cross-runtime comparison of gbash against GNU bash and alternative sandboxed-shell runtimes. Each scenario is run as an independent process invocation — measuring real end-to-end latency including startup, execution, and teardown.
+
+## Runtimes
+
+<table>
+  <thead>
+    <tr>
+      <th>Runtime</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td><strong>gbash</strong></td><td>Native Go binary — the default runtime</td></tr>
+    <tr><td><strong>GNU bash</strong></td><td>Host system bash (unsandboxed baseline)</td></tr>
+    <tr><td><strong>gbash-extras</strong></td><td>gbash with <code>awk</code>, <code>jq</code>, <code>sqlite3</code>, <code>yq</code> pre-registered</td></tr>
+    <tr><td><strong>gbash-node-wasm</strong></td><td>gbash compiled to WebAssembly, run in Node.js</td></tr>
+    <tr><td><strong>just-bash</strong></td><td>Published npm package (<code>just-bash@2.13.0</code>)</td></tr>
+  </tbody>
+</table>
+
+## Results
+
+import BenchmarkChart from "@/app/components/docs/BenchmarkChart";
+
+<BenchmarkChart />
+
+## Methodology
+
+- Each scenario runs the command as a fresh process invocation (cold start).
+- A single untimed warmup run precedes the timed trials to prime OS caches.
+- Latency is measured wall-clock from process spawn to exit.
+- Artifact size includes all files needed to run the runtime (e.g., for `just-bash`, this includes Node.js itself plus the npm package).
+- All runtimes execute the same shell command and validate stdout matches the expected output.
+- The harness source is at [`scripts/bench-compare/main.go`](https://github.com/ewhauser/gbash/blob/main/scripts/bench-compare/main.go).
+
+> **Note:** just-bash ships significantly more functionality than gbash today — Python and lightweight JavaScript runtimes are bundled in the core — so the artifact sizes and startup costs are not directly comparable.


### PR DESCRIPTION
## Summary
- Adds a **Performance > Benchmarks** section to the docs site with cross-runtime comparison data (gbash vs GNU bash, gbash-extras, gbash-node-wasm, just-bash)
- Benchmark data generated from `bench-compare` harness (50 runs on Apple M3 Max) with latency tables (min/median/p95) and artifact sizes
- Includes test environment details (machine model, chip, cores, memory, OS, Go version)
- Adds an `update-benchmarks` skill (`.agents/skills/`) for re-running this workflow in the future

## New files
- `website/content/performance/benchmarks.mdx` — page content
- `website/content/performance/benchmark-data.json` — transformed harness output
- `website/app/components/docs/BenchmarkChart.tsx` — renders environment info, latency tables, artifact sizes
- `.agents/skills/update-benchmarks/SKILL.md` — reusable skill for refreshing data

## Test plan
- [ ] `cd website && npm run build` succeeds and `/docs/performance/benchmarks` appears in route list
- [ ] Visual check of the page in browser
- [ ] Navigation sidebar shows Performance > Benchmarks