### PR TITLE
shell: preserve let arithmetic assignments

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -464,6 +464,7 @@ Implementation detail for MVP:
 - `interp.Dir(...)` is set to a host-safe existing directory such as `/`, not the virtual sandbox cwd
 - the runtime prepends a shell shim that initializes `PWD` and `OLDPWD`
 - the shim owns virtual `cd` and wraps shell-visible `pwd` to the Go `pwd` command so `-L` / `-P` still honor virtual `PWD`
+- `let` clauses are rewritten through an internal helper so quoted and runtime-expanded arithmetic expressions still mutate the current shell state
 - all project path handlers resolve relative paths from virtual `PWD`, not from `HandlerContext.Dir`
 
 ### 9.3 Stdio

--- a/internal/runtime/shell_regressions_test.go
+++ b/internal/runtime/shell_regressions_test.go
@@ -62,3 +62,15 @@ func TestLoopRegressionSupportsForControlFlow(t *testing.T) {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }
+
+func TestLetRegressionSupportsQuotedAndExpandedArithmeticExpressions(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	result := mustExecSession(t, session, "expr='x = 1 + 2'\nlet \"$expr\"\nlet 'y=4+5' z=6+7\nprintf '%s,%s,%s\\n' \"$x\" \"$y\" \"$z\"\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "3,9,13\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}

--- a/shell/instrument.go
+++ b/shell/instrument.go
@@ -55,6 +55,75 @@ func instrumentLoopBudgets(program *syntax.File, pol policy.Policy) error {
 	return walkErr
 }
 
+func rewriteLetClauses(program *syntax.File) error {
+	if program == nil {
+		return nil
+	}
+
+	printer := syntax.NewPrinter()
+	parser := syntax.NewParser()
+	var walkErr error
+
+	syntax.Walk(program, func(node syntax.Node) bool {
+		if walkErr != nil {
+			return false
+		}
+
+		stmt, ok := node.(*syntax.Stmt)
+		if !ok || stmt.Cmd == nil {
+			return true
+		}
+		_, ok = stmt.Cmd.(*syntax.LetClause)
+		if !ok {
+			return true
+		}
+
+		call, err := rewriteLetClause(printer, parser, stmt.Cmd)
+		if err != nil {
+			walkErr = err
+			return false
+		}
+		stmt.Cmd = call
+		return true
+	})
+
+	return walkErr
+}
+
+func rewriteLetClause(printer *syntax.Printer, parser *syntax.Parser, cmd syntax.Command) (*syntax.CallExpr, error) {
+	if printer == nil {
+		printer = syntax.NewPrinter()
+	}
+	if parser == nil {
+		parser = syntax.NewParser()
+	}
+
+	var rendered strings.Builder
+	if err := printer.Print(&rendered, cmd); err != nil {
+		return nil, err
+	}
+
+	source := strings.TrimSpace(rendered.String())
+	rest, ok := strings.CutPrefix(source, "let")
+	if !ok {
+		return nil, fmt.Errorf("unexpected let rendering: %q", source)
+	}
+
+	file, err := parser.Parse(strings.NewReader(letHelperCommandName+rest+"\n"), "let-helper")
+	if err != nil {
+		return nil, err
+	}
+	if len(file.Stmts) != 1 {
+		return nil, fmt.Errorf("unexpected let helper statement count: %d", len(file.Stmts))
+	}
+
+	call, ok := file.Stmts[0].Cmd.(*syntax.CallExpr)
+	if !ok {
+		return nil, fmt.Errorf("unexpected let helper command type: %T", file.Stmts[0].Cmd)
+	}
+	return call, nil
+}
+
 func loopKind(clause *syntax.WhileClause) string {
 	if clause != nil && clause.Until {
 		return "until"

--- a/shell/mvdan.go
+++ b/shell/mvdan.go
@@ -81,6 +81,7 @@ type MVdan struct {
 }
 
 const hostRunnerDir = "/"
+const letHelperCommandName = "__jb_let"
 
 func New() *MVdan {
 	return &MVdan{
@@ -121,6 +122,9 @@ func (m *MVdan) Run(ctx context.Context, exec *Execution) (result *RunResult, ru
 		}
 		validationProgram = parsed
 	}
+	if err := rewriteLetClauses(validationProgram); err != nil {
+		return nil, err
+	}
 	if violation := validateExecutionBudgets(validationProgram, exec.Policy); violation != nil {
 		if exec.Stderr != nil {
 			_, _ = fmt.Fprintln(exec.Stderr, violation.Error())
@@ -140,6 +144,11 @@ func (m *MVdan) Run(ctx context.Context, exec *Execution) (result *RunResult, ru
 			return nil, err
 		}
 		program = parsed
+	}
+	if program != validationProgram {
+		if err := rewriteLetClauses(program); err != nil {
+			return nil, err
+		}
 	}
 
 	if exec.Stdin == nil {
@@ -368,6 +377,9 @@ func (m *MVdan) execHandler(exec *Execution, budget *executionBudget) interp.Exe
 		}
 		if args[0] == loopIterCommandName {
 			return budget.beforeLoopIteration(ctx, args[1:])
+		}
+		if args[0] == letHelperCommandName {
+			return execLetHelper(ctx, args[1:])
 		}
 
 		hc := interp.HandlerCtx(ctx)
@@ -1093,6 +1105,62 @@ func prependRuntimePreludeLines(script string) string {
 
 func isInternalHelperCommand(name string) bool {
 	return strings.HasPrefix(name, "__jb_")
+}
+
+func execLetHelper(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return shellFailure(ctx, 2, "let: expression expected")
+	}
+
+	hc := interp.HandlerCtx(ctx)
+	return hc.Builtin(ctx, []string{"eval", buildLetEvalScript(args)})
+}
+
+func buildLetEvalScript(args []string) string {
+	expressions := parseLetArgs(args)
+	if len(expressions) == 0 {
+		return ""
+	}
+
+	var script strings.Builder
+	for i, expr := range expressions {
+		if i > 0 {
+			script.WriteString("; ")
+		}
+		script.WriteString("(( ")
+		script.WriteString(expr)
+		script.WriteString(" ))")
+	}
+	return script.String()
+}
+
+func parseLetArgs(args []string) []string {
+	expressions := make([]string, 0, len(args))
+	var current strings.Builder
+	parenDepth := 0
+
+	for _, arg := range args {
+		for _, ch := range arg {
+			switch ch {
+			case '(':
+				parenDepth++
+			case ')':
+				parenDepth--
+			}
+		}
+		if current.Len() > 0 {
+			current.WriteByte(' ')
+		}
+		current.WriteString(arg)
+		if parenDepth == 0 {
+			expressions = append(expressions, current.String())
+			current.Reset()
+		}
+	}
+	if current.Len() > 0 {
+		expressions = append(expressions, current.String())
+	}
+	return expressions
 }
 
 var _ Engine = (*MVdan)(nil)

--- a/shell/mvdan_interactive.go
+++ b/shell/mvdan_interactive.go
@@ -79,6 +79,9 @@ func (m *MVdan) Interact(ctx context.Context, exec *Execution) (*InteractiveResu
 		if err != nil {
 			return &InteractiveResult{ExitCode: exitCode}, err
 		}
+		if err := rewriteLetClauses(file); err != nil {
+			return &InteractiveResult{ExitCode: exitCode}, err
+		}
 		if violation := validateExecutionBudgets(file, exec.Policy); violation != nil {
 			exitCode = 126
 			_, _ = fmt.Fprintln(exec.Stderr, violation.Error())


### PR DESCRIPTION
## Summary
- rewrite parsed `let` clauses through an internal shell helper so quoted and expanded arithmetic expressions update shell variables correctly
- add a runtime regression covering quoted and runtime-expanded `let` expressions
- document the `let` shim in `SPEC.md`

## Verification
- `go test ./internal/runtime -run 'TestLetRegressionSupportsQuotedAndExpandedArithmeticExpressions|TestLoopRegressionSupportsForControlFlow' -v`
- `go test ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...`
- `make lint`
- `go run ./cmd/gbash -c "let 'x=1+2'; printf '%s\\n' \"\\$x\""`