### PR TITLE
fix: resolve all golangci-lint issues in builtins

### DIFF
--- a/internal/builtins/grep.go
+++ b/internal/builtins/grep.go
@@ -269,19 +269,6 @@ func compileGrepPattern(opts grepOptions) (*regexp.Regexp, error) {
 	return regexp.Compile(pattern)
 }
 
-func grepContent(inv *Invocation, re *regexp.Regexp, data []byte, name string, showName bool, opts grepOptions) (bool, error) {
-	result, err := grepSearchContent(re, data, name, showName, opts)
-	if err != nil {
-		return false, err
-	}
-	if result.output != "" {
-		if _, err := fmt.Fprint(inv.Stdout, result.output); err != nil {
-			return result.matched, &ExitError{Code: 1, Err: err}
-		}
-	}
-	return result.matched, nil
-}
-
 func grepSearchContent(re *regexp.Regexp, data []byte, name string, showName bool, opts grepOptions) (grepSearchResult, error) {
 	if opts.count {
 		matchCount := 0

--- a/internal/builtins/rg.go
+++ b/internal/builtins/rg.go
@@ -178,7 +178,7 @@ func (c *RG) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 		return rgWriteTypeList(inv)
 	}
 
-	patterns, err := rgLoadPatterns(ctx, inv, opts)
+	patterns, err := rgLoadPatterns(ctx, inv, &opts)
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func (c *RG) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 		return exitf(inv, 2, "rg: no pattern given")
 	}
 
-	re, err := rgCompilePattern(patterns, opts)
+	re, err := rgCompilePattern(patterns, &opts)
 	if err != nil {
 		return exitf(inv, 2, "rg: invalid regex: %v", err)
 	}
@@ -208,10 +208,10 @@ func (c *RG) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 
 	var ignoreMatcher *rgIgnoreMatcher
 	if !opts.noIgnore {
-		ignoreMatcher = newRGIgnoreMatcher(opts)
+		ignoreMatcher = newRGIgnoreMatcher(&opts)
 	}
 
-	collectResult, err := c.collectFiles(ctx, inv, roots, opts, ignoreMatcher, typeRegistry)
+	collectResult, err := c.collectFiles(ctx, inv, roots, &opts, ignoreMatcher, typeRegistry)
 	if err != nil {
 		return err
 	}
