### PR TITLE
ci: build multi-platform compat Docker image (amd64 + arm64)

### DIFF
--- a/.github/workflows/compat-image.yml
+++ b/.github/workflows/compat-image.yml
@@ -31,6 +31,9 @@ jobs:
         id: go-version
         run: echo "value=$(awk '/^go / { print $2; exit }' go.mod)" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -56,7 +59,7 @@ jobs:
           context: .
           file: docker/compat/Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             GO_VERSION=${{ steps.go-version.outputs.value }}
           cache-from: type=gha,scope=compat-image

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GNU_CACHE_DIR ?= .cache/gnu
 GNU_RESULTS_DIR ?=
 COMPAT_DOCKER_IMAGE ?= gbash-compat-local
 COMPAT_DOCKER_BASE_IMAGE ?= ghcr.io/ewhauser/gbash-compat:latest
-COMPAT_DOCKER_PLATFORM ?= linux/amd64
+COMPAT_DOCKER_PLATFORM ?=
 COMPAT_DOCKER_PULL ?= always
 
 FUZZ_SMOKE_SHARD_CORE := \

--- a/scripts/compat-docker-build.sh
+++ b/scripts/compat-docker-build.sh
@@ -6,7 +6,7 @@ REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 
 IMAGE_NAME=${COMPAT_DOCKER_IMAGE:-gbash-compat-local}
 BASE_IMAGE=${COMPAT_DOCKER_BASE_IMAGE:-}
-PLATFORM=${COMPAT_DOCKER_PLATFORM:-linux/amd64}
+PLATFORM=${COMPAT_DOCKER_PLATFORM:-}
 PULL_MODE=${COMPAT_DOCKER_PULL:-0}
 GO_VERSION=${COMPAT_DOCKER_GO_VERSION:-$(awk '/^go / { print $2; exit }' "$REPO_ROOT/go.mod")}
 
@@ -17,11 +17,11 @@ sync_from_base_image() {
 
   case "$PULL_MODE" in
     1|true|TRUE|always)
-      docker pull --platform "$PLATFORM" "$BASE_IMAGE" || true
+      docker pull ${PLATFORM:+--platform "$PLATFORM"} "$BASE_IMAGE" || true
       ;;
     missing)
       if ! docker image inspect "$BASE_IMAGE" >/dev/null 2>&1; then
-        docker pull --platform "$PLATFORM" "$BASE_IMAGE" || return 1
+        docker pull ${PLATFORM:+--platform "$PLATFORM"} "$BASE_IMAGE" || return 1
       fi
       ;;
     0|false|FALSE|"")
@@ -43,8 +43,13 @@ if sync_from_base_image; then
   exit 0
 fi
 
+platform_args=()
+if [[ -n "$PLATFORM" ]]; then
+  platform_args=(--platform "$PLATFORM")
+fi
+
 exec docker build \
-  --platform "$PLATFORM" \
+  "${platform_args[@]}" \
   --build-arg "GO_VERSION=$GO_VERSION" \
   -t "$IMAGE_NAME" \
   -f "$REPO_ROOT/docker/compat/Dockerfile" \

--- a/scripts/compat-docker-run.sh
+++ b/scripts/compat-docker-run.sh
@@ -6,7 +6,7 @@ REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 
 IMAGE_NAME=${COMPAT_DOCKER_IMAGE:-gbash-compat-local}
 BASE_IMAGE=${COMPAT_DOCKER_BASE_IMAGE:-}
-PLATFORM=${COMPAT_DOCKER_PLATFORM:-linux/amd64}
+PLATFORM=${COMPAT_DOCKER_PLATFORM:-}
 PULL_MODE=${COMPAT_DOCKER_PULL:-0}
 GNU_CACHE_DIR=${GNU_CACHE_DIR:-.cache/gnu}
 GNU_RESULTS_DIR=${GNU_RESULTS_DIR:-.cache/gnu/results/docker-latest}
@@ -35,7 +35,7 @@ ensure_image() {
   if [[ -n "$BASE_IMAGE" ]]; then
     case "$PULL_MODE" in
       1|true|TRUE|always)
-        docker pull --platform "$PLATFORM" "$BASE_IMAGE" >/dev/null 2>&1 || true
+        docker pull ${PLATFORM:+--platform "$PLATFORM"} "$BASE_IMAGE" >/dev/null 2>&1 || true
         if docker image inspect "$BASE_IMAGE" >/dev/null 2>&1; then
           if [[ "$BASE_IMAGE" != "$IMAGE_NAME" ]]; then
             docker tag "$BASE_IMAGE" "$IMAGE_NAME"
