### PR TITLE
cli: add structured --json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ gbash --root /path/to/project --cwd /home/agent/project -c 'pwd; ls'
 
 `--root` mounts a host directory read-only at `/home/agent/project` under an in-memory writable overlay. `--cwd` sets the initial sandbox working directory.
 
+For programmatic wrappers and harnesses, non-interactive runs can emit one structured JSON object instead of streaming stdout and stderr directly:
+
+```bash
+gbash -c 'echo hello' --json
+```
+
+The JSON payload includes `stdout`, `stderr`, `exitCode`, truncation flags, timing metadata, and trace metadata when the wrapper enables tracing on the underlying runtime.
+
 Install `gbash-extras` when you want the same CLI surface with the stable official contrib commands (`awk`, `jq`, `sqlite3`, and `yq`) pre-registered:
 
 ```bash

--- a/SPEC.md
+++ b/SPEC.md
@@ -133,11 +133,12 @@ The normal CLI entrypoint also accepts filesystem selection flags before the she
 - `gbash --root <dir> ...` mounts `<dir>` read-only at `/home/agent/project` with an in-memory writable overlay
 - `gbash --cwd <dir> ...` sets the initial sandbox working directory
 - `gbash --readwrite-root <dir> ...` mounts `<dir>` as sandbox `/` so writes persist back to the host, but only when `<dir>` is inside the system temp directory
+- `gbash --json ...` emits one JSON object for a non-interactive execution with `stdout`, `stderr`, `exitCode`, truncation flags, timing metadata, and optional trace metadata when tracing is enabled
 - when `--cwd` is omitted, `--root` starts at `/home/agent/project` and `--readwrite-root` starts at `/`
 
 External test harnesses should use the normal CLI entrypoint together with the filesystem selection flags above. In particular, GNU-style wrapper scripts may invoke `gbash --readwrite-root <tempdir> --cwd <dir> -c 'exec "$@"' _ <utility> ...` so the harness exercises the same shell and runtime path as normal `gbash` execution.
 
-That frontend is also exposed as a public `cli` package so shipped binaries can reuse the same flag parsing, version rendering, interactive behavior, and runtime setup:
+That frontend is also exposed as a public `cli` package so shipped binaries can reuse the same flag parsing, version rendering, interactive behavior, JSON result rendering, and runtime setup:
 
 - `cmd/gbash` is a thin wrapper over `github.com/ewhauser/gbash/cli`
 - `contrib/extras/cmd/gbash-extras` is a thin wrapper over the same package with `contrib/extras` pre-registered into the runtime

--- a/cli/json_output.go
+++ b/cli/json_output.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/ewhauser/gbash"
+	"github.com/ewhauser/gbash/trace"
+)
+
+type jsonExecutionResult struct {
+	Stdout          string            `json:"stdout"`
+	Stderr          string            `json:"stderr"`
+	ExitCode        int               `json:"exitCode"`
+	StdoutTruncated bool              `json:"stdoutTruncated"`
+	StderrTruncated bool              `json:"stderrTruncated"`
+	Timing          *jsonTiming       `json:"timing,omitempty"`
+	Trace           *jsonTraceSummary `json:"trace,omitempty"`
+}
+
+type jsonTiming struct {
+	StartedAt  string  `json:"startedAt"`
+	FinishedAt string  `json:"finishedAt"`
+	DurationMs float64 `json:"durationMs"`
+}
+
+type jsonTraceSummary struct {
+	Schema      string `json:"schema"`
+	SessionID   string `json:"sessionId,omitempty"`
+	ExecutionID string `json:"executionId,omitempty"`
+	EventCount  int    `json:"eventCount"`
+}
+
+func writeJSONExecutionResult(w io.Writer, payload jsonExecutionResult) error {
+	encoder := json.NewEncoder(writerOrDiscard(w))
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(payload)
+}
+
+func buildJSONExecutionResult(exitCode int, result *gbash.ExecutionResult, errText string) jsonExecutionResult {
+	payload := jsonExecutionResult{
+		ExitCode: exitCode,
+	}
+	if result != nil {
+		payload.Stdout = result.Stdout
+		payload.Stderr = result.Stderr
+		payload.StdoutTruncated = result.StdoutTruncated
+		payload.StderrTruncated = result.StderrTruncated
+		payload.Timing = jsonTimingFromExecution(result)
+		payload.Trace = jsonTraceFromEvents(result.Events)
+	}
+	payload.Stderr = appendStderrMessage(payload.Stderr, errText)
+	return payload
+}
+
+func jsonTimingFromExecution(result *gbash.ExecutionResult) *jsonTiming {
+	if result == nil || (result.StartedAt.IsZero() && result.FinishedAt.IsZero() && result.Duration == 0) {
+		return nil
+	}
+	return &jsonTiming{
+		StartedAt:  formatJSONTime(result.StartedAt),
+		FinishedAt: formatJSONTime(result.FinishedAt),
+		DurationMs: durationMilliseconds(result.Duration),
+	}
+}
+
+func jsonTraceFromEvents(events []trace.Event) *jsonTraceSummary {
+	if len(events) == 0 {
+		return nil
+	}
+	first := events[0]
+	schema := strings.TrimSpace(first.Schema)
+	if schema == "" {
+		schema = trace.SchemaVersion
+	}
+	return &jsonTraceSummary{
+		Schema:      schema,
+		SessionID:   first.SessionID,
+		ExecutionID: first.ExecutionID,
+		EventCount:  len(events),
+	}
+}
+
+func formatJSONTime(at time.Time) string {
+	if at.IsZero() {
+		return ""
+	}
+	return at.UTC().Format(time.RFC3339Nano)
+}
+
+func durationMilliseconds(d time.Duration) float64 {
+	return float64(d) / float64(time.Millisecond)
+}
+
+func appendStderrMessage(stderrText, message string) string {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return stderrText
+	}
+
+	var builder strings.Builder
+	if stderrText != "" {
+		builder.WriteString(stderrText)
+		if !strings.HasSuffix(stderrText, "\n") {
+			builder.WriteByte('\n')
+		}
+	}
+	builder.WriteString(message)
+	if !strings.HasSuffix(message, "\n") {
+		builder.WriteByte('\n')
+	}
+	return builder.String()
+}
+
+func formatCLIError(name string, err error) string {
+	if err == nil {
+		return ""
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return err.Error()
+	}
+	return fmt.Sprintf("%s: %v", name, err)
+}
+
+func writerOrDiscard(w io.Writer) io.Writer {
+	if w == nil {
+		return io.Discard
+	}
+	return w
+}

--- a/cli/run.go
+++ b/cli/run.go
@@ -26,6 +26,12 @@ func run(ctx context.Context, cfg Config, argv0 string, args []string, stdin io.
 
 	runtimeOpts, args, err := parseRuntimeOptions(args)
 	if err != nil {
+		if runtimeOpts.json {
+			if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(2, nil, formatCLIError(cfg.Name, err))); jsonErr != nil {
+				return 1, jsonErr
+			}
+			return 2, nil
+		}
 		return 2, err
 	}
 
@@ -35,6 +41,12 @@ func run(ctx context.Context, cfg Config, argv0 string, args []string, stdin io.
 		LongInteractive:  true,
 	})
 	if err != nil {
+		if runtimeOpts.json {
+			if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(2, nil, formatCLIError(cfg.Name, err))); jsonErr != nil {
+				return 1, jsonErr
+			}
+			return 2, nil
+		}
 		return 2, err
 	}
 	switch parsed.Action {
@@ -47,14 +59,29 @@ func run(ctx context.Context, cfg Config, argv0 string, args []string, stdin io.
 		_, _ = io.WriteString(stdout, versionText(cfg))
 		return 0, nil
 	}
+	if runtimeOpts.json && parsed.Source == builtins.BashSourceStdin && (parsed.Interactive || stdinTTY) {
+		if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(2, nil, formatCLIError(cfg.Name, fmt.Errorf("--json is only supported for non-interactive executions")))); jsonErr != nil {
+			return 1, jsonErr
+		}
+		return 2, nil
+	}
 
 	rt, err := newRuntime(cfg, runtimeOpts)
 	if err != nil {
+		if runtimeOpts.json {
+			if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(1, nil, formatCLIError(cfg.Name, fmt.Errorf("init runtime: %w", err)))); jsonErr != nil {
+				return 1, jsonErr
+			}
+			return 1, nil
+		}
 		return 1, fmt.Errorf("init runtime: %w", err)
 	}
 
 	if parsed.Source == builtins.BashSourceStdin && (parsed.Interactive || stdinTTY) {
 		return runInteractiveShell(ctx, rt, parsed, stdin, stdout, stderr)
+	}
+	if runtimeOpts.json {
+		return runBashInvocationJSON(ctx, cfg.Name, rt, parsed, stdin, stdout)
 	}
 	return runBashInvocation(ctx, rt, parsed, stdin, stdout, stderr)
 }
@@ -63,37 +90,9 @@ func runBashInvocation(ctx context.Context, rt *gbash.Runtime, parsed *builtins.
 	if parsed == nil {
 		parsed = &builtins.BashInvocation{Name: "gbash", Source: builtins.BashSourceStdin}
 	}
-
-	var (
-		script      string
-		execStdin   = stdin
-		readErr     error
-		missingPath string
-	)
-	switch parsed.Source {
-	case builtins.BashSourceCommandString:
-		script = parsed.CommandString
-	case builtins.BashSourceFile:
-		data, err := os.ReadFile(parsed.ScriptPath)
-		if err != nil {
-			readErr = err
-			missingPath = parsed.ScriptPath
-			break
-		}
-		script = string(data)
-	default:
-		var data []byte
-		data, readErr = io.ReadAll(stdin)
-		if readErr == nil {
-			script = string(data)
-		}
-		execStdin = nil
-	}
-	if readErr != nil {
-		if missingPath != "" {
-			return 127, fmt.Errorf("%s: No such file or directory", missingPath)
-		}
-		return 1, fmt.Errorf("read script: %w", readErr)
+	script, execStdin, exitCode, err := loadBashInvocationScript(parsed, stdin)
+	if err != nil {
+		return exitCode, err
 	}
 
 	req := &gbash.ExecutionRequest{
@@ -128,6 +127,97 @@ func runBashInvocation(ctx context.Context, rt *gbash.Runtime, parsed *builtins.
 		return 1, fmt.Errorf("runtime returned no result")
 	}
 	return result.ExitCode, nil
+}
+
+func runBashInvocationJSON(ctx context.Context, name string, rt *gbash.Runtime, parsed *builtins.BashInvocation, stdin io.Reader, stdout io.Writer) (int, error) {
+	if parsed == nil {
+		parsed = &builtins.BashInvocation{Name: "gbash", Source: builtins.BashSourceStdin}
+	}
+	script, execStdin, exitCode, err := loadBashInvocationScript(parsed, stdin)
+	if err != nil {
+		if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(exitCode, nil, formatCLIError(name, err))); jsonErr != nil {
+			return 1, jsonErr
+		}
+		return exitCode, nil
+	}
+
+	req := &gbash.ExecutionRequest{
+		Name:            parsed.ExecutionName,
+		Interpreter:     parsed.Name,
+		PassthroughArgs: append([]string(nil), parsed.RawArgs...),
+		Script:          script,
+		Args:            append([]string(nil), parsed.Args...),
+		StartupOptions:  append([]string(nil), parsed.StartupOptions...),
+		Interactive:     parsed.Interactive,
+		Stdin:           execStdin,
+	}
+	if len(req.PassthroughArgs) == 0 {
+		req.PassthroughArgs = []string{"-s"}
+	}
+
+	session, err := rt.NewSession(ctx)
+	if err != nil {
+		if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(1, nil, formatCLIError(name, fmt.Errorf("new session: %w", err)))); jsonErr != nil {
+			return 1, jsonErr
+		}
+		return 1, nil
+	}
+
+	result, err := session.Exec(ctx, req)
+	if err != nil {
+		if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(1, result, formatCLIError(name, fmt.Errorf("runtime error: %w", err)))); jsonErr != nil {
+			return 1, jsonErr
+		}
+		return 1, nil
+	}
+	if result == nil {
+		if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(1, nil, formatCLIError(name, fmt.Errorf("runtime returned no result")))); jsonErr != nil {
+			return 1, jsonErr
+		}
+		return 1, nil
+	}
+	if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(result.ExitCode, result, "")); jsonErr != nil {
+		return 1, jsonErr
+	}
+	return result.ExitCode, nil
+}
+
+func loadBashInvocationScript(parsed *builtins.BashInvocation, stdin io.Reader) (script string, execStdin io.Reader, exitCode int, err error) {
+	if parsed == nil {
+		parsed = &builtins.BashInvocation{Name: "gbash", Source: builtins.BashSourceStdin}
+	}
+
+	var (
+		readErr     error
+		missingPath string
+	)
+	execStdin = stdin
+	switch parsed.Source {
+	case builtins.BashSourceCommandString:
+		script = parsed.CommandString
+	case builtins.BashSourceFile:
+		data, readFileErr := os.ReadFile(parsed.ScriptPath)
+		if readFileErr != nil {
+			readErr = readFileErr
+			missingPath = parsed.ScriptPath
+			break
+		}
+		script = string(data)
+	default:
+		var data []byte
+		data, readErr = io.ReadAll(stdin)
+		if readErr == nil {
+			script = string(data)
+		}
+		execStdin = nil
+	}
+	if readErr != nil {
+		if missingPath != "" {
+			return "", nil, 127, fmt.Errorf("%s: No such file or directory", missingPath)
+		}
+		return "", nil, 1, fmt.Errorf("read script: %w", readErr)
+	}
+	return script, execStdin, 0, nil
 }
 
 func stdinIsTTY(stdin io.Reader) bool {

--- a/cli/runtime_options.go
+++ b/cli/runtime_options.go
@@ -16,48 +16,76 @@ type runtimeOptions struct {
 	root          string
 	readWriteRoot string
 	cwd           string
+	json          bool
 }
 
 func parseRuntimeOptions(args []string) (runtimeOptions, []string, error) {
 	var opts runtimeOptions
-	rest := append([]string(nil), args...)
-	for len(rest) > 0 {
-		arg := rest[0]
+	rest := make([]string, 0, len(args))
+	pendingShellValues := 0
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if pendingShellValues > 0 {
+			rest = append(rest, arg)
+			pendingShellValues--
+			continue
+		}
+
 		switch {
 		case arg == "--root":
-			if len(rest) < 2 {
-				return runtimeOptions{}, nil, fmt.Errorf("--root requires a path")
+			if i+1 >= len(args) {
+				return opts, nil, fmt.Errorf("--root requires a path")
 			}
-			opts.root = rest[1]
-			rest = rest[2:]
+			i++
+			opts.root = args[i]
 		case strings.HasPrefix(arg, "--root="):
 			opts.root = strings.TrimPrefix(arg, "--root=")
-			rest = rest[1:]
 		case arg == "--readwrite-root":
-			if len(rest) < 2 {
-				return runtimeOptions{}, nil, fmt.Errorf("--readwrite-root requires a path")
+			if i+1 >= len(args) {
+				return opts, nil, fmt.Errorf("--readwrite-root requires a path")
 			}
-			opts.readWriteRoot = rest[1]
-			rest = rest[2:]
+			i++
+			opts.readWriteRoot = args[i]
 		case strings.HasPrefix(arg, "--readwrite-root="):
 			opts.readWriteRoot = strings.TrimPrefix(arg, "--readwrite-root=")
-			rest = rest[1:]
 		case arg == "--cwd":
-			if len(rest) < 2 {
-				return runtimeOptions{}, nil, fmt.Errorf("--cwd requires a path")
+			if i+1 >= len(args) {
+				return opts, nil, fmt.Errorf("--cwd requires a path")
 			}
-			opts.cwd = rest[1]
-			rest = rest[2:]
+			i++
+			opts.cwd = args[i]
 		case strings.HasPrefix(arg, "--cwd="):
 			opts.cwd = strings.TrimPrefix(arg, "--cwd=")
-			rest = rest[1:]
+		case arg == "--json":
+			opts.json = true
 		case arg == "--":
-			return opts, rest[1:], nil
-		default:
+			rest = append(rest, args[i:]...)
 			return opts, rest, nil
+		default:
+			rest = append(rest, arg)
+			if !strings.HasPrefix(arg, "-") || arg == "-" {
+				rest = append(rest, args[i+1:]...)
+				return opts, rest, nil
+			}
+			pendingShellValues += bashInvocationValueCount(arg)
 		}
 	}
-	return opts, nil, nil
+	return opts, rest, nil
+}
+
+func bashInvocationValueCount(arg string) int {
+	if len(arg) < 2 || !strings.HasPrefix(arg, "-") || strings.HasPrefix(arg, "--") {
+		return 0
+	}
+
+	count := 0
+	for _, ch := range arg[1:] {
+		switch ch {
+		case 'c', 'o':
+			count++
+		}
+	}
+	return count
 }
 
 func (opts runtimeOptions) gbashOptions() ([]gbash.Option, error) {
@@ -165,6 +193,8 @@ func renderHelp(w io.Writer, name string) error {
 	_, err := io.WriteString(w, "\nCLI filesystem options:\n"+
 		"  --root DIR            mount DIR read-only at /home/agent/project with a writable in-memory overlay\n"+
 		"  --cwd DIR             set the initial sandbox working directory\n"+
-		"  --readwrite-root DIR  mount DIR as sandbox / with writes persisted back to the host filesystem\n")
+		"  --readwrite-root DIR  mount DIR as sandbox / with writes persisted back to the host filesystem\n"+
+		"\nCLI output options:\n"+
+		"  --json                emit one JSON result object for a non-interactive execution\n")
 	return err
 }

--- a/cmd/gbash/cli_test.go
+++ b/cmd/gbash/cli_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +15,29 @@ import (
 
 	"github.com/ewhauser/gbash"
 )
+
+type cliJSONTiming struct {
+	StartedAt  string  `json:"startedAt"`
+	FinishedAt string  `json:"finishedAt"`
+	DurationMs float64 `json:"durationMs"`
+}
+
+type cliJSONTrace struct {
+	Schema      string `json:"schema"`
+	SessionID   string `json:"sessionId"`
+	ExecutionID string `json:"executionId"`
+	EventCount  int    `json:"eventCount"`
+}
+
+type cliJSONResult struct {
+	Stdout          string         `json:"stdout"`
+	Stderr          string         `json:"stderr"`
+	ExitCode        int            `json:"exitCode"`
+	StdoutTruncated bool           `json:"stdoutTruncated"`
+	StderrTruncated bool           `json:"stderrTruncated"`
+	Timing          *cliJSONTiming `json:"timing"`
+	Trace           *cliJSONTrace  `json:"trace"`
+}
 
 func TestRunCLIPrintsVersion(t *testing.T) {
 	prevVersion, prevCommit, prevDate, prevBuiltBy := version, commit, date, builtBy
@@ -76,10 +100,113 @@ func TestRunCLIHelpRendersFilesystemFlags(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("exitCode = %d, want 0", exitCode)
 	}
-	for _, want := range []string{"CLI filesystem options:", "--root DIR", "--cwd DIR", "--readwrite-root DIR"} {
+	for _, want := range []string{"CLI filesystem options:", "--root DIR", "--cwd DIR", "--readwrite-root DIR", "CLI output options:", "--json"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want help to contain %q", stdout.String(), want)
 		}
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
+func TestRunCLIJSONOutputEncodesExecutionResult(t *testing.T) {
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), "gbash", []string{"-c", "printf 'hello\\n'; printf 'warn\\n' >&2", "--json"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+
+	payload := mustParseCLIJSONResult(t, stdout.String())
+	if got, want := payload.Stdout, "hello\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if got, want := payload.Stderr, "warn\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+	if got := payload.ExitCode; got != 0 {
+		t.Fatalf("payload exitCode = %d, want 0", got)
+	}
+	if payload.StdoutTruncated || payload.StderrTruncated {
+		t.Fatalf("truncated flags = stdout %t stderr %t, want both false", payload.StdoutTruncated, payload.StderrTruncated)
+	}
+	if payload.Timing == nil || payload.Timing.StartedAt == "" || payload.Timing.FinishedAt == "" {
+		t.Fatalf("timing = %#v, want populated timing fields", payload.Timing)
+	}
+	if payload.Trace != nil {
+		t.Fatalf("trace = %#v, want nil when tracing is disabled", payload.Trace)
+	}
+}
+
+func TestRunCLIJSONOutputEncodesCLIError(t *testing.T) {
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), "gbash", []string{"-c", "pwd", "--json", "--root", "/", "--readwrite-root", "/"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 1 {
+		t.Fatalf("exitCode = %d, want 1; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+
+	payload := mustParseCLIJSONResult(t, stdout.String())
+	if got := payload.Stdout; got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	if !strings.Contains(payload.Stderr, "gbash: init runtime: --root and --readwrite-root are mutually exclusive") {
+		t.Fatalf("stderr = %q, want init-runtime JSON diagnostic", payload.Stderr)
+	}
+	if payload.Timing != nil {
+		t.Fatalf("timing = %#v, want nil when execution never started", payload.Timing)
+	}
+}
+
+func TestRunCLIJSONOutputRejectsInteractiveShell(t *testing.T) {
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), "gbash", []string{"--json"}, strings.NewReader(""), &stdout, &stderr, true)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d, want 2; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+
+	payload := mustParseCLIJSONResult(t, stdout.String())
+	if !strings.Contains(payload.Stderr, "only supported for non-interactive executions") {
+		t.Fatalf("stderr = %q, want non-interactive rejection", payload.Stderr)
+	}
+}
+
+func TestRunCLISharedFlagsStopAfterFirstScriptPositional(t *testing.T) {
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), "gbash", []string{"-c", `printf '%s\n' "$1"`, "_", "--json"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got, want := stdout.String(), "--json\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
 	}
 	if got := stderr.String(); got != "" {
 		t.Fatalf("stderr = %q, want empty", got)
@@ -128,6 +255,16 @@ func TestRunCLIReadWriteRootPersistsHostWritesAcrossExecutions(t *testing.T) {
 	if got := stderr.String(); got != "" {
 		t.Fatalf("read stderr = %q, want empty", got)
 	}
+}
+
+func mustParseCLIJSONResult(t *testing.T, raw string) cliJSONResult {
+	t.Helper()
+
+	var out cliJSONResult
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("Unmarshal(JSON output) error = %v; raw=%q", err, raw)
+	}
+	return out
 }
 
 func TestRunCLIRootMountReadsHostFilesWithoutPersistingWrites(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a shared `--json` CLI flag for non-interactive executions
- emit one JSON object with `stdout`, `stderr`, `exitCode`, truncation flags, timing metadata, and optional trace metadata
- allow shared CLI flags like `--json` to appear after `-c` before the first real script positional, and document the new CLI surface in `README.md` and `SPEC.md`

## Behavior
`gbash -c 'echo hello' --json` now writes structured JSON to stdout while preserving the shell exit code.

Interactive invocations reject `--json` with a JSON-formatted usage error instead of falling into the interactive shell path.

## Testing
- `go test ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...`
- `go test ./cmd/gbash ./contrib/extras/cmd/gbash-extras`

## Lint
- `make lint` still fails on pre-existing unrelated issues in `internal/builtins/rg.go`, `internal/builtins/rg_ignore.go`, `internal/builtins/rg_types.go`, and `internal/builtins/grep.go`
