### PR TITLE
build: restrict Renovate to security updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "security:only-security-updates",
     "helpers:pinGitHubActionDigests"
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary
- switch Renovate from `config:recommended` to `security:only-security-updates`
- stop routine dependency upgrade PRs and keep vulnerability-driven updates enabled

## Testing
- not run (configuration-only change)