@@ -47,7 +47,7 @@ ensure_image() {
   fi
   case "$PULL_MODE" in
     1|true|TRUE|always)
-      if docker pull --platform "$PLATFORM" "$IMAGE_NAME" >/dev/null 2>&1; then
+      if docker pull ${PLATFORM:+--platform "$PLATFORM"} "$IMAGE_NAME" >/dev/null 2>&1; then
         return
       fi
       ;;
@@ -59,7 +59,7 @@ ensure_image() {
     case "$PULL_MODE" in
       1|true|TRUE|always|missing)
         if [[ "$PULL_MODE" == "missing" ]] && ! docker image inspect "$BASE_IMAGE" >/dev/null 2>&1; then
-          docker pull --platform "$PLATFORM" "$BASE_IMAGE" || true
+          docker pull ${PLATFORM:+--platform "$PLATFORM"} "$BASE_IMAGE" || true
         fi
         if docker image inspect "$BASE_IMAGE" >/dev/null 2>&1; then
           if [[ "$BASE_IMAGE" != "$IMAGE_NAME" ]]; then
@@ -72,7 +72,7 @@ ensure_image() {
   fi
   case "$PULL_MODE" in
     1|true|TRUE|always|missing)
-      if docker pull --platform "$PLATFORM" "$IMAGE_NAME"; then
+      if docker pull ${PLATFORM:+--platform "$PLATFORM"} "$IMAGE_NAME"; then
         return
       fi
       ;;
@@ -96,7 +96,7 @@ mkdir -p \
 
 ensure_image
 
-docker run --rm --platform "$PLATFORM" \
+docker run --rm ${PLATFORM:+--platform "$PLATFORM"} \
   --user "$(id -u):$(id -g)" \
   -e HOME=/tmp/gbash-home \
   -e GOCACHE=/workspace/.cache/go-build \

--- a/scripts/gnu-test.sh
+++ b/scripts/gnu-test.sh
@@ -421,6 +421,16 @@ else
   : > "$log_path"
 fi
 
+for test_path in "${selected_tests[@]}"; do
+  test_base=$(test_base_from_path "$test_path")
+  test_log="$workdir/$test_base.log"
+  if [[ -f "$test_log" ]]; then
+    dest_dir="$GNU_RESULTS_DIR/${test_base%/*}"
+    mkdir -p "$dest_dir"
+    cp "$test_log" "$dest_dir/"
+  fi
+done
+
 if [[ "${GNU_KEEP_WORKDIR:-0}" == "1" ]]; then
   workdir=$(preserve_workdir "$workdir")
 fi
@@ -442,9 +452,25 @@ if [[ -f "$GNU_RESULTS_DIR/summary.json" ]]; then
   go run ./scripts/compat-report --summary "$GNU_RESULTS_DIR/summary.json" --output "$GNU_RESULTS_DIR"
 fi
 
+echo ""
 echo "results: $GNU_RESULTS_DIR"
+if [[ -f "$GNU_RESULTS_DIR/index.html" ]]; then
+  echo "report:  $GNU_RESULTS_DIR/index.html"
+fi
 if [[ "${GNU_KEEP_WORKDIR:-0}" == "1" ]]; then
   echo "workdir: $workdir"
+fi
+
+if [[ $summary_status -ne 0 ]]; then
+  echo ""
+  echo "failed tests:"
+  for test_path in "${selected_tests[@]}"; do
+    test_base=$(test_base_from_path "$test_path")
+    test_log="$GNU_RESULTS_DIR/$test_base.log"
+    if [[ -f "$test_log" ]] && grep -q "^FAIL: $test_path\$" "$log_path"; then
+      echo "  $test_path -> $test_log"
+    fi
+  done
 fi
 
 exit "$summary_status"


### PR DESCRIPTION
## Summary
- Build both `linux/amd64` and `linux/arm64` compat images in CI (adds QEMU setup step for cross-build)
- Default local scripts to native platform instead of forcing `linux/amd64`, eliminating QEMU emulation on Apple Silicon
- Platform can still be overridden via `COMPAT_DOCKER_PLATFORM` env var

## Test plan
- [ ] Verify `compat-image.yml` workflow builds and pushes both platform variants
- [ ] Run `make compat-docker-run GNU_UTILS=basenc` locally on Apple Silicon and confirm it uses the native arm64 image
- [ ] Verify `COMPAT_DOCKER_PLATFORM=linux/amd64` still forces x86_64 when needed