### PR TITLE
builtins: align rg with upstream just-bash

### DIFF
--- a/internal/builtins/rg.go
+++ b/internal/builtins/rg.go
@@ -1,28 +1,81 @@
 package builtins
 
 import (
-	"bufio"
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	stdfs "io/fs"
 	"path"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
+	"unicode"
 
-	"github.com/ewhauser/gbash/internal/commandutil"
 	"github.com/ewhauser/gbash/policy"
 )
 
 type RG struct{}
 
+type rgCaseMode int
+
+const (
+	rgCaseModeSmart rgCaseMode = iota
+	rgCaseModeIgnore
+	rgCaseModeSensitive
+)
+
 type rgOptions struct {
-	pattern    string
-	ignoreCase bool
-	lineNumber bool
-	count      bool
-	listFiles  bool
-	hidden     bool
-	listOnly   bool
-	globs      []string
+	caseMode            rgCaseMode
+	patterns            []string
+	patternFiles        []string
+	types               []string
+	typesNot            []string
+	typeAdd             []string
+	typeClear           []string
+	globs               []string
+	iglobs              []string
+	fixedStrings        bool
+	wordRegexp          bool
+	lineRegexp          bool
+	invert              bool
+	count               bool
+	listFiles           bool
+	filesWithoutMatch   bool
+	listOnly            bool
+	typeList            bool
+	hidden              bool
+	noIgnore            bool
+	noIgnoreDot         bool
+	noIgnoreVcs         bool
+	followSymlinks      bool
+	searchBinary        bool
+	onlyMatching        bool
+	quiet               bool
+	noFilename          bool
+	withFilename        bool
+	lineNumber          bool
+	explicitLineNumbers bool
+	globCaseInsensitive bool
+	sortPath            bool
+	maxCount            int
+	beforeContext       int
+	afterContext        int
+	maxDepth            int
+	unrestrictedCount   int
+}
+
+type rgCollectedFile struct {
+	abs     string
+	display string
+}
+
+type rgCollectResult struct {
+	files              []rgCollectedFile
+	hadError           bool
+	singleExplicitFile bool
 }
 
 func NewRG() *RG {
@@ -40,27 +93,79 @@ func (c *RG) Run(ctx context.Context, inv *Invocation) error {
 func (c *RG) Spec() CommandSpec {
 	return CommandSpec{
 		Name:  "rg",
-		About: "Search recursively for lines matching a pattern",
-		Usage: "rg [OPTIONS] PATTERN [PATH ...]\n       rg [OPTIONS] --files [PATH ...]",
+		About: "ripgrep-style recursive search",
+		Usage: "rg [OPTIONS] PATTERN [PATH ...]\n       rg [OPTIONS] --files [PATH ...]\n       rg --type-list",
 		Options: []OptionSpec{
-			{Name: "line-number", Short: 'n', Help: "show line numbers"},
-			{Name: "ignore-case", Short: 'i', Help: "case-insensitive search"},
-			{Name: "files-with-matches", Short: 'l', Help: "print only paths of files with matches"},
-			{Name: "count", Short: 'c', Help: "print only a count of matching lines per file"},
+			{Name: "line-number", Short: 'n', Long: "line-number", Help: "show line numbers"},
+			{Name: "no-line-number", Short: 'N', Long: "no-line-number", Help: "hide line numbers"},
+			{Name: "ignore-case", Short: 'i', Long: "ignore-case", Help: "case-insensitive search"},
+			{Name: "case-sensitive", Short: 's', Long: "case-sensitive", Help: "case-sensitive search"},
+			{Name: "smart-case", Short: 'S', Long: "smart-case", Help: "smart case search (default)"},
+			{Name: "fixed-strings", Short: 'F', Long: "fixed-strings", Help: "treat patterns as literal strings"},
+			{Name: "word-regexp", Short: 'w', Long: "word-regexp", Help: "show matches surrounded by word boundaries"},
+			{Name: "line-regexp", Short: 'x', Long: "line-regexp", Help: "show matches surrounded by line boundaries"},
+			{Name: "invert-match", Short: 'v', Long: "invert-match", Help: "invert matching"},
+			{Name: "regexp", Short: 'e', Long: "regexp", Arity: OptionRequiredValue, ValueName: "PATTERN", Repeatable: true, Help: "use PATTERN for matching"},
+			{Name: "file", Short: 'f', Long: "file", Arity: OptionRequiredValue, ValueName: "FILE", Repeatable: true, Help: "read patterns from FILE"},
+			{Name: "count", Short: 'c', Long: "count", Help: "print only a count of matching lines per file"},
+			{Name: "files-with-matches", Short: 'l', Long: "files-with-matches", Help: "print only paths with matches"},
+			{Name: "files-without-match", Long: "files-without-match", Help: "print only paths without matches"},
+			{Name: "files", Long: "files", Help: "print files that would be searched"},
+			{Name: "type-list", Long: "type-list", Help: "show all supported file types"},
+			{Name: "only-matching", Short: 'o', Long: "only-matching", Help: "show only the matching text"},
+			{Name: "quiet", Short: 'q', Long: "quiet", Help: "suppress output and stop after the first match"},
+			{Name: "no-filename", Long: "no-filename", Help: "never print the path with matches"},
+			{Name: "with-filename", Short: 'H', Long: "with-filename", Help: "always print the path with matches"},
 			{Name: "hidden", Long: "hidden", Help: "search hidden files and directories"},
-			{Name: "files", Long: "files", Help: "print matching files that would be searched, not matches"},
-			{Name: "glob", Short: 'g', Arity: OptionRequiredValue, ValueName: "GLOB", Repeatable: true, Help: "include or exclude files matching the given glob"},
+			{Name: "no-ignore", Long: "no-ignore", Help: "do not respect ignore files"},
+			{Name: "no-ignore-dot", Long: "no-ignore-dot", Help: "do not respect .ignore or .rgignore files"},
+			{Name: "no-ignore-vcs", Long: "no-ignore-vcs", Help: "do not respect .gitignore files"},
+			{Name: "glob", Short: 'g', Long: "glob", Arity: OptionRequiredValue, ValueName: "GLOB", Repeatable: true, Help: "include or exclude files matching GLOB"},
+			{Name: "iglob", Long: "iglob", Arity: OptionRequiredValue, ValueName: "GLOB", Repeatable: true, Help: "like --glob but case-insensitive"},
+			{Name: "glob-case-insensitive", Long: "glob-case-insensitive", Help: "make --glob matching case-insensitive"},
+			{Name: "max-count", Short: 'm', Long: "max-count", Arity: OptionRequiredValue, ValueName: "NUM", Help: "stop after NUM matching lines per file"},
+			{Name: "after-context", Short: 'A', Long: "after-context", Arity: OptionRequiredValue, ValueName: "NUM", Help: "show NUM lines after each match"},
+			{Name: "before-context", Short: 'B', Long: "before-context", Arity: OptionRequiredValue, ValueName: "NUM", Help: "show NUM lines before each match"},
+			{Name: "context", Short: 'C', Long: "context", Arity: OptionRequiredValue, ValueName: "NUM", Help: "show NUM lines before and after each match"},
+			{Name: "max-depth", Short: 'd', Long: "max-depth", Arity: OptionRequiredValue, ValueName: "NUM", Help: "descend at most NUM directories"},
+			{Name: "unrestricted", Short: 'u', Long: "unrestricted", Help: "reduce or disable smart filtering"},
+			{Name: "follow", Short: 'L', Long: "follow", Help: "follow symbolic links"},
+			{Name: "text", Short: 'a', Long: "text", Help: "search binary files as if they were text"},
+			{Name: "type", Short: 't', Long: "type", Arity: OptionRequiredValue, ValueName: "TYPE", Repeatable: true, Help: "only search files matching TYPE"},
+			{Name: "type-not", Short: 'T', Long: "type-not", Arity: OptionRequiredValue, ValueName: "TYPE", Repeatable: true, Help: "do not search files matching TYPE"},
+			{Name: "type-add", Long: "type-add", Arity: OptionRequiredValue, ValueName: "SPEC", Repeatable: true, Help: "add a file type definition"},
+			{Name: "type-clear", Long: "type-clear", Arity: OptionRequiredValue, ValueName: "TYPE", Repeatable: true, Help: "clear a file type definition"},
+			{Name: "sort", Long: "sort", Arity: OptionRequiredValue, ValueName: "SORTBY", Help: "sort paths by 'path' or leave them as 'none'"},
 		},
 		Args: []ArgSpec{
-			{Name: "args", ValueName: "ARG", Repeatable: true},
+			{Name: "arg", ValueName: "ARG", Repeatable: true},
 		},
 		Parse: ParseConfig{
 			GroupShortOptions:        true,
 			ShortOptionValueAttached: true,
 			LongOptionValueEquals:    true,
-			StopAtFirstPositional:    true,
+			AutoHelp:                 true,
 		},
 	}
+}
+
+func (c *RG) NormalizeParseError(inv *Invocation, err error) error {
+	if err == nil {
+		return nil
+	}
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		return err
+	}
+	message := strings.TrimSuffix(err.Error(), "\nTry 'rg --help' for more information.")
+	if message == err.Error() {
+		return err
+	}
+	trimmed := strings.TrimSuffix(message, "\n")
+	if inv != nil && inv.Stderr != nil {
+		_, _ = io.WriteString(inv.Stderr, trimmed+"\n")
+	}
+	return &ExitError{Code: exitErr.Code}
 }
 
 func (c *RG) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCommand) error {
@@ -68,78 +173,113 @@ func (c *RG) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 	if err != nil {
 		return err
 	}
+
+	if opts.typeList {
+		return rgWriteTypeList(inv)
+	}
+
+	patterns, err := rgLoadPatterns(ctx, inv, opts)
+	if err != nil {
+		return err
+	}
+	if !opts.listOnly && len(patterns) == 0 {
+		if len(opts.patternFiles) > 0 {
+			return &ExitError{Code: 1}
+		}
+		return exitf(inv, 2, "rg: no pattern given")
+	}
+
+	re, err := rgCompilePattern(patterns, opts)
+	if err != nil {
+		return exitf(inv, 2, "rg: invalid regex: %v", err)
+	}
+
+	typeRegistry := newRGTypeRegistry()
+	for _, name := range opts.typeClear {
+		typeRegistry.ClearType(name)
+	}
+	for _, spec := range opts.typeAdd {
+		typeRegistry.AddType(spec)
+	}
+
 	if len(roots) == 0 {
 		roots = []string{"."}
 	}
 
-	if opts.listOnly {
-		files, hadError, _, err := c.collectFiles(ctx, inv, roots, opts)
-		if err != nil {
-			return err
-		}
-		for _, file := range files {
-			if _, err := fmt.Fprintln(inv.Stdout, file); err != nil {
-				return &ExitError{Code: 1, Err: err}
-			}
-		}
-		if hadError {
-			return &ExitError{Code: 2}
-		}
-		return nil
+	var ignoreMatcher *rgIgnoreMatcher
+	if !opts.noIgnore {
+		ignoreMatcher = newRGIgnoreMatcher(opts)
 	}
 
-	re, err := compileGrepPattern(grepOptions{
-		pattern:    opts.pattern,
-		ignoreCase: opts.ignoreCase,
-	})
-	if err != nil {
-		return exitf(inv, 2, "rg: invalid pattern: %v", err)
-	}
-
-	files, hadError, anyDir, err := c.collectFiles(ctx, inv, roots, opts)
+	collectResult, err := c.collectFiles(ctx, inv, roots, opts, ignoreMatcher, typeRegistry)
 	if err != nil {
 		return err
 	}
 
-	matchedAny := false
-	showNames := len(files) > 1 || anyDir || len(roots) > 1
-	for _, file := range files {
-		if opts.listFiles {
-			matched, err := rgFileHasMatch(ctx, inv, re, file)
-			if err != nil {
-				return err
-			}
-			if !matched {
-				continue
-			}
-			matchedAny = true
-			if _, err := fmt.Fprintln(inv.Stdout, file); err != nil {
+	if opts.listOnly {
+		for _, file := range collectResult.files {
+			if _, err := fmt.Fprintln(inv.Stdout, file.display); err != nil {
 				return &ExitError{Code: 1, Err: err}
 			}
+		}
+		if collectResult.hadError {
+			return &ExitError{Code: 2}
+		}
+		if len(collectResult.files) == 0 {
+			return &ExitError{Code: 1}
+		}
+		return nil
+	}
+
+	grepOpts := grepOptions{
+		pattern:           strings.Join(patterns, "\n"),
+		ignoreCase:        rgDetermineIgnoreCase(opts, patterns),
+		lineNumber:        rgEffectiveLineNumbers(opts, collectResult.singleExplicitFile, len(collectResult.files)),
+		invert:            opts.invert,
+		count:             opts.count,
+		listFiles:         opts.listFiles,
+		filesWithoutMatch: opts.filesWithoutMatch,
+		wordRegexp:        opts.wordRegexp,
+		lineRegexp:        opts.lineRegexp,
+		fixedStrings:      opts.fixedStrings,
+		onlyMatching:      opts.onlyMatching,
+		quiet:             opts.quiet,
+		maxCount:          opts.maxCount,
+		beforeContext:     opts.beforeContext,
+		afterContext:      opts.afterContext,
+	}
+
+	showNames := !opts.noFilename && (opts.withFilename || !collectResult.singleExplicitFile || len(collectResult.files) > 1)
+	state := &grepRunState{}
+	for _, file := range collectResult.files {
+		data, _, err := readAllFile(ctx, inv, file.abs)
+		if err != nil {
+			return err
+		}
+		if !opts.searchBinary && rgLooksBinary(data) {
 			continue
 		}
-
-		data, _, err := readAllFile(ctx, inv, file)
-		if err != nil {
+		if err := writeGrepResult(inv, re, data, file.display, showNames, grepOpts, state); err != nil {
 			return err
 		}
-		matched, err := grepContent(inv, re, data, file, showNames, grepOptions{
-			pattern:    opts.pattern,
-			ignoreCase: opts.ignoreCase,
-			lineNumber: opts.lineNumber,
-			count:      opts.count,
-			listFiles:  opts.listFiles,
-		})
-		if err != nil {
-			return err
+		if state.quietMatched {
+			return nil
 		}
-		matchedAny = matchedAny || matched
 	}
 
-	if hadError {
+	if state.quietMatched {
+		return nil
+	}
+	if collectResult.hadError {
 		return &ExitError{Code: 2}
 	}
-	if matchedAny {
+	if opts.filesWithoutMatch {
+		if state.filesWithoutMatchAny {
+			return nil
+		}
+		return &ExitError{Code: 1}
+	}
+	if state.matchedAny {
 		return nil
 	}
 	return &ExitError{Code: 1}
@@ -147,121 +287,583 @@ func (c *RG) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 
 func parseRGMatches(inv *Invocation, matches *ParsedCommand) (rgOptions, []string, error) {
 	opts := rgOptions{
-		lineNumber: matches.Has("line-number"),
-		ignoreCase: matches.Has("ignore-case"),
-		count:      matches.Has("count"),
-		listFiles:  matches.Has("files-with-matches"),
-		hidden:     matches.Has("hidden"),
-		listOnly:   matches.Has("files"),
-		globs:      matches.Values("glob"),
+		caseMode: rgCaseModeSmart,
+		maxDepth: 256,
+		sortPath: true,
 	}
 
-	args := matches.Args("args")
-	if opts.listOnly {
+	valueIndex := map[string]int{}
+	valueAt := func(name string) string {
+		values := matches.Values(name)
+		idx := valueIndex[name]
+		if idx >= len(values) {
+			return ""
+		}
+		valueIndex[name] = idx + 1
+		return values[idx]
+	}
+
+	explicitA := -1
+	explicitB := -1
+	explicitC := -1
+
+	for _, name := range matches.OptionOrder() {
+		switch name {
+		case "line-number":
+			opts.lineNumber = true
+			opts.explicitLineNumbers = true
+		case "no-line-number":
+			opts.lineNumber = false
+			opts.explicitLineNumbers = true
+		case "ignore-case":
+			opts.caseMode = rgCaseModeIgnore
+		case "case-sensitive":
+			opts.caseMode = rgCaseModeSensitive
+		case "smart-case":
+			opts.caseMode = rgCaseModeSmart
+		case "fixed-strings":
+			opts.fixedStrings = true
+		case "word-regexp":
+			opts.wordRegexp = true
+		case "line-regexp":
+			opts.lineRegexp = true
+		case "invert-match":
+			opts.invert = true
+		case "regexp":
+			opts.patterns = append(opts.patterns, valueAt("regexp"))
+		case "file":
+			opts.patternFiles = append(opts.patternFiles, valueAt("file"))
+		case "count":
+			opts.count = true
+		case "files-with-matches":
+			opts.listFiles = true
+		case "files-without-match":
+			opts.filesWithoutMatch = true
+		case "files":
+			opts.listOnly = true
+		case "type-list":
+			opts.typeList = true
+		case "only-matching":
+			opts.onlyMatching = true
+		case "quiet":
+			opts.quiet = true
+		case "no-filename":
+			opts.noFilename = true
+			opts.withFilename = false
+		case "with-filename":
+			opts.withFilename = true
+			opts.noFilename = false
+		case "hidden":
+			opts.hidden = true
+		case "no-ignore":
+			opts.noIgnore = true
+		case "no-ignore-dot":
+			opts.noIgnoreDot = true
+		case "no-ignore-vcs":
+			opts.noIgnoreVcs = true
+		case "glob":
+			opts.globs = append(opts.globs, valueAt("glob"))
+		case "iglob":
+			opts.iglobs = append(opts.iglobs, valueAt("iglob"))
+		case "glob-case-insensitive":
+			opts.globCaseInsensitive = true
+		case "max-count":
+			value, err := parseRGFlagInt(valueAt("max-count"))
+			if err != nil {
+				return rgOptions{}, nil, exitf(inv, 2, "rg: invalid max count %q", matches.Value("max-count"))
+			}
+			opts.maxCount = value
+		case "after-context":
+			value, err := parseRGFlagInt(valueAt("after-context"))
+			if err != nil {
+				return rgOptions{}, nil, exitf(inv, 2, "rg: invalid context length %q", matches.Value("after-context"))
+			}
+			if value > explicitA {
+				explicitA = value
+			}
+		case "before-context":
+			value, err := parseRGFlagInt(valueAt("before-context"))
+			if err != nil {
+				return rgOptions{}, nil, exitf(inv, 2, "rg: invalid context length %q", matches.Value("before-context"))
+			}
+			if value > explicitB {
+				explicitB = value
+			}
+		case "context":
+			value, err := parseRGFlagInt(valueAt("context"))
+			if err != nil {
+				return rgOptions{}, nil, exitf(inv, 2, "rg: invalid context length %q", matches.Value("context"))
+			}
+			explicitC = value
+		case "max-depth":
+			value, err := parseRGFlagInt(valueAt("max-depth"))
+			if err != nil {
+				return rgOptions{}, nil, exitf(inv, 2, "rg: invalid maximum depth %q", matches.Value("max-depth"))
+			}
+			opts.maxDepth = value
+		case "unrestricted":
+			opts.unrestrictedCount++
+		case "follow":
+			opts.followSymlinks = true
+		case "text":
+			opts.searchBinary = true
+		case "type":
+			opts.types = append(opts.types, valueAt("type"))
+		case "type-not":
+			opts.typesNot = append(opts.typesNot, valueAt("type-not"))
+		case "type-add":
+			opts.typeAdd = append(opts.typeAdd, valueAt("type-add"))
+		case "type-clear":
+			opts.typeClear = append(opts.typeClear, valueAt("type-clear"))
+		case "sort":
+			switch valueAt("sort") {
+			case "path", "":
+				opts.sortPath = true
+			case "none":
+				opts.sortPath = false
+			default:
+				return rgOptions{}, nil, exitf(inv, 2, "rg: invalid sort mode %q", matches.Value("sort"))
+			}
+		}
+	}
+
+	if explicitA >= 0 || explicitC >= 0 {
+		opts.afterContext = max(explicitA, explicitC)
+	}
+	if explicitB >= 0 || explicitC >= 0 {
+		opts.beforeContext = max(explicitB, explicitC)
+	}
+
+	if opts.unrestrictedCount >= 1 {
+		opts.noIgnore = true
+	}
+	if opts.unrestrictedCount >= 2 {
+		opts.hidden = true
+	}
+	if opts.unrestrictedCount >= 3 {
+		opts.searchBinary = true
+	}
+
+	args := matches.Args("arg")
+	if opts.listOnly || opts.typeList {
 		return opts, args, nil
 	}
-	if len(args) == 0 {
-		return rgOptions{}, nil, exitf(inv, 2, "rg: missing pattern")
+	if len(opts.patterns) == 0 && len(opts.patternFiles) == 0 {
+		if len(args) == 0 {
+			return opts, nil, nil
+		}
+		opts.patterns = append(opts.patterns, args[0])
+		args = args[1:]
 	}
-	opts.pattern = args[0]
-	return opts, args[1:], nil
+	return opts, args, nil
 }
 
-func (c *RG) collectFiles(ctx context.Context, inv *Invocation, roots []string, opts rgOptions) (files []string, hadError, anyDir bool, err error) {
-	files = make([]string, 0)
+func parseRGFlagInt(value string) (int, error) {
+	number, err := strconv.Atoi(value)
+	if err != nil || number < 0 {
+		return 0, fmt.Errorf("invalid number")
+	}
+	return number, nil
+}
+
+func rgLoadPatterns(ctx context.Context, inv *Invocation, opts rgOptions) ([]string, error) {
+	patterns := append([]string(nil), opts.patterns...)
+	for _, name := range opts.patternFiles {
+		var data []byte
+		var err error
+		if name == "-" {
+			data, err = readAllStdin(ctx, inv)
+		} else {
+			data, _, err = readAllFile(ctx, inv, name)
+		}
+		if err != nil {
+			return nil, exitf(inv, 2, "rg: %s: %s", name, readAllErrorText(err))
+		}
+		for _, line := range textLines(data) {
+			if line == "" {
+				continue
+			}
+			patterns = append(patterns, line)
+		}
+	}
+	return patterns, nil
+}
+
+func rgCompilePattern(patterns []string, opts rgOptions) (*regexp.Regexp, error) {
+	ignoreCase := rgDetermineIgnoreCase(opts, patterns)
+	pattern := ""
+	switch {
+	case len(patterns) == 0:
+		pattern = ""
+	case opts.fixedStrings:
+		pattern = strings.Join(patterns, "\n")
+	case len(patterns) == 1:
+		pattern = patterns[0]
+	default:
+		parts := make([]string, 0, len(patterns))
+		for _, item := range patterns {
+			parts = append(parts, "(?:"+item+")")
+		}
+		pattern = strings.Join(parts, "|")
+	}
+	return compileGrepPattern(grepOptions{
+		pattern:      pattern,
+		ignoreCase:   ignoreCase,
+		wordRegexp:   opts.wordRegexp,
+		lineRegexp:   opts.lineRegexp,
+		fixedStrings: opts.fixedStrings,
+	})
+}
+
+func rgDetermineIgnoreCase(opts rgOptions, patterns []string) bool {
+	switch opts.caseMode {
+	case rgCaseModeIgnore:
+		return true
+	case rgCaseModeSensitive:
+		return false
+	default:
+		for _, pattern := range patterns {
+			for _, r := range pattern {
+				if unicode.IsUpper(r) {
+					return false
+				}
+			}
+		}
+		return true
+	}
+}
+
+func rgEffectiveLineNumbers(opts rgOptions, singleExplicitFile bool, fileCount int) bool {
+	if opts.explicitLineNumbers {
+		return opts.lineNumber
+	}
+	if opts.onlyMatching {
+		return false
+	}
+	return !(singleExplicitFile && fileCount == 1)
+}
+
+func rgLooksBinary(data []byte) bool {
+	return bytes.IndexByte(data, 0) >= 0
+}
+
+func (c *RG) collectFiles(ctx context.Context, inv *Invocation, roots []string, opts rgOptions, ignoreMatcher *rgIgnoreMatcher, typeRegistry *rgTypeRegistry) (rgCollectResult, error) {
+	result := rgCollectResult{
+		files: make([]rgCollectedFile, 0),
+	}
+
+	explicitFileCount := 0
+	directoryCount := 0
 	for _, root := range roots {
 		info, abs, exists, err := statMaybe(ctx, inv, policy.FileActionStat, root)
 		if err != nil {
-			return nil, false, false, err
+			return rgCollectResult{}, err
 		}
 		if !exists {
 			_, _ = fmt.Fprintf(inv.Stderr, "rg: %s: No such file or directory\n", root)
-			hadError = true
+			result.hadError = true
 			continue
 		}
+		if ignoreMatcher != nil {
+			if err := ignoreMatcher.loadPath(ctx, inv, abs); err != nil {
+				return rgCollectResult{}, err
+			}
+		}
 		if !info.IsDir() {
-			if c.includeFile(path.Base(abs), abs, abs, opts) {
-				files = append(files, abs)
+			explicitFileCount++
+			display := rgDisplayExplicitRoot(inv, root, abs)
+			if c.includeFile(display, abs, opts, ignoreMatcher, typeRegistry) {
+				result.files = append(result.files, rgCollectedFile{abs: abs, display: display})
 			}
 			continue
 		}
-		anyDir = true
-		if err := c.walkRoot(ctx, inv, abs, abs, opts, &files); err != nil {
-			return nil, false, false, err
+		directoryCount++
+		if err := c.walkRoot(ctx, inv, rgWalkState{
+			rootAbs:      abs,
+			prefix:       rgDisplayDirRoot(root),
+			depth:        0,
+			opts:         opts,
+			ignore:       ignoreMatcher,
+			typeRegistry: typeRegistry,
+		}, &result.files); err != nil {
+			return rgCollectResult{}, err
 		}
 	}
-	return files, hadError, anyDir, nil
+
+	if opts.sortPath {
+		sort.Slice(result.files, func(i, j int) bool {
+			return result.files[i].display < result.files[j].display
+		})
+	}
+	result.singleExplicitFile = explicitFileCount == 1 && directoryCount == 0
+	return result, nil
 }
 
-func (c *RG) walkRoot(ctx context.Context, inv *Invocation, rootAbs, currentAbs string, opts rgOptions, files *[]string) error {
-	entries, _, err := readDir(ctx, inv, currentAbs)
+type rgWalkState struct {
+	rootAbs      string
+	prefix       string
+	depth        int
+	opts         rgOptions
+	ignore       *rgIgnoreMatcher
+	typeRegistry *rgTypeRegistry
+}
+
+func (c *RG) walkRoot(ctx context.Context, inv *Invocation, state rgWalkState, files *[]rgCollectedFile) error {
+	if state.depth >= state.opts.maxDepth {
+		return nil
+	}
+	if state.ignore != nil {
+		if err := state.ignore.loadPath(ctx, inv, state.rootAbs); err != nil {
+			return err
+		}
+	}
+
+	entries, _, err := readDir(ctx, inv, state.rootAbs)
 	if err != nil {
 		return err
 	}
 	for _, entry := range entries {
 		name := entry.Name()
-		if !opts.hidden && strings.HasPrefix(name, ".") {
+		if state.ignore != nil && !state.opts.noIgnore && rgIsCommonIgnoredDir(name) {
 			continue
 		}
-		child := joinChildPath(currentAbs, name)
-		info, err := entry.Info()
+
+		childAbs := joinChildPath(state.rootAbs, name)
+		display := name
+		if state.prefix != "" {
+			display = state.prefix + "/" + name
+		}
+
+		linfo, _, err := lstatPath(ctx, inv, childAbs)
 		if err != nil {
-			info, _, err = statPath(ctx, inv, child)
+			return err
+		}
+		isSymlink := linfo.Mode()&stdfs.ModeSymlink != 0
+		if isSymlink && !state.opts.followSymlinks {
+			continue
+		}
+
+		info := linfo
+		if isSymlink {
+			info, _, err = statPath(ctx, inv, childAbs)
 			if err != nil {
-				return err
+				continue
 			}
 		}
-		if info.IsDir() {
-			if err := c.walkRoot(ctx, inv, rootAbs, child, opts, files); err != nil {
+
+		isDir := info.IsDir()
+		if state.ignore != nil && state.ignore.matches(childAbs, isDir) {
+			continue
+		}
+		if !state.opts.hidden && strings.HasPrefix(name, ".") && !(state.ignore != nil && state.ignore.whitelisted(childAbs, isDir)) {
+			continue
+		}
+
+		if isDir {
+			next := state
+			next.rootAbs = childAbs
+			next.prefix = display
+			next.depth++
+			if err := c.walkRoot(ctx, inv, next, files); err != nil {
 				return err
 			}
 			continue
 		}
-		if c.includeFile(name, child, rootAbs, opts) {
-			*files = append(*files, child)
+
+		if c.includeFile(display, childAbs, state.opts, state.ignore, state.typeRegistry) {
+			*files = append(*files, rgCollectedFile{abs: childAbs, display: display})
 		}
 	}
 	return nil
 }
 
-func (c *RG) includeFile(name, abs, rootAbs string, opts rgOptions) bool {
-	if len(opts.globs) == 0 {
-		return true
+func (c *RG) includeFile(display, abs string, opts rgOptions, ignoreMatcher *rgIgnoreMatcher, typeRegistry *rgTypeRegistry) bool {
+	if ignoreMatcher != nil && ignoreMatcher.matches(abs, false) {
+		return false
 	}
-	rel := strings.TrimPrefix(abs, rootAbs)
-	rel = strings.TrimPrefix(rel, "/")
-	for _, glob := range opts.globs {
-		if matched, _ := path.Match(glob, name); matched {
-			return true
-		}
-		if rel != "" {
-			if matched, _ := path.Match(glob, rel); matched {
-				return true
-			}
-		}
+
+	filename := path.Base(display)
+	if len(opts.types) > 0 && !typeRegistry.MatchesType(filename, opts.types) {
+		return false
 	}
-	return false
+	if len(opts.typesNot) > 0 && typeRegistry.MatchesType(filename, opts.typesNot) {
+		return false
+	}
+
+	if !rgMatchGlobSet(display, filename, opts.globs, opts.globCaseInsensitive) {
+		return false
+	}
+	if !rgMatchGlobSet(display, filename, opts.iglobs, true) {
+		return false
+	}
+	return true
 }
 
-func rgFileHasMatch(ctx context.Context, inv *Invocation, re *regexp.Regexp, name string) (bool, error) {
-	file, _, err := openRead(ctx, inv, name)
+func rgMatchGlobSet(display, filename string, globs []string, ignoreCase bool) bool {
+	if len(globs) == 0 {
+		return true
+	}
+	positive := make([]string, 0, len(globs))
+	negative := make([]string, 0, len(globs))
+	for _, glob := range globs {
+		trimmed := glob
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "!") {
+			negative = append(negative, strings.TrimPrefix(trimmed, "!"))
+			continue
+		}
+		positive = append(positive, trimmed)
+	}
+
+	if len(positive) > 0 {
+		matched := false
+		for _, glob := range positive {
+			ok, _ := rgMatchGlob(filename, glob, ignoreCase)
+			if !ok && !strings.HasPrefix(glob, "/") {
+				ok, _ = rgMatchGlob(display, glob, ignoreCase)
+			}
+			if strings.HasPrefix(glob, "/") {
+				ok, _ = rgMatchGlob(display, strings.TrimPrefix(glob, "/"), ignoreCase)
+			}
+			if ok {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	for _, glob := range negative {
+		ok, _ := rgMatchGlob(filename, glob, ignoreCase)
+		if !ok && !strings.HasPrefix(glob, "/") {
+			ok, _ = rgMatchGlob(display, glob, ignoreCase)
+		}
+		if strings.HasPrefix(glob, "/") {
+			ok, _ = rgMatchGlob(display, strings.TrimPrefix(glob, "/"), ignoreCase)
+		}
+		if ok {
+			return false
+		}
+	}
+	return true
+}
+
+func rgMatchGlob(value, glob string, ignoreCase bool) (bool, error) {
+	re, err := rgGlobRegexp(glob, ignoreCase)
 	if err != nil {
 		return false, err
 	}
-	defer func() { _ = file.Close() }()
+	return re.MatchString(value), nil
+}
 
-	scanner := bufio.NewScanner(file)
-	var buf [4 * 1024]byte
-	scanner.Buffer(buf[:], commandutil.ScannerTokenLimit(inv.Limits.MaxFileBytes))
-	for scanner.Scan() {
-		if re.Match(scanner.Bytes()) {
-			return true, nil
+func rgGlobRegexp(glob string, ignoreCase bool) (*regexp.Regexp, error) {
+	var b strings.Builder
+	if ignoreCase {
+		b.WriteString("(?i)")
+	}
+	b.WriteString("^")
+	for i := 0; i < len(glob); i++ {
+		switch glob[i] {
+		case '*':
+			if i+1 < len(glob) && glob[i+1] == '*' {
+				b.WriteString(".*")
+				i++
+				continue
+			}
+			b.WriteString("[^/]*")
+		case '?':
+			b.WriteString("[^/]")
+		case '[':
+			j := i + 1
+			if j < len(glob) && glob[j] == '!' {
+				j++
+			}
+			if j < len(glob) && glob[j] == ']' {
+				j++
+			}
+			for j < len(glob) && glob[j] != ']' {
+				j++
+			}
+			if j >= len(glob) {
+				return nil, fmt.Errorf("unclosed character class")
+			}
+			class := glob[i : j+1]
+			if strings.HasPrefix(class, "[!") {
+				class = "[^" + class[2:]
+			}
+			b.WriteString(class)
+			i = j
+		default:
+			b.WriteString(regexp.QuoteMeta(string(glob[i])))
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return false, &ExitError{Code: 1, Err: err}
+	b.WriteString("$")
+	return regexp.Compile(b.String())
+}
+
+func rgDisplayExplicitRoot(inv *Invocation, root, abs string) string {
+	if root == "" {
+		root = abs
 	}
-	return false, nil
+	cleaned := path.Clean(root)
+	if cleaned == "." {
+		if rel := rgRelativeToCwd(inv, abs); rel != "" && rel != "." {
+			return rel
+		}
+	}
+	return cleaned
+}
+
+func rgDisplayDirRoot(root string) string {
+	cleaned := path.Clean(root)
+	switch cleaned {
+	case "", ".":
+		return ""
+	default:
+		return cleaned
+	}
+}
+
+func rgRelativeToCwd(inv *Invocation, abs string) string {
+	if inv == nil || inv.FS == nil {
+		return abs
+	}
+	cwd := inv.FS.Getwd()
+	if abs == cwd {
+		return "."
+	}
+	prefix := cwd
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	if strings.HasPrefix(abs, prefix) {
+		return strings.TrimPrefix(abs, prefix)
+	}
+	return abs
+}
+
+func rgIsCommonIgnoredDir(name string) bool {
+	switch name {
+	case ".git", ".hg", ".svn", "node_modules", "__pycache__", ".pytest_cache", ".mypy_cache", "venv", ".venv", ".next", ".nuxt", ".cargo":
+		return true
+	default:
+		return false
+	}
+}
+
+func rgWriteTypeList(inv *Invocation) error {
+	output := formatRGTypeList()
+	if _, err := io.WriteString(inv.Stdout, output); err != nil {
+		return &ExitError{Code: 1, Err: err}
+	}
+	return nil
 }
 
 var _ Command = (*RG)(nil)
+var _ SpecProvider = (*RG)(nil)
+var _ ParsedRunner = (*RG)(nil)
+var _ ParseErrorNormalizer = (*RG)(nil)

--- a/internal/builtins/rg_ignore.go
+++ b/internal/builtins/rg_ignore.go
@@ -1,0 +1,212 @@
+package builtins
+
+import (
+	"context"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/ewhauser/gbash/policy"
+)
+
+type rgIgnoreRule struct {
+	base          string
+	regex         *regexp.Regexp
+	negated       bool
+	directoryOnly bool
+}
+
+type rgIgnoreMatcher struct {
+	opts   rgOptions
+	rules  []rgIgnoreRule
+	loaded map[string]bool
+}
+
+func newRGIgnoreMatcher(opts rgOptions) *rgIgnoreMatcher {
+	return &rgIgnoreMatcher{
+		opts:   opts,
+		loaded: make(map[string]bool),
+	}
+}
+
+func (m *rgIgnoreMatcher) loadPath(ctx context.Context, inv *Invocation, targetAbs string) error {
+	if m == nil {
+		return nil
+	}
+	current := targetAbs
+	info, _, exists, err := lstatMaybe(ctx, inv, policy.FileActionLstat, targetAbs)
+	if err != nil {
+		return err
+	}
+	if exists && info != nil && !info.IsDir() {
+		current = path.Dir(targetAbs)
+	}
+
+	dirs := make([]string, 0)
+	for {
+		dirs = append(dirs, current)
+		if current == "/" {
+			break
+		}
+		current = path.Dir(current)
+	}
+	for i := len(dirs) - 1; i >= 0; i-- {
+		if err := m.loadDir(ctx, inv, dirs[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *rgIgnoreMatcher) loadDir(ctx context.Context, inv *Invocation, dir string) error {
+	if m == nil || m.loaded[dir] {
+		return nil
+	}
+	m.loaded[dir] = true
+
+	names := make([]string, 0, 3)
+	if !m.opts.noIgnoreVcs {
+		names = append(names, ".gitignore")
+	}
+	if !m.opts.noIgnoreDot {
+		names = append(names, ".rgignore", ".ignore")
+	}
+	for _, name := range names {
+		ignorePath := path.Join(dir, name)
+		data, _, err := readAllFile(ctx, inv, ignorePath)
+		if err != nil {
+			if errorsIsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		m.parse(dir, string(data))
+	}
+	return nil
+}
+
+func (m *rgIgnoreMatcher) parse(base, content string) {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimRight(line, " \t\r")
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		negated := false
+		if strings.HasPrefix(trimmed, "!") {
+			negated = true
+			trimmed = strings.TrimPrefix(trimmed, "!")
+		}
+
+		directoryOnly := false
+		if strings.HasSuffix(trimmed, "/") {
+			directoryOnly = true
+			trimmed = strings.TrimSuffix(trimmed, "/")
+		}
+		if trimmed == "" {
+			continue
+		}
+
+		rooted := false
+		if strings.HasPrefix(trimmed, "/") {
+			rooted = true
+			trimmed = strings.TrimPrefix(trimmed, "/")
+		} else if strings.Contains(trimmed, "/") && !strings.HasPrefix(trimmed, "**/") {
+			rooted = true
+		}
+
+		re, err := rgIgnorePatternRegexp(trimmed, rooted)
+		if err != nil {
+			continue
+		}
+		m.rules = append(m.rules, rgIgnoreRule{
+			base:          base,
+			regex:         re,
+			negated:       negated,
+			directoryOnly: directoryOnly,
+		})
+	}
+}
+
+func rgIgnorePatternRegexp(pattern string, rooted bool) (*regexp.Regexp, error) {
+	var b strings.Builder
+	b.WriteString("^")
+	if !rooted {
+		b.WriteString("(?:|.*/)")
+	}
+	for i := 0; i < len(pattern); i++ {
+		switch pattern[i] {
+		case '*':
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				if i+2 < len(pattern) && pattern[i+2] == '/' {
+					b.WriteString("(?:.*/)?")
+					i += 2
+					continue
+				}
+				b.WriteString(".*")
+				i++
+				continue
+			}
+			b.WriteString("[^/]*")
+		case '?':
+			b.WriteString("[^/]")
+		case '[':
+			j := i + 1
+			if j < len(pattern) && pattern[j] == '!' {
+				j++
+			}
+			if j < len(pattern) && pattern[j] == ']' {
+				j++
+			}
+			for j < len(pattern) && pattern[j] != ']' {
+				j++
+			}
+			if j >= len(pattern) {
+				b.WriteString(`\[`)
+				continue
+			}
+			class := pattern[i : j+1]
+			if strings.HasPrefix(class, "[!") {
+				class = "[^" + class[2:]
+			}
+			b.WriteString(class)
+			i = j
+		default:
+			b.WriteString(regexp.QuoteMeta(string(pattern[i])))
+		}
+	}
+	b.WriteString("(?:/.*)?$")
+	return regexp.Compile(b.String())
+}
+
+func (m *rgIgnoreMatcher) matches(abs string, isDir bool) bool {
+	_, ignored, _ := m.state(abs, isDir)
+	return ignored
+}
+
+func (m *rgIgnoreMatcher) whitelisted(abs string, isDir bool) bool {
+	_, ignored, negated := m.state(abs, isDir)
+	return !ignored && negated
+}
+
+func (m *rgIgnoreMatcher) state(abs string, isDir bool) (matched, ignored, negated bool) {
+	if m == nil {
+		return false, false, false
+	}
+	for _, rule := range m.rules {
+		if !strings.HasPrefix(abs, rule.base) {
+			continue
+		}
+		rel := strings.TrimPrefix(abs, rule.base)
+		rel = strings.TrimPrefix(rel, "/")
+		if rule.directoryOnly && !isDir {
+			continue
+		}
+		if rule.regex.MatchString(rel) {
+			matched = true
+			ignored = !rule.negated
+			negated = rule.negated
+		}
+	}
+	return matched, ignored, negated
+}

--- a/internal/builtins/rg_test.go
+++ b/internal/builtins/rg_test.go
@@ -2,14 +2,17 @@ package builtins_test
 
 import (
 	"context"
+	"strings"
 	"testing"
+
+	"github.com/ewhauser/gbash/policy"
 )
 
-func TestRGSearchesRecursivelyWithGlobFilter(t *testing.T) {
+func TestRGBasicSearchMatchesUpstreamDefaults(t *testing.T) {
 	rt := newRuntime(t, &Config{})
 
 	result, err := rt.Run(context.Background(), &ExecutionRequest{
-		Script: "mkdir -p dir/sub\nprintf 'needle\\n' > dir/a.txt\nprintf 'needle\\n' > dir/sub/b.md\nprintf 'needle\\n' > dir/.hidden.txt\nrg -n -g '*.txt' needle dir\n",
+		Script: "printf 'Hello\\nhello\\n' > a.txt\nprintf 'hello\\n' > b.txt\nrg hello\n",
 	})
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
@@ -17,16 +20,16 @@ func TestRGSearchesRecursivelyWithGlobFilter(t *testing.T) {
 	if result.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
 	}
-	if got, want := result.Stdout, "/home/agent/dir/a.txt:1:needle\n"; got != want {
+	if got, want := result.Stdout, "a.txt:1:Hello\na.txt:2:hello\nb.txt:1:hello\n"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }
 
-func TestRGHiddenModeIncludesDotfiles(t *testing.T) {
+func TestRGSingleExplicitFileSuppressesPrefixesByDefault(t *testing.T) {
 	rt := newRuntime(t, &Config{})
 
 	result, err := rt.Run(context.Background(), &ExecutionRequest{
-		Script: "mkdir -p dir\nprintf 'needle\\n' > dir/.hidden.txt\nrg --hidden -n needle dir\n",
+		Script: "printf 'needle\\n' > file.txt\nrg needle file.txt\n",
 	})
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
@@ -34,7 +37,265 @@ func TestRGHiddenModeIncludesDotfiles(t *testing.T) {
 	if result.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
 	}
-	if got, want := result.Stdout, "/home/agent/dir/.hidden.txt:1:needle\n"; got != want {
+	if got, want := result.Stdout, "needle\n"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRGSupportsSmartCaseAndCaseFlags(t *testing.T) {
+	session := newSession(t, &Config{})
+	mustExecSession(t, session, "printf 'Hello\\nhello\\n' > file.txt\n")
+
+	upper := mustExecSession(t, session, "rg Hello file.txt\n")
+	if got, want := upper.Stdout, "Hello\n"; got != want {
+		t.Fatalf("uppercase smart-case stdout = %q, want %q", got, want)
+	}
+
+	ignoreCase := mustExecSession(t, session, "rg -i Hello file.txt\n")
+	if got, want := ignoreCase.Stdout, "Hello\nhello\n"; got != want {
+		t.Fatalf("-i stdout = %q, want %q", got, want)
+	}
+
+	caseSensitive := mustExecSession(t, session, "rg -s hello file.txt\n")
+	if got, want := caseSensitive.Stdout, "hello\n"; got != want {
+		t.Fatalf("-s stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRGHiddenIgnoreAndUnrestrictedModes(t *testing.T) {
+	session := newSession(t, &Config{})
+	mustExecSession(t, session, ""+
+		"printf '*.log\\n' > .gitignore\n"+
+		"printf 'needle\\n' > app.ts\n"+
+		"printf 'needle\\n' > debug.log\n"+
+		"printf 'needle\\n' > .hidden.txt\n")
+
+	defaultSearch := mustExecSession(t, session, "rg needle\n")
+	if got, want := defaultSearch.Stdout, "app.ts:1:needle\n"; got != want {
+		t.Fatalf("default stdout = %q, want %q", got, want)
+	}
+
+	noIgnore := mustExecSession(t, session, "rg --no-ignore needle\n")
+	if got, want := noIgnore.Stdout, "app.ts:1:needle\ndebug.log:1:needle\n"; got != want {
+		t.Fatalf("--no-ignore stdout = %q, want %q", got, want)
+	}
+
+	unrestricted := mustExecSession(t, session, "rg -uu needle\n")
+	if got, want := unrestricted.Stdout, ".hidden.txt:1:needle\napp.ts:1:needle\ndebug.log:1:needle\n"; got != want {
+		t.Fatalf("-uu stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRGSupportsGlobFilteringAndFilesMode(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "" +
+			"printf 'foo\\n' > app.ts\n" +
+			"printf 'foo\\n' > test.ts\n" +
+			"printf 'foo\\n' > app.js\n" +
+			"rg -g '*.ts' -g '!test.ts' foo\n" +
+			"printf '%s' $?\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "app.ts:1:foo\n0"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+
+	files, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "" +
+			"printf 'foo\\n' > a.txt\n" +
+			"printf 'foo\\n' > b.md\n" +
+			"rg --files -g '*.txt'\n",
+	})
+	if err != nil {
+		t.Fatalf("Run(files) error = %v", err)
+	}
+	if got, want := files.Stdout, "a.txt\n"; got != want {
+		t.Fatalf("--files stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRGSupportsMaxDepth(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "" +
+			"printf 'hello\\n' > level0.txt\n" +
+			"mkdir -p dir1/dir2\n" +
+			"printf 'hello\\n' > dir1/level1.txt\n" +
+			"printf 'hello\\n' > dir1/dir2/level2.txt\n" +
+			"rg --max-depth 2 hello\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "dir1/level1.txt:1:hello\nlevel0.txt:1:hello\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRGSupportsOutputModesAndContext(t *testing.T) {
+	session := newSession(t, &Config{})
+	mustExecSession(t, session, ""+
+		"printf 'alpha\\nhello\\nbravo\\n' > a.txt\n"+
+		"printf 'world\\n' > b.txt\n"+
+		"printf '123 456\\n' > digits.txt\n")
+
+	listFiles := mustExecSession(t, session, "rg -l hello\n")
+	if got, want := listFiles.Stdout, "a.txt\n"; got != want {
+		t.Fatalf("-l stdout = %q, want %q", got, want)
+	}
+
+	filesWithout := mustExecSession(t, session, "rg --files-without-match hello\n")
+	if got, want := filesWithout.Stdout, "b.txt\ndigits.txt\n"; got != want {
+		t.Fatalf("--files-without-match stdout = %q, want %q", got, want)
+	}
+
+	onlyMatching := mustExecSession(t, session, "rg -o '[0-9]+'\n")
+	if got, want := onlyMatching.Stdout, "digits.txt:123\ndigits.txt:456\n"; got != want {
+		t.Fatalf("-o stdout = %q, want %q", got, want)
+	}
+
+	contextSearch := mustExecSession(t, session, "rg -C1 hello\n")
+	if got, want := contextSearch.Stdout, "a.txt-1-alpha\na.txt:2:hello\na.txt-3-bravo\n"; got != want {
+		t.Fatalf("-C stdout = %q, want %q", got, want)
+	}
+
+	quiet := mustExecSession(t, session, "rg -q hello\n")
+	if quiet.ExitCode != 0 || quiet.Stdout != "" || quiet.Stderr != "" {
+		t.Fatalf("-q result = %+v, want exit 0 with empty output", quiet)
+	}
+}
+
+func TestRGSupportsMatchModeFlagsAndMaxCount(t *testing.T) {
+	session := newSession(t, &Config{})
+	mustExecSession(t, session, ""+
+		"printf 'a.c\\nabc\\n' > fixed.txt\n"+
+		"printf 'foo\\nfoobar\\n' > words.txt\n"+
+		"printf 'foo\\nfoo bar\\n' > lines.txt\n"+
+		"printf 'hit\\nmiss\\nhit\\n' > invert.txt\n"+
+		"printf 'hit\\nhit\\nhit\\n' > count.txt\n")
+
+	fixed := mustExecSession(t, session, "rg -F 'a.c' fixed.txt\n")
+	if got, want := fixed.Stdout, "a.c\n"; got != want {
+		t.Fatalf("-F stdout = %q, want %q", got, want)
+	}
+
+	word := mustExecSession(t, session, "rg -w foo words.txt\n")
+	if got, want := word.Stdout, "foo\n"; got != want {
+		t.Fatalf("-w stdout = %q, want %q", got, want)
+	}
+
+	line := mustExecSession(t, session, "rg -x foo lines.txt\n")
+	if got, want := line.Stdout, "foo\n"; got != want {
+		t.Fatalf("-x stdout = %q, want %q", got, want)
+	}
+
+	invert := mustExecSession(t, session, "rg -v hit invert.txt\n")
+	if got, want := invert.Stdout, "miss\n"; got != want {
+		t.Fatalf("-v stdout = %q, want %q", got, want)
+	}
+
+	maxCount := mustExecSession(t, session, "rg -m1 hit count.txt\n")
+	if got, want := maxCount.Stdout, "hit\n"; got != want {
+		t.Fatalf("-m stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRGSupportsPatternFilesFilenameFlagsAndIglob(t *testing.T) {
+	session := newSession(t, &Config{})
+	mustExecSession(t, session, ""+
+		"printf 'foo\\nbar\\n' > patterns.txt\n"+
+		"printf 'foo\\nbar\\nbaz\\n' > data.txt\n"+
+		"printf 'hello\\n' > APP.TS\n"+
+		"printf 'hello\\n' > app.js\n")
+
+	patternFile := mustExecSession(t, session, "rg -f patterns.txt data.txt\n")
+	if got, want := patternFile.Stdout, "foo\nbar\n"; got != want {
+		t.Fatalf("-f stdout = %q, want %q", got, want)
+	}
+
+	withFilename := mustExecSession(t, session, "rg -H -N hello APP.TS\n")
+	if got, want := withFilename.Stdout, "APP.TS:hello\n"; got != want {
+		t.Fatalf("-H -N stdout = %q, want %q", got, want)
+	}
+
+	iglob := mustExecSession(t, session, "rg --iglob '*.ts' hello\n")
+	if got, want := iglob.Stdout, "APP.TS:1:hello\n"; got != want {
+		t.Fatalf("--iglob stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRGSupportsTypeFilteringAndTypeList(t *testing.T) {
+	session := newSession(t, &Config{})
+	mustExecSession(t, session, ""+
+		"printf 'foo\\n' > app.ts\n"+
+		"printf 'foo\\n' > app.js\n")
+
+	typeOnly := mustExecSession(t, session, "rg -t ts foo\n")
+	if got, want := typeOnly.Stdout, "app.ts:1:foo\n"; got != want {
+		t.Fatalf("-t stdout = %q, want %q", got, want)
+	}
+
+	typeExclude := mustExecSession(t, session, "rg -T ts foo\n")
+	if got, want := typeExclude.Stdout, "app.js:1:foo\n"; got != want {
+		t.Fatalf("-T stdout = %q, want %q", got, want)
+	}
+
+	typeList := mustExecSession(t, session, "rg --type-list\n")
+	if typeList.ExitCode != 0 {
+		t.Fatalf("--type-list exit = %d, want 0; stderr=%q", typeList.ExitCode, typeList.Stderr)
+	}
+	for _, want := range []string{"js: *.js", "ts: *.ts", "py: *.py"} {
+		if !strings.Contains(typeList.Stdout, want) {
+			t.Fatalf("--type-list stdout = %q, want substring %q", typeList.Stdout, want)
+		}
+	}
+}
+
+func TestRGSupportsBinaryFilesAndFollowLinks(t *testing.T) {
+	session := newSession(t, &Config{})
+	mustExecSession(t, session, ""+
+		"printf 'hello\\000world\\n' > binary.bin\n"+
+		"printf 'hello\\n' > real.txt\n")
+
+	defaultBinary := mustExecSession(t, session, "rg hello binary.bin\n")
+	if defaultBinary.ExitCode != 1 || defaultBinary.Stdout != "" {
+		t.Fatalf("default binary result = %+v, want exit 1 and empty stdout", defaultBinary)
+	}
+
+	textBinary := mustExecSession(t, session, "rg -a hello binary.bin\n")
+	if got, want := textBinary.Stdout, "hello\x00world\n"; got != want {
+		t.Fatalf("-a stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRGFollowLinksHonorsFollowEnabledPolicy(t *testing.T) {
+	session := newSession(t, &Config{
+		Policy: policy.NewStatic(&policy.Config{
+			SymlinkMode: policy.SymlinkFollow,
+		}),
+	})
+	mustExecSession(t, session, ""+
+		"printf 'hello\\n' > real.txt\n"+
+		"ln -s real.txt link.txt\n")
+
+	defaultLinks := mustExecSession(t, session, "rg hello\n")
+	if got, want := defaultLinks.Stdout, "real.txt:1:hello\n"; got != want {
+		t.Fatalf("default link stdout = %q, want %q", got, want)
+	}
+
+	followLinks := mustExecSession(t, session, "rg -L hello\n")
+	if got, want := followLinks.Stdout, "link.txt:1:hello\nreal.txt:1:hello\n"; got != want {
+		t.Fatalf("-L stdout = %q, want %q", got, want)
 	}
 }

--- a/internal/builtins/rg_types.go
+++ b/internal/builtins/rg_types.go
@@ -1,0 +1,168 @@
+package builtins
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type rgFileType struct {
+	extensions []string
+	globs      []string
+}
+
+type rgTypeRegistry struct {
+	types map[string]rgFileType
+}
+
+func newRGTypeRegistry() *rgTypeRegistry {
+	types := make(map[string]rgFileType, len(rgDefaultFileTypes))
+	for name, fileType := range rgDefaultFileTypes {
+		types[name] = rgFileType{
+			extensions: append([]string(nil), fileType.extensions...),
+			globs:      append([]string(nil), fileType.globs...),
+		}
+	}
+	return &rgTypeRegistry{types: types}
+}
+
+func (r *rgTypeRegistry) AddType(spec string) {
+	name, pattern, ok := strings.Cut(spec, ":")
+	if !ok || name == "" || pattern == "" {
+		return
+	}
+	current := r.types[name]
+	if strings.HasPrefix(pattern, "include:") {
+		other := r.types[strings.TrimPrefix(pattern, "include:")]
+		current.extensions = appendUniqueStrings(current.extensions, other.extensions...)
+		current.globs = appendUniqueStrings(current.globs, other.globs...)
+		r.types[name] = current
+		return
+	}
+	if strings.HasPrefix(pattern, "*.") && !strings.Contains(pattern[2:], "*") {
+		current.extensions = appendUniqueStrings(current.extensions, pattern[1:])
+	} else {
+		current.globs = appendUniqueStrings(current.globs, pattern)
+	}
+	r.types[name] = current
+}
+
+func (r *rgTypeRegistry) ClearType(name string) {
+	if _, ok := r.types[name]; !ok {
+		return
+	}
+	r.types[name] = rgFileType{}
+}
+
+func (r *rgTypeRegistry) MatchesType(filename string, typeNames []string) bool {
+	lowerName := strings.ToLower(filename)
+	for _, name := range typeNames {
+		if name == "all" {
+			if r.matchesAnyType(filename) {
+				return true
+			}
+			continue
+		}
+		fileType, ok := r.types[name]
+		if !ok {
+			continue
+		}
+		for _, ext := range fileType.extensions {
+			if strings.HasSuffix(lowerName, ext) {
+				return true
+			}
+		}
+		for _, glob := range fileType.globs {
+			if matched, _ := rgMatchGlob(filename, glob, true); matched {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (r *rgTypeRegistry) matchesAnyType(filename string) bool {
+	for name := range r.types {
+		if r.MatchesType(filename, []string{name}) {
+			return true
+		}
+	}
+	return false
+}
+
+func formatRGTypeList() string {
+	names := make([]string, 0, len(rgDefaultFileTypes))
+	for name := range rgDefaultFileTypes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	lines := make([]string, 0, len(names))
+	for _, name := range names {
+		fileType := rgDefaultFileTypes[name]
+		patterns := make([]string, 0, len(fileType.extensions)+len(fileType.globs))
+		for _, ext := range fileType.extensions {
+			patterns = append(patterns, "*"+ext)
+		}
+		patterns = append(patterns, fileType.globs...)
+		lines = append(lines, fmt.Sprintf("%s: %s", name, strings.Join(patterns, ", ")))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func appendUniqueStrings(dst []string, values ...string) []string {
+	for _, value := range values {
+		found := false
+		for _, existing := range dst {
+			if existing == value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			dst = append(dst, value)
+		}
+	}
+	return dst
+}
+
+var rgDefaultFileTypes = map[string]rgFileType{
+	"bat":      {extensions: []string{".bat", ".cmd"}},
+	"c":        {extensions: []string{".c", ".h"}},
+	"clojure":  {extensions: []string{".clj", ".cljc", ".cljs", ".edn"}},
+	"cpp":      {extensions: []string{".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".h"}},
+	"css":      {extensions: []string{".css", ".scss", ".sass", ".less"}},
+	"csv":      {extensions: []string{".csv", ".tsv"}},
+	"docker":   {globs: []string{"Dockerfile", "Dockerfile.*", "*.dockerfile"}},
+	"go":       {extensions: []string{".go"}},
+	"graphql":  {extensions: []string{".graphql", ".gql"}},
+	"html":     {extensions: []string{".html", ".htm", ".xhtml"}},
+	"ini":      {extensions: []string{".ini", ".cfg", ".conf"}},
+	"java":     {extensions: []string{".java"}},
+	"js":       {extensions: []string{".js", ".mjs", ".cjs", ".jsx"}},
+	"json":     {extensions: []string{".json", ".jsonc", ".json5"}},
+	"kotlin":   {extensions: []string{".kt", ".kts"}},
+	"lua":      {extensions: []string{".lua"}},
+	"make":     {extensions: []string{".mk", ".mak"}, globs: []string{"Makefile", "GNUmakefile", "makefile"}},
+	"markdown": {extensions: []string{".md", ".mdx", ".markdown", ".mdown", ".mkd"}},
+	"md":       {extensions: []string{".md", ".mdx", ".markdown", ".mdown", ".mkd"}},
+	"perl":     {extensions: []string{".pl", ".pm", ".pod", ".t"}},
+	"php":      {extensions: []string{".php", ".phtml", ".php3", ".php4", ".php5"}},
+	"proto":    {extensions: []string{".proto"}},
+	"ps":       {extensions: []string{".ps1", ".psm1", ".psd1"}},
+	"py":       {extensions: []string{".py", ".pyi", ".pyw"}},
+	"rb":       {extensions: []string{".rb", ".rake", ".gemspec"}, globs: []string{"Rakefile", "Gemfile"}},
+	"rst":      {extensions: []string{".rst"}},
+	"rust":     {extensions: []string{".rs"}},
+	"scala":    {extensions: []string{".scala", ".sc"}},
+	"sh":       {extensions: []string{".sh", ".bash", ".zsh", ".fish"}, globs: []string{".bashrc", ".zshrc", ".profile"}},
+	"sql":      {extensions: []string{".sql"}},
+	"tex":      {extensions: []string{".tex", ".ltx", ".sty", ".cls"}},
+	"tf":       {extensions: []string{".tf", ".tfvars"}},
+	"toml":     {extensions: []string{".toml"}, globs: []string{"Cargo.toml", "pyproject.toml"}},
+	"ts":       {extensions: []string{".ts", ".tsx", ".mts", ".cts"}},
+	"txt":      {extensions: []string{".txt", ".text"}},
+	"xml":      {extensions: []string{".xml", ".xsl", ".xslt"}},
+	"yaml":     {extensions: []string{".yaml", ".yml"}},
+	"zig":      {extensions: []string{".zig"}},
+}


### PR DESCRIPTION
## Summary
- expand `rg` to match the upstream just-bash behavior more closely for smart-case, match/output flags, file filtering, ignore handling, and type filtering
- add dedicated ignore and file type helpers used by `rg`, including upstream-style relative path output and `--type-list`
- replace the minimal `rg` coverage with upstream-inspired parity tests, including a policy-aware `-L` regression

## Testing
- `go build ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...`
- `go test ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...`