@@ -233,8 +233,8 @@ func (c *RG) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 
 	grepOpts := grepOptions{
 		pattern:           strings.Join(patterns, "\n"),
-		ignoreCase:        rgDetermineIgnoreCase(opts, patterns),
-		lineNumber:        rgEffectiveLineNumbers(opts, collectResult.singleExplicitFile, len(collectResult.files)),
+		ignoreCase:        rgDetermineIgnoreCase(&opts, patterns),
+		lineNumber:        rgEffectiveLineNumbers(&opts, collectResult.singleExplicitFile, len(collectResult.files)),
 		invert:            opts.invert,
 		count:             opts.count,
 		listFiles:         opts.listFiles,
@@ -466,7 +466,7 @@ func parseRGFlagInt(value string) (int, error) {
 	return number, nil
 }
 
-func rgLoadPatterns(ctx context.Context, inv *Invocation, opts rgOptions) ([]string, error) {
+func rgLoadPatterns(ctx context.Context, inv *Invocation, opts *rgOptions) ([]string, error) {
 	patterns := append([]string(nil), opts.patterns...)
 	for _, name := range opts.patternFiles {
 		var data []byte
@@ -489,7 +489,7 @@ func rgLoadPatterns(ctx context.Context, inv *Invocation, opts rgOptions) ([]str
 	return patterns, nil
 }
 
-func rgCompilePattern(patterns []string, opts rgOptions) (*regexp.Regexp, error) {
+func rgCompilePattern(patterns []string, opts *rgOptions) (*regexp.Regexp, error) {
 	ignoreCase := rgDetermineIgnoreCase(opts, patterns)
 	pattern := ""
 	switch {
@@ -515,7 +515,7 @@ func rgCompilePattern(patterns []string, opts rgOptions) (*regexp.Regexp, error)
 	})
 }
 
-func rgDetermineIgnoreCase(opts rgOptions, patterns []string) bool {
+func rgDetermineIgnoreCase(opts *rgOptions, patterns []string) bool {
 	switch opts.caseMode {
 	case rgCaseModeIgnore:
 		return true
@@ -533,21 +533,21 @@ func rgDetermineIgnoreCase(opts rgOptions, patterns []string) bool {
 	}
 }
 
-func rgEffectiveLineNumbers(opts rgOptions, singleExplicitFile bool, fileCount int) bool {
+func rgEffectiveLineNumbers(opts *rgOptions, singleExplicitFile bool, fileCount int) bool {
 	if opts.explicitLineNumbers {
 		return opts.lineNumber
 	}
 	if opts.onlyMatching {
 		return false
 	}
-	return !(singleExplicitFile && fileCount == 1)
+	return !singleExplicitFile || fileCount != 1
 }
 
 func rgLooksBinary(data []byte) bool {
 	return bytes.IndexByte(data, 0) >= 0
 }
 
-func (c *RG) collectFiles(ctx context.Context, inv *Invocation, roots []string, opts rgOptions, ignoreMatcher *rgIgnoreMatcher, typeRegistry *rgTypeRegistry) (rgCollectResult, error) {
+func (c *RG) collectFiles(ctx context.Context, inv *Invocation, roots []string, opts *rgOptions, ignoreMatcher *rgIgnoreMatcher, typeRegistry *rgTypeRegistry) (rgCollectResult, error) {
 	result := rgCollectResult{
 		files: make([]rgCollectedFile, 0),
 	}
@@ -578,7 +578,7 @@ func (c *RG) collectFiles(ctx context.Context, inv *Invocation, roots []string, 
 			continue
 		}
 		directoryCount++
-		if err := c.walkRoot(ctx, inv, rgWalkState{
+		if err := c.walkRoot(ctx, inv, &rgWalkState{
 			rootAbs:      abs,
 			prefix:       rgDisplayDirRoot(root),
 			depth:        0,
@@ -603,12 +603,12 @@ type rgWalkState struct {
 	rootAbs      string
 	prefix       string
 	depth        int
-	opts         rgOptions
+	opts         *rgOptions
 	ignore       *rgIgnoreMatcher
 	typeRegistry *rgTypeRegistry
 }
 
-func (c *RG) walkRoot(ctx context.Context, inv *Invocation, state rgWalkState, files *[]rgCollectedFile) error {
+func (c *RG) walkRoot(ctx context.Context, inv *Invocation, state *rgWalkState, files *[]rgCollectedFile) error {
 	if state.depth >= state.opts.maxDepth {
 		return nil
 	}
@@ -655,16 +655,16 @@ func (c *RG) walkRoot(ctx context.Context, inv *Invocation, state rgWalkState, f
 		if state.ignore != nil && state.ignore.matches(childAbs, isDir) {
 			continue
 		}
-		if !state.opts.hidden && strings.HasPrefix(name, ".") && !(state.ignore != nil && state.ignore.whitelisted(childAbs, isDir)) {
+		if !state.opts.hidden && strings.HasPrefix(name, ".") && (state.ignore == nil || !state.ignore.whitelisted(childAbs, isDir)) {
 			continue
 		}
 
 		if isDir {
-			next := state
+			next := *state
 			next.rootAbs = childAbs
 			next.prefix = display
 			next.depth++
-			if err := c.walkRoot(ctx, inv, next, files); err != nil {
+			if err := c.walkRoot(ctx, inv, &next, files); err != nil {
 				return err
 			}
 			continue
@@ -677,7 +677,7 @@ func (c *RG) walkRoot(ctx context.Context, inv *Invocation, state rgWalkState, f
 	return nil
 }
 
-func (c *RG) includeFile(display, abs string, opts rgOptions, ignoreMatcher *rgIgnoreMatcher, typeRegistry *rgTypeRegistry) bool {
+func (c *RG) includeFile(display, abs string, opts *rgOptions, ignoreMatcher *rgIgnoreMatcher, typeRegistry *rgTypeRegistry) bool {
 	if ignoreMatcher != nil && ignoreMatcher.matches(abs, false) {
 		return false
 	}
@@ -710,8 +710,8 @@ func rgMatchGlobSet(display, filename string, globs []string, ignoreCase bool) b
 		if trimmed == "" {
 			continue
 		}
-		if strings.HasPrefix(trimmed, "!") {
-			negative = append(negative, strings.TrimPrefix(trimmed, "!"))
+		if after, ok := strings.CutPrefix(trimmed, "!"); ok {
+			negative = append(negative, after)
 			continue
 		}
 		positive = append(positive, trimmed)
@@ -724,8 +724,8 @@ func rgMatchGlobSet(display, filename string, globs []string, ignoreCase bool) b
 			if !ok && !strings.HasPrefix(glob, "/") {
 				ok, _ = rgMatchGlob(display, glob, ignoreCase)
 			}
-			if strings.HasPrefix(glob, "/") {
-				ok, _ = rgMatchGlob(display, strings.TrimPrefix(glob, "/"), ignoreCase)
+			if after, hasPrefix := strings.CutPrefix(glob, "/"); hasPrefix {
+				ok, _ = rgMatchGlob(display, after, ignoreCase)
 			}
 			if ok {
 				matched = true
@@ -742,8 +742,8 @@ func rgMatchGlobSet(display, filename string, globs []string, ignoreCase bool) b
 		if !ok && !strings.HasPrefix(glob, "/") {
 			ok, _ = rgMatchGlob(display, glob, ignoreCase)
 		}
-		if strings.HasPrefix(glob, "/") {
-			ok, _ = rgMatchGlob(display, strings.TrimPrefix(glob, "/"), ignoreCase)
+		if after, hasPrefix := strings.CutPrefix(glob, "/"); hasPrefix {
+			ok, _ = rgMatchGlob(display, after, ignoreCase)
 		}
 		if ok {
 			return false
@@ -840,8 +840,8 @@ func rgRelativeToCwd(inv *Invocation, abs string) string {
 	if !strings.HasSuffix(prefix, "/") {
 		prefix += "/"
 	}
-	if strings.HasPrefix(abs, prefix) {
-		return strings.TrimPrefix(abs, prefix)
+	if after, ok := strings.CutPrefix(abs, prefix); ok {
+		return after
 	}
 	return abs
 }

--- a/internal/builtins/rg_ignore.go
+++ b/internal/builtins/rg_ignore.go
@@ -17,12 +17,12 @@ type rgIgnoreRule struct {
 }
 
 type rgIgnoreMatcher struct {
-	opts   rgOptions
+	opts   *rgOptions
 	rules  []rgIgnoreRule
 	loaded map[string]bool
 }
 
-func newRGIgnoreMatcher(opts rgOptions) *rgIgnoreMatcher {
+func newRGIgnoreMatcher(opts *rgOptions) *rgIgnoreMatcher {
 	return &rgIgnoreMatcher{
 		opts:   opts,
 		loaded: make(map[string]bool),
@@ -86,16 +86,16 @@ func (m *rgIgnoreMatcher) loadDir(ctx context.Context, inv *Invocation, dir stri
 }
 
 func (m *rgIgnoreMatcher) parse(base, content string) {
-	for _, line := range strings.Split(content, "\n") {
+	for line := range strings.SplitSeq(content, "\n") {
 		trimmed := strings.TrimRight(line, " \t\r")
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
 
 		negated := false
-		if strings.HasPrefix(trimmed, "!") {
+		if after, ok := strings.CutPrefix(trimmed, "!"); ok {
 			negated = true
-			trimmed = strings.TrimPrefix(trimmed, "!")
+			trimmed = after
 		}
 
 		directoryOnly := false
@@ -108,9 +108,9 @@ func (m *rgIgnoreMatcher) parse(base, content string) {
 		}
 
 		rooted := false
-		if strings.HasPrefix(trimmed, "/") {
+		if after, ok := strings.CutPrefix(trimmed, "/"); ok {
 			rooted = true
-			trimmed = strings.TrimPrefix(trimmed, "/")
+			trimmed = after
 		} else if strings.Contains(trimmed, "/") && !strings.HasPrefix(trimmed, "**/") {
 			rooted = true
 		}

--- a/internal/builtins/rg_types.go
+++ b/internal/builtins/rg_types.go
@@ -2,6 +2,7 @@ package builtins
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -32,8 +33,8 @@ func (r *rgTypeRegistry) AddType(spec string) {
 		return
 	}
 	current := r.types[name]
-	if strings.HasPrefix(pattern, "include:") {
-		other := r.types[strings.TrimPrefix(pattern, "include:")]
+	if after, ok := strings.CutPrefix(pattern, "include:"); ok {
+		other := r.types[after]
 		current.extensions = appendUniqueStrings(current.extensions, other.extensions...)
 		current.globs = appendUniqueStrings(current.globs, other.globs...)
 		r.types[name] = current
@@ -112,14 +113,7 @@ func formatRGTypeList() string {
 
 func appendUniqueStrings(dst []string, values ...string) []string {
 	for _, value := range values {
-		found := false
-		for _, existing := range dst {
-			if existing == value {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(dst, value) {
 			dst = append(dst, value)
 		}
 	}


### PR DESCRIPTION
## Summary
- Pass `rgOptions` and `rgWalkState` by pointer to avoid copying heavy structs (gocritic hugeParam)
- Replace `HasPrefix`+`TrimPrefix` patterns with `strings.CutPrefix` (modernize)
- Use `strings.SplitSeq` and `slices.Contains` for more idiomatic Go (modernize)
- Apply De Morgan's law to simplify negated boolean expressions (staticcheck)
- Remove unused `grepContent` function (unused)

## Test plan
- [x] `make lint` passes with 0 issues across all modules
- [x] `go test ./internal/builtins/...` passes