### PR TITLE
fs: add mount namespaces and lazy initial files

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,39 @@ The shared frontend is also exposed as the public `github.com/ewhauser/gbash/cli
 Most callers should use one of these entry points:
 
 - `gbash.New()` — default mutable in-memory sandbox
+- `gbash.WithFileSystem(gbash.SeededInMemoryFileSystem(...))` — in-memory sandbox preloaded with eager or lazy files
 - `gbash.WithWorkspace(root)` — real host directory mounted read-only under an in-memory overlay
+- `gbash.WithFileSystem(gbash.MountableFileSystem(...))` — multi-mount namespace over a base filesystem plus sibling mounts
 - `gbash.WithFileSystem(gbash.ReadWriteDirectoryFileSystem(...))` — just-bash-style mutable host-backed root
 - `gbash.WithFileSystem(gbash.CustomFileSystem(...))` — seeded or custom backends
+
+Preload an in-memory sandbox with eager or lazy files:
+
+```go
+gb, err := gbash.New(
+	gbash.WithFileSystem(gbash.SeededInMemoryFileSystem(gbfs.InitialFiles{
+		"/home/agent/config.json": {Content: []byte("{\"mode\":\"dev\"}\n")},
+		"/home/agent/big.txt": {
+			Lazy: func(ctx context.Context) ([]byte, error) {
+				return fetchLargeFixture(ctx)
+			},
+		},
+	})),
+)
+```
+
+Compose multiple sandbox mounts under one namespace:
+
+```go
+gb, err := gbash.New(
+	gbash.WithFileSystem(gbash.MountableFileSystem(gbash.MountableFileSystemOptions{
+		Mounts: []gbfs.MountConfig{
+			{MountPoint: "/workspace", Factory: gbfs.Overlay(gbfs.Host(gbfs.HostOptions{Root: "/path/to/project", VirtualRoot: "/"}))},
+			{MountPoint: "/cache", Factory: gbfs.Memory()},
+		},
+	})),
+)
+```
 
 Mount a host directory as a read-only workspace overlay:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -564,24 +564,30 @@ Implementation detail for the current runtime:
 - `fs/` may use private clone helpers internally for backend composition, but that is not the same as moving user-visible `cp` semantics into the filesystem layer
 - `MemoryFS` stores symlink entries directly for testing and path-safety enforcement, but the runtime still defaults to `SymlinkDeny`
 - `MemoryFS.Stat`, `Open`, `ReadDir`, `Chdir`, and `Realpath` follow symlinks; `Lstat`, `Readlink`, `Remove`, and `Rename` operate on the symlink entry itself
+- `MemoryFS` may also hold lazy regular-file providers that materialize on first content-sensitive access such as `Open`, `Stat`, `Lstat`, or `DirEntry.Info`
 
 Current and planned backends:
 
 - `MemoryFS`: default mutable sandbox
+- `SeededMemory`: in-memory factory seeded with eager or lazy per-path files for a fresh session
 - `HostFS`: read-only host-backed directory view mounted at a configurable virtual root with sanitized errors and a backend-local regular-file read cap
 - `ReadWriteFS`: mutable host-backed directory view rooted at `/` with sanitized errors and a backend-local regular-file read cap for opt-in host-backed workflows
 - `OverlayFS`: copy-on-write backend with a read-only lower layer, writable in-memory upper layer, merged `readdir`, and tombstones for deletions
+- `MountableFS`: multi-mount namespace over a base filesystem plus sibling mount points, with synthetic parent directories and path routing handled inside the backend
 - `SnapshotFS`: deterministic read-only clone of another filesystem for tests and replay fixtures
 
 Backend boundary for the current implementation:
 
 - `gbash.Config.FileSystem` is the public setup boundary for session storage and starting directory; callers should not have to coordinate separate runtime knobs to mount a backend and choose the initial working directory
+- `SeededMemory` and `gbash.SeededInMemoryFileSystem(...)` are the productized seed path for eager or lazy per-file session bootstrap
 - `HostFS` is an opt-in lower-layer backend exposed through `gbfs.Host(...)`; it is intended to sit underneath `gbfs.Overlay(...)`, not to replace the default in-memory runtime path
 - `ReadWriteFS` is an opt-in mutable backend exposed through `gbfs.ReadWrite(...)`; it is intended for developer tooling, external test harnesses, and embedders that explicitly want host mutations
 - `OverlayFS` is intended for internal session use and is exposed through `gbfs.Overlay(...)`
+- `MountableFS` is an opt-in namespace backend exposed through `gbfs.Mountable(...)` and `gbash.MountableFileSystem(...)`; live `mount` and `unmount` behavior remains a concrete-backend capability rather than part of the core filesystem interface
 - `SnapshotFS` is a read-only backend for deterministic fixtures and direct tests
 - `SnapshotFS` is not the default `runtime` session backend because session bootstrap still creates the sandbox layout and command stubs
 - the common host-project workflow should be represented as a high-level runtime helper that mounts a read-only host tree under an in-memory overlay and starts the session in that mounted directory
+- the `@ewhauser/gbash-wasm` bridge should expose the same seeded-memory model for `files`, including lazy per-path providers, rather than eagerly writing every file after session creation
 
 ## 12. Policy Model
 

--- a/api.go
+++ b/api.go
@@ -116,7 +116,8 @@ type Config struct {
 // FileSystemConfig describes how gbash provisions a session filesystem.
 //
 // Callers rarely need to populate this struct directly. Prefer the helper
-// constructors [InMemoryFileSystem], [HostDirectoryFileSystem],
+// constructors [InMemoryFileSystem], [SeededInMemoryFileSystem],
+// [HostDirectoryFileSystem], [MountableFileSystem],
 // [ReadWriteDirectoryFileSystem], and [CustomFileSystem], and then apply the
 // result with [WithFileSystem].
 type FileSystemConfig struct {
@@ -124,6 +125,20 @@ type FileSystemConfig struct {
 	Factory gbfs.Factory
 
 	// WorkingDir is the directory new sessions start in.
+	WorkingDir string
+}
+
+// MountableFileSystemOptions configures a multi-mount sandbox filesystem.
+type MountableFileSystemOptions struct {
+	// Base provisions the base filesystem used for unmounted paths. When nil, a
+	// fresh in-memory filesystem is used.
+	Base gbfs.Factory
+
+	// Mounts configures the mounted filesystems visible inside the sandbox.
+	Mounts []gbfs.MountConfig
+
+	// WorkingDir is the directory new sessions start in. When empty,
+	// /home/agent is used.
 	WorkingDir string
 }
 
@@ -297,6 +312,15 @@ func InMemoryFileSystem() FileSystemConfig {
 	}
 }
 
+// SeededInMemoryFileSystem returns an in-memory filesystem configuration
+// preloaded with the provided files.
+func SeededInMemoryFileSystem(files gbfs.InitialFiles) FileSystemConfig {
+	return FileSystemConfig{
+		Factory:    gbfs.SeededMemory(files),
+		WorkingDir: InMemoryFileSystem().WorkingDir,
+	}
+}
+
 // CustomFileSystem wires an arbitrary filesystem factory into the runtime.
 //
 // This is the low-level escape hatch for callers that want to seed a custom
@@ -304,6 +328,21 @@ func InMemoryFileSystem() FileSystemConfig {
 func CustomFileSystem(factory gbfs.Factory, workingDir string) FileSystemConfig {
 	return FileSystemConfig{
 		Factory:    factory,
+		WorkingDir: workingDir,
+	}
+}
+
+// MountableFileSystem returns a multi-mount filesystem configuration.
+func MountableFileSystem(opts MountableFileSystemOptions) FileSystemConfig {
+	workingDir := strings.TrimSpace(opts.WorkingDir)
+	if workingDir == "" {
+		workingDir = InMemoryFileSystem().WorkingDir
+	}
+	return FileSystemConfig{
+		Factory: gbfs.Mountable(gbfs.MountableOptions{
+			Base:   opts.Base,
+			Mounts: append([]gbfs.MountConfig(nil), opts.Mounts...),
+		}),
 		WorkingDir: workingDir,
 	}
 }

--- a/fs/copy_internal.go
+++ b/fs/copy_internal.go
@@ -1,0 +1,98 @@
+package fs
+
+import (
+	"context"
+	"io"
+	stdfs "io/fs"
+	"os"
+)
+
+func copyPathInto(ctx context.Context, src FileSystem, srcName string, dst FileSystem, dstName string) error {
+	return copyPathIntoWithInfo(ctx, src, srcName, nil, dst, dstName)
+}
+
+func copyPathIntoWithInfo(ctx context.Context, src FileSystem, srcName string, info stdfs.FileInfo, dst FileSystem, dstName string) error {
+	var err error
+	if info == nil {
+		info, err = src.Lstat(ctx, srcName)
+		if err != nil {
+			return err
+		}
+	}
+
+	ownership, hasOwnership := OwnershipFromFileInfo(info)
+	absDst := Clean(dstName)
+
+	switch {
+	case info.Mode()&stdfs.ModeSymlink != 0:
+		target, err := src.Readlink(ctx, srcName)
+		if err != nil {
+			return err
+		}
+		if err := dst.Symlink(ctx, target, absDst); err != nil {
+			return err
+		}
+		if hasOwnership {
+			if err := dst.Chown(ctx, absDst, ownership.UID, ownership.GID, false); err != nil {
+				return err
+			}
+		}
+		return nil
+	case info.IsDir():
+		if err := dst.MkdirAll(ctx, absDst, info.Mode().Perm()); err != nil {
+			return err
+		}
+		if err := dst.Chmod(ctx, absDst, info.Mode().Perm()); err != nil {
+			return err
+		}
+		if hasOwnership {
+			if err := dst.Chown(ctx, absDst, ownership.UID, ownership.GID, false); err != nil {
+				return err
+			}
+		}
+		entries, err := src.ReadDir(ctx, srcName)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			childSrc := joinChildPath(Clean(srcName), entry.Name())
+			childDst := joinChildPath(absDst, entry.Name())
+			var childInfo stdfs.FileInfo
+			if entry.Type()&stdfs.ModeSymlink == 0 {
+				childInfo, _ = entry.Info()
+			}
+			if err := copyPathIntoWithInfo(ctx, src, childSrc, childInfo, dst, childDst); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return copyFileInto(ctx, src, srcName, dst, absDst, info)
+	}
+}
+
+func copyFileInto(ctx context.Context, src FileSystem, srcName string, dst FileSystem, dstName string, info stdfs.FileInfo) error {
+	reader, err := src.Open(ctx, srcName)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = reader.Close() }()
+
+	writer, err := dst.OpenFile(ctx, dstName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = writer.Close() }()
+
+	if _, err := io.Copy(writer, reader); err != nil {
+		return err
+	}
+	if err := dst.Chmod(ctx, dstName, info.Mode().Perm()); err != nil {
+		return err
+	}
+	ownership, ok := OwnershipFromFileInfo(info)
+	if !ok {
+		return nil
+	}
+	return dst.Chown(ctx, dstName, ownership.UID, ownership.GID, true)
+}

--- a/fs/initial_files.go
+++ b/fs/initial_files.go
@@ -1,0 +1,51 @@
+package fs
+
+import (
+	"context"
+	stdfs "io/fs"
+	"time"
+)
+
+// LazyFileProvider returns file contents on first materialization.
+type LazyFileProvider func(context.Context) ([]byte, error)
+
+// InitialFile describes an eagerly or lazily seeded in-memory file.
+//
+// When Lazy is nil, Content is used as the initial file contents. A nil Content
+// value in that case represents an empty file.
+type InitialFile struct {
+	Content []byte
+	Lazy    LazyFileProvider
+	Mode    stdfs.FileMode
+	ModTime time.Time
+}
+
+// InitialFiles maps sandbox paths to seeded file contents.
+type InitialFiles map[string]InitialFile
+
+type seededMemoryFactory struct {
+	files InitialFiles
+}
+
+func (f seededMemoryFactory) New(context.Context) (FileSystem, error) {
+	mem := NewMemory()
+	if err := mem.seedInitialFiles(f.files, time.Now().UTC()); err != nil {
+		return nil, err
+	}
+	return mem, nil
+}
+
+// SeededMemory returns a factory that creates a fresh in-memory filesystem
+// preloaded with the provided initial files.
+func SeededMemory(files InitialFiles) Factory {
+	copied := make(InitialFiles, len(files))
+	for name, file := range files {
+		copied[name] = InitialFile{
+			Content: append([]byte(nil), file.Content...),
+			Lazy:    file.Lazy,
+			Mode:    file.Mode,
+			ModTime: file.ModTime,
+		}
+	}
+	return seededMemoryFactory{files: copied}
+}

--- a/fs/memory.go
+++ b/fs/memory.go
@@ -23,6 +23,7 @@ type MemoryFS struct {
 type memoryNode struct {
 	mode     stdfs.FileMode
 	data     []byte
+	lazy     LazyFileProvider
 	target   string
 	children map[string]struct{}
 	atime    time.Time
@@ -62,7 +63,9 @@ func (m *MemoryFS) Clone() *MemoryFS {
 	for name, node := range m.nodes {
 		cloned := &memoryNode{
 			mode:    node.mode,
+			lazy:    node.lazy,
 			target:  node.target,
+			atime:   node.atime,
 			modTime: node.modTime,
 			uid:     node.uid,
 			gid:     node.gid,
@@ -82,6 +85,127 @@ func (m *MemoryFS) Clone() *MemoryFS {
 	return &MemoryFS{
 		cwd:   m.cwd,
 		nodes: nodes,
+	}
+}
+
+func (m *MemoryFS) seedInitialFiles(files InitialFiles, now time.Time) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for name, file := range files {
+		if err := m.seedInitialFileLocked(name, file, now); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *MemoryFS) seedInitialFileLocked(name string, file InitialFile, now time.Time) error {
+	abs := Clean(name)
+	if abs == "/" {
+		return &os.PathError{Op: "seed", Path: abs, Err: stdfs.ErrInvalid}
+	}
+	if file.Lazy != nil && file.Content != nil {
+		return &os.PathError{Op: "seed", Path: abs, Err: stdfs.ErrInvalid}
+	}
+	if err := m.mkdirAllLocked(parentDir(abs), 0o755); err != nil {
+		return err
+	}
+
+	mode := file.Mode.Perm()
+	if mode == 0 {
+		mode = 0o644
+	}
+	modTime := file.ModTime.UTC()
+	if modTime.IsZero() {
+		modTime = now.UTC()
+	}
+
+	node := &memoryNode{
+		mode:    mode,
+		lazy:    file.Lazy,
+		data:    append([]byte(nil), file.Content...),
+		atime:   modTime,
+		modTime: modTime,
+		uid:     DefaultOwnerUID,
+		gid:     DefaultOwnerGID,
+	}
+	m.nodes[abs] = node
+	m.nodes[parentDir(abs)].children[path.Base(abs)] = struct{}{}
+	return nil
+}
+
+func isLazyFileNode(node *memoryNode) bool {
+	return node != nil && node.lazy != nil && !node.mode.IsDir() && node.mode&stdfs.ModeSymlink == 0
+}
+
+func (m *MemoryFS) materializePath(ctx context.Context, name string, followFinal bool) (string, *memoryNode, error) {
+	for {
+		m.mu.RLock()
+		abs, node, err := m.resolvePathLocked(name, followFinal, false)
+		if err != nil {
+			m.mu.RUnlock()
+			return "", nil, err
+		}
+		if !isLazyFileNode(node) {
+			m.mu.RUnlock()
+			return abs, node, nil
+		}
+		lazy := node.lazy
+		m.mu.RUnlock()
+
+		data, err := lazy(ctx)
+		if err != nil {
+			return "", nil, err
+		}
+		buf := append([]byte(nil), data...)
+
+		m.mu.Lock()
+		current, ok := m.nodes[abs]
+		if ok && current == node && isLazyFileNode(current) {
+			current.data = buf
+			current.lazy = nil
+			m.mu.Unlock()
+			return abs, current, nil
+		}
+		m.mu.Unlock()
+	}
+}
+
+func (m *MemoryFS) materializeResolvedPath(ctx context.Context, abs string) error {
+	for {
+		m.mu.RLock()
+		node, ok := m.nodes[abs]
+		if !ok {
+			m.mu.RUnlock()
+			return stdfs.ErrNotExist
+		}
+		if !isLazyFileNode(node) {
+			m.mu.RUnlock()
+			return nil
+		}
+		lazy := node.lazy
+		m.mu.RUnlock()
+
+		data, err := lazy(ctx)
+		if err != nil {
+			return err
+		}
+		buf := append([]byte(nil), data...)
+
+		m.mu.Lock()
+		current, ok := m.nodes[abs]
+		if ok && current == node && isLazyFileNode(current) {
+			current.data = buf
+			current.lazy = nil
+			m.mu.Unlock()
+			return nil
+		}
+		m.mu.Unlock()
 	}
 }
 
@@ -139,7 +263,13 @@ func (m *MemoryFS) Open(ctx context.Context, name string) (File, error) {
 	return m.OpenFile(ctx, name, os.O_RDONLY, 0)
 }
 
-func (m *MemoryFS) OpenFile(_ context.Context, name string, flag int, perm stdfs.FileMode) (File, error) {
+func (m *MemoryFS) OpenFile(ctx context.Context, name string, flag int, perm stdfs.FileMode) (File, error) {
+	if !hasWriteIntent(flag) && flag&os.O_CREATE == 0 {
+		if _, _, err := m.materializePath(ctx, name, true); err != nil {
+			return nil, &os.PathError{Op: "open", Path: Resolve(m.Getwd(), name), Err: err}
+		}
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -189,6 +319,7 @@ func (m *MemoryFS) OpenFile(_ context.Context, name string, flag int, perm stdfs
 	}
 
 	if flag&os.O_TRUNC != 0 && canWrite(flag) {
+		node.lazy = nil
 		node.data = nil
 		node.modTime = time.Now().UTC()
 	}
@@ -206,22 +337,16 @@ func (m *MemoryFS) OpenFile(_ context.Context, name string, flag int, perm stdfs
 	}, nil
 }
 
-func (m *MemoryFS) Stat(_ context.Context, name string) (stdfs.FileInfo, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	abs, node, err := m.resolvePathLocked(name, true, false)
+func (m *MemoryFS) Stat(ctx context.Context, name string) (stdfs.FileInfo, error) {
+	abs, node, err := m.materializePath(ctx, name, true)
 	if err != nil {
 		return nil, &os.PathError{Op: "stat", Path: Resolve(m.cwd, name), Err: err}
 	}
 	return newFileInfo(path.Base(abs), node), nil
 }
 
-func (m *MemoryFS) Lstat(_ context.Context, name string) (stdfs.FileInfo, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	abs, node, err := m.resolvePathLocked(name, false, false)
+func (m *MemoryFS) Lstat(ctx context.Context, name string) (stdfs.FileInfo, error) {
+	abs, node, err := m.materializePath(ctx, name, false)
 	if err != nil {
 		return nil, &os.PathError{Op: "lstat", Path: Resolve(m.cwd, name), Err: err}
 	}
@@ -250,8 +375,12 @@ func (m *MemoryFS) ReadDir(_ context.Context, name string) ([]stdfs.DirEntry, er
 	for _, child := range names {
 		childPath := Resolve(abs, child)
 		childNode := m.nodes[childPath]
-		info := newFileInfo(child, childNode)
-		entries = append(entries, stdfs.FileInfoToDirEntry(info))
+		entries = append(entries, memoryDirEntry{
+			fs:   m,
+			name: child,
+			path: childPath,
+			mode: childNode.mode,
+		})
 	}
 	return entries, nil
 }
@@ -615,23 +744,37 @@ func (f *memoryFile) Read(p []byte) (int, error) {
 		return 0, &os.PathError{Op: "read", Path: f.path, Err: stdfs.ErrPermission}
 	}
 
-	f.fs.mu.RLock()
-	defer f.fs.mu.RUnlock()
-
-	node, ok := f.fs.nodes[f.path]
-	if !ok {
-		return 0, &os.PathError{Op: "read", Path: f.path, Err: stdfs.ErrNotExist}
+	var (
+		node *memoryNode
+		ok   bool
+	)
+	for {
+		f.fs.mu.RLock()
+		node, ok = f.fs.nodes[f.path]
+		if !ok {
+			f.fs.mu.RUnlock()
+			return 0, &os.PathError{Op: "read", Path: f.path, Err: stdfs.ErrNotExist}
+		}
+		if isLazyFileNode(node) {
+			f.fs.mu.RUnlock()
+			if err := f.fs.materializeResolvedPath(context.Background(), f.path); err != nil {
+				return 0, &os.PathError{Op: "read", Path: f.path, Err: err}
+			}
+			continue
+		}
+		if node.mode.IsDir() {
+			f.fs.mu.RUnlock()
+			return 0, &os.PathError{Op: "read", Path: f.path, Err: stdfs.ErrInvalid}
+		}
+		if f.offset >= int64(len(node.data)) {
+			f.fs.mu.RUnlock()
+			return 0, io.EOF
+		}
+		n := copy(p, node.data[f.offset:])
+		f.offset += int64(n)
+		f.fs.mu.RUnlock()
+		return n, nil
 	}
-	if node.mode.IsDir() {
-		return 0, &os.PathError{Op: "read", Path: f.path, Err: stdfs.ErrInvalid}
-	}
-
-	if f.offset >= int64(len(node.data)) {
-		return 0, io.EOF
-	}
-	n := copy(p, node.data[f.offset:])
-	f.offset += int64(n)
-	return n, nil
 }
 
 func (f *memoryFile) Write(p []byte) (int, error) {
@@ -651,6 +794,10 @@ func (f *memoryFile) Write(p []byte) (int, error) {
 	}
 	if node.mode.IsDir() {
 		return 0, &os.PathError{Op: "write", Path: f.path, Err: stdfs.ErrInvalid}
+	}
+	if isLazyFileNode(node) {
+		node.lazy = nil
+		node.data = nil
 	}
 
 	if f.flag&os.O_APPEND != 0 {
@@ -762,6 +909,20 @@ type fileInfo struct {
 	modTime time.Time
 	uid     uint32
 	gid     uint32
+}
+
+type memoryDirEntry struct {
+	fs   *MemoryFS
+	name string
+	path string
+	mode stdfs.FileMode
+}
+
+func (e memoryDirEntry) Name() string         { return e.name }
+func (e memoryDirEntry) IsDir() bool          { return e.mode.IsDir() }
+func (e memoryDirEntry) Type() stdfs.FileMode { return e.mode.Type() }
+func (e memoryDirEntry) Info() (stdfs.FileInfo, error) {
+	return e.fs.Lstat(context.Background(), e.path)
 }
 
 func newFileInfo(name string, node *memoryNode) *fileInfo {

--- a/fs/mountable.go
+++ b/fs/mountable.go
@@ -1,0 +1,758 @@
+package fs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	stdfs "io/fs"
+	"os"
+	"path"
+	"slices"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// MountConfig describes a filesystem mounted at a sandbox path.
+type MountConfig struct {
+	MountPoint string
+	Factory    Factory
+}
+
+// MountedFS is a snapshot of a live mount table entry.
+type MountedFS struct {
+	MountPoint string
+	FileSystem FileSystem
+}
+
+// MountableOptions configures a multi-mount filesystem factory.
+type MountableOptions struct {
+	Base   Factory
+	Mounts []MountConfig
+}
+
+type mountableFactory struct {
+	base   Factory
+	mounts []MountConfig
+}
+
+func (f mountableFactory) New(ctx context.Context) (FileSystem, error) {
+	baseFactory := f.base
+	if baseFactory == nil {
+		baseFactory = Memory()
+	}
+	base, err := baseFactory.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	mountable := NewMountable(base)
+	for _, cfg := range f.mounts {
+		if cfg.Factory == nil {
+			return nil, fmt.Errorf("mount %q: factory is nil", cfg.MountPoint)
+		}
+		fsys, err := cfg.Factory.New(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("mount %q: %w", cfg.MountPoint, err)
+		}
+		if err := mountable.Mount(cfg.MountPoint, fsys); err != nil {
+			return nil, err
+		}
+	}
+	return mountable, nil
+}
+
+// Mountable returns a factory that provisions a multi-mount filesystem.
+func Mountable(opts MountableOptions) Factory {
+	mounts := make([]MountConfig, 0, len(opts.Mounts))
+	for _, cfg := range opts.Mounts {
+		mounts = append(mounts, MountConfig{
+			MountPoint: cfg.MountPoint,
+			Factory:    cfg.Factory,
+		})
+	}
+	return mountableFactory{
+		base:   opts.Base,
+		mounts: mounts,
+	}
+}
+
+// MountableFS routes sandbox paths across a base filesystem and mounted child
+// filesystems.
+type MountableFS struct {
+	mu     sync.RWMutex
+	base   FileSystem
+	cwd    string
+	mounts map[string]mountedEntry
+}
+
+type mountedEntry struct {
+	mountPoint string
+	fs         FileSystem
+}
+
+// NewMountable creates a mountable filesystem over base.
+func NewMountable(base FileSystem) *MountableFS {
+	if base == nil {
+		base = NewMemory()
+	}
+	return &MountableFS{
+		base:   base,
+		cwd:    "/",
+		mounts: make(map[string]mountedEntry),
+	}
+}
+
+// Mount mounts fs at mountPoint.
+func (m *MountableFS) Mount(mountPoint string, fsys FileSystem) error {
+	if fsys == nil {
+		return fmt.Errorf("mount %q: filesystem is nil", mountPoint)
+	}
+	if err := validateMountPath(mountPoint); err != nil {
+		return err
+	}
+	normalized := Clean(strings.TrimSpace(mountPoint))
+	if normalized == "/" {
+		return fmt.Errorf("cannot mount at root %q", normalized)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err := m.validateMountLocked(normalized); err != nil {
+		return err
+	}
+	m.mounts[normalized] = mountedEntry{
+		mountPoint: normalized,
+		fs:         fsys,
+	}
+	return nil
+}
+
+// Unmount removes the filesystem mounted at mountPoint.
+func (m *MountableFS) Unmount(mountPoint string) error {
+	normalized := Clean(strings.TrimSpace(mountPoint))
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.mounts[normalized]
+	if !ok {
+		return fmt.Errorf("no filesystem mounted at %q", mountPoint)
+	}
+	if pathWithinMount(m.cwd, entry.mountPoint) {
+		return &os.PathError{Op: "unmount", Path: normalized, Err: syscall.EBUSY}
+	}
+	delete(m.mounts, normalized)
+	return nil
+}
+
+// Mounts returns a stable snapshot of the current mount table.
+func (m *MountableFS) Mounts() []MountedFS {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make([]MountedFS, 0, len(m.mounts))
+	for _, entry := range m.mounts {
+		out = append(out, MountedFS{
+			MountPoint: entry.mountPoint,
+			FileSystem: entry.fs,
+		})
+	}
+	slices.SortFunc(out, func(a, b MountedFS) int {
+		return strings.Compare(a.MountPoint, b.MountPoint)
+	})
+	return out
+}
+
+// IsMountPoint reports whether path is an exact mount point.
+func (m *MountableFS) IsMountPoint(pathValue string) bool {
+	normalized := Clean(pathValue)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, ok := m.mounts[normalized]
+	return ok
+}
+
+func (m *MountableFS) Open(ctx context.Context, name string) (File, error) {
+	return m.OpenFile(ctx, name, os.O_RDONLY, 0)
+}
+
+func (m *MountableFS) OpenFile(ctx context.Context, name string, flag int, perm stdfs.FileMode) (File, error) {
+	abs := m.resolve(name)
+	fsys, rel := m.routedView(abs)
+	return fsys.OpenFile(ctx, rel, flag, perm)
+}
+
+func (m *MountableFS) Stat(ctx context.Context, name string) (stdfs.FileInfo, error) {
+	abs := m.resolve(name)
+	entry, rel, mounted, synthetic := m.route(abs)
+	switch {
+	case mounted && rel == "/":
+		info, err := entry.fs.Stat(ctx, "/")
+		if err == nil {
+			return remapFileInfoName(path.Base(abs), info), nil
+		}
+		return syntheticDirInfo(abs), nil
+	case mounted:
+		return namespacedFS{mountPoint: entry.mountPoint, inner: entry.fs}.Stat(ctx, rel)
+	case synthetic:
+		info, err := m.base.Stat(ctx, abs)
+		if err == nil {
+			return info, nil
+		}
+		if errors.Is(err, stdfs.ErrNotExist) {
+			return syntheticDirInfo(abs), nil
+		}
+		return nil, err
+	default:
+		return m.base.Stat(ctx, abs)
+	}
+}
+
+func (m *MountableFS) Lstat(ctx context.Context, name string) (stdfs.FileInfo, error) {
+	abs := m.resolve(name)
+	entry, rel, mounted, synthetic := m.route(abs)
+	switch {
+	case mounted && rel == "/":
+		info, err := entry.fs.Lstat(ctx, "/")
+		if err == nil {
+			return remapFileInfoName(path.Base(abs), info), nil
+		}
+		return syntheticDirInfo(abs), nil
+	case mounted:
+		return namespacedFS{mountPoint: entry.mountPoint, inner: entry.fs}.Lstat(ctx, rel)
+	case synthetic:
+		info, err := m.base.Lstat(ctx, abs)
+		if err == nil {
+			return info, nil
+		}
+		if errors.Is(err, stdfs.ErrNotExist) {
+			return syntheticDirInfo(abs), nil
+		}
+		return nil, err
+	default:
+		return m.base.Lstat(ctx, abs)
+	}
+}
+
+func (m *MountableFS) ReadDir(ctx context.Context, name string) ([]stdfs.DirEntry, error) {
+	abs := m.resolve(name)
+	entry, rel, mounted, synthetic := m.route(abs)
+	switch {
+	case mounted:
+		return namespacedFS{mountPoint: entry.mountPoint, inner: entry.fs}.ReadDir(ctx, rel)
+	case !synthetic:
+		return m.base.ReadDir(ctx, abs)
+	}
+
+	entriesByName := make(map[string]stdfs.DirEntry)
+	baseEntries, err := m.base.ReadDir(ctx, abs)
+	switch {
+	case err == nil:
+		for _, dirEntry := range baseEntries {
+			entriesByName[dirEntry.Name()] = dirEntry
+		}
+	case errors.Is(err, stdfs.ErrNotExist):
+	default:
+		return nil, err
+	}
+
+	for _, child := range m.childMountNames(abs) {
+		if _, ok := entriesByName[child]; ok {
+			continue
+		}
+		entriesByName[child] = stdfs.FileInfoToDirEntry(syntheticDirInfo(joinChildPath(abs, child)))
+	}
+
+	names := make([]string, 0, len(entriesByName))
+	for name := range entriesByName {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	out := make([]stdfs.DirEntry, 0, len(names))
+	for _, name := range names {
+		out = append(out, entriesByName[name])
+	}
+	return out, nil
+}
+
+func (m *MountableFS) Readlink(ctx context.Context, name string) (string, error) {
+	abs := m.resolve(name)
+	entry, rel, mounted, _ := m.route(abs)
+	if mounted {
+		return namespacedFS{mountPoint: entry.mountPoint, inner: entry.fs}.Readlink(ctx, rel)
+	}
+	return m.base.Readlink(ctx, abs)
+}
+
+func (m *MountableFS) Realpath(ctx context.Context, name string) (string, error) {
+	abs := m.resolve(name)
+	entry, rel, mounted, synthetic := m.route(abs)
+	switch {
+	case mounted && rel == "/":
+		return entry.mountPoint, nil
+	case mounted:
+		return namespacedFS{mountPoint: entry.mountPoint, inner: entry.fs}.Realpath(ctx, rel)
+	case synthetic:
+		resolved, err := m.base.Realpath(ctx, abs)
+		if err == nil {
+			return resolved, nil
+		}
+		if errors.Is(err, stdfs.ErrNotExist) {
+			return abs, nil
+		}
+		return "", err
+	default:
+		return m.base.Realpath(ctx, abs)
+	}
+}
+
+func (m *MountableFS) Symlink(ctx context.Context, target, linkName string) error {
+	abs := m.resolve(linkName)
+	fsys, rel := m.routedView(abs)
+	return fsys.Symlink(ctx, target, rel)
+}
+
+func (m *MountableFS) Link(ctx context.Context, oldName, newName string) error {
+	oldAbs := m.resolve(oldName)
+	newAbs := m.resolve(newName)
+	oldEntry, oldRel, oldMounted, _ := m.route(oldAbs)
+	newEntry, newRel, newMounted, _ := m.route(newAbs)
+	if oldMounted != newMounted || (oldMounted && oldEntry.mountPoint != newEntry.mountPoint) {
+		return &os.LinkError{Op: "link", Old: oldAbs, New: newAbs, Err: syscall.EXDEV}
+	}
+	if oldMounted {
+		return namespacedFS{mountPoint: oldEntry.mountPoint, inner: oldEntry.fs}.Link(ctx, oldRel, newRel)
+	}
+	return m.base.Link(ctx, oldRel, newRel)
+}
+
+func (m *MountableFS) Chown(ctx context.Context, name string, uid, gid uint32, follow bool) error {
+	abs := m.resolve(name)
+	fsys, rel := m.routedView(abs)
+	return fsys.Chown(ctx, rel, uid, gid, follow)
+}
+
+func (m *MountableFS) Chmod(ctx context.Context, name string, mode stdfs.FileMode) error {
+	abs := m.resolve(name)
+	fsys, rel := m.routedView(abs)
+	return fsys.Chmod(ctx, rel, mode)
+}
+
+func (m *MountableFS) Chtimes(ctx context.Context, name string, atime, mtime time.Time) error {
+	abs := m.resolve(name)
+	fsys, rel := m.routedView(abs)
+	return fsys.Chtimes(ctx, rel, atime, mtime)
+}
+
+func (m *MountableFS) MkdirAll(ctx context.Context, name string, perm stdfs.FileMode) error {
+	abs := m.resolve(name)
+	_, _, mounted, synthetic := m.route(abs)
+	if synthetic {
+		if info, err := m.base.Stat(ctx, abs); err == nil {
+			if !info.IsDir() {
+				return &os.PathError{Op: "mkdir", Path: abs, Err: stdfs.ErrInvalid}
+			}
+		} else if !errors.Is(err, stdfs.ErrNotExist) {
+			return err
+		}
+		return nil
+	}
+	fsys, rel := m.routedView(abs)
+	if mounted && rel == "/" {
+		return nil
+	}
+	return fsys.MkdirAll(ctx, rel, perm)
+}
+
+func (m *MountableFS) Remove(ctx context.Context, name string, recursive bool) error {
+	abs := m.resolve(name)
+	if m.pathContainsMount(abs) {
+		return &os.PathError{Op: "remove", Path: abs, Err: syscall.EBUSY}
+	}
+	fsys, rel := m.routedView(abs)
+	return fsys.Remove(ctx, rel, recursive)
+}
+
+func (m *MountableFS) Rename(ctx context.Context, oldName, newName string) error {
+	oldAbs := m.resolve(oldName)
+	newAbs := m.resolve(newName)
+	if m.pathContainsMount(oldAbs) {
+		return &os.PathError{Op: "rename", Path: oldAbs, Err: syscall.EBUSY}
+	}
+	if m.pathContainsMount(newAbs) {
+		return &os.PathError{Op: "rename", Path: newAbs, Err: syscall.EBUSY}
+	}
+
+	oldEntry, oldRel, oldMounted, _ := m.route(oldAbs)
+	newEntry, newRel, newMounted, _ := m.route(newAbs)
+	if oldMounted == newMounted && (!oldMounted || oldEntry.mountPoint == newEntry.mountPoint) {
+		if oldMounted {
+			return namespacedFS{mountPoint: oldEntry.mountPoint, inner: oldEntry.fs}.Rename(ctx, oldRel, newRel)
+		}
+		return m.base.Rename(ctx, oldRel, newRel)
+	}
+
+	src := m.base
+	if oldMounted {
+		src = namespacedFS{mountPoint: oldEntry.mountPoint, inner: oldEntry.fs}
+	}
+	dst := m.base
+	if newMounted {
+		dst = namespacedFS{mountPoint: newEntry.mountPoint, inner: newEntry.fs}
+	}
+	if err := copyPathInto(ctx, src, oldRel, dst, newRel); err != nil {
+		return err
+	}
+	return src.Remove(ctx, oldRel, true)
+}
+
+func (m *MountableFS) Getwd() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.cwd
+}
+
+func (m *MountableFS) Chdir(name string) error {
+	abs := m.resolve(name)
+	entry, rel, mounted, synthetic := m.route(abs)
+
+	switch {
+	case mounted:
+		info, err := namespacedFS{mountPoint: entry.mountPoint, inner: entry.fs}.Stat(context.Background(), rel)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return &os.PathError{Op: "chdir", Path: abs, Err: stdfs.ErrInvalid}
+		}
+	case synthetic:
+		if info, err := m.base.Stat(context.Background(), abs); err == nil {
+			if !info.IsDir() {
+				return &os.PathError{Op: "chdir", Path: abs, Err: stdfs.ErrInvalid}
+			}
+		} else if !errors.Is(err, stdfs.ErrNotExist) {
+			return err
+		}
+	default:
+		info, err := m.base.Stat(context.Background(), abs)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return &os.PathError{Op: "chdir", Path: abs, Err: stdfs.ErrInvalid}
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cwd = abs
+	return nil
+}
+
+func (m *MountableFS) resolve(name string) string {
+	return Resolve(m.Getwd(), name)
+}
+
+func (m *MountableFS) route(abs string) (entry mountedEntry, rel string, mounted, synthetic bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	entry, rel, mounted = m.routeLocked(abs)
+	synthetic = m.isSyntheticParentLocked(abs)
+	return entry, rel, mounted, synthetic
+}
+
+func (m *MountableFS) routedView(abs string) (fsys FileSystem, rel string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	entry, rel, mounted := m.routeLocked(abs)
+	if mounted {
+		fsys = namespacedFS{mountPoint: entry.mountPoint, inner: entry.fs}
+		return fsys, rel
+	}
+	return m.base, rel
+}
+
+func (m *MountableFS) routeLocked(abs string) (mountedEntry, string, bool) {
+	abs = Clean(abs)
+	if entry, ok := m.mounts[abs]; ok {
+		return entry, "/", true
+	}
+	for mountPoint, entry := range m.mounts {
+		if strings.HasPrefix(abs, mountPoint+"/") {
+			return entry, strings.TrimPrefix(abs, mountPoint), true
+		}
+	}
+	return mountedEntry{}, abs, false
+}
+
+func (m *MountableFS) validateMountLocked(mountPoint string) error {
+	for existing := range m.mounts {
+		if existing == mountPoint {
+			continue
+		}
+		if strings.HasPrefix(mountPoint, existing+"/") {
+			return fmt.Errorf("cannot mount at %q: inside existing mount %q", mountPoint, existing)
+		}
+		if strings.HasPrefix(existing, mountPoint+"/") {
+			return fmt.Errorf("cannot mount at %q: would contain existing mount %q", mountPoint, existing)
+		}
+	}
+	return nil
+}
+
+func (m *MountableFS) childMountNames(abs string) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.childMountNamesLocked(abs)
+}
+
+func (m *MountableFS) childMountNamesLocked(abs string) []string {
+	abs = Clean(abs)
+	prefix := abs
+	if prefix == "/" {
+		prefix = ""
+	}
+	children := make(map[string]struct{})
+	for mountPoint := range m.mounts {
+		if prefix != "" && !strings.HasPrefix(mountPoint, prefix+"/") {
+			continue
+		}
+		remainder := strings.TrimPrefix(mountPoint, prefix+"/")
+		if prefix == "" {
+			remainder = strings.TrimPrefix(mountPoint, "/")
+		}
+		child := strings.SplitN(remainder, "/", 2)[0]
+		if child != "" {
+			children[child] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(children))
+	for child := range children {
+		names = append(names, child)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func (m *MountableFS) isSyntheticParentLocked(abs string) bool {
+	if _, ok := m.mounts[abs]; ok {
+		return false
+	}
+	for mountPoint := range m.mounts {
+		if strings.HasPrefix(mountPoint, abs+"/") || abs == "/" {
+			if abs == "/" || strings.HasPrefix(mountPoint, abs+"/") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (m *MountableFS) pathContainsMount(abs string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if abs == "/" {
+		return len(m.mounts) > 0
+	}
+	for mountPoint := range m.mounts {
+		if mountPoint == abs || strings.HasPrefix(mountPoint, abs+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func pathWithinMount(pathValue, mountPoint string) bool {
+	return pathValue == mountPoint || strings.HasPrefix(pathValue, mountPoint+"/")
+}
+
+func validateMountPath(mountPoint string) error {
+	mountPoint = strings.TrimSpace(mountPoint)
+	if mountPoint == "" {
+		return fmt.Errorf("mount point must be absolute: %q", mountPoint)
+	}
+	if !strings.HasPrefix(mountPoint, "/") {
+		return fmt.Errorf("mount point must be absolute: %q", mountPoint)
+	}
+	for segment := range strings.SplitSeq(mountPoint, "/") {
+		if segment == "." || segment == ".." {
+			return fmt.Errorf("invalid mount point %q: contains '.' or '..' segments", mountPoint)
+		}
+	}
+	if Clean(mountPoint) == "/" {
+		return fmt.Errorf("cannot mount at root %q", mountPoint)
+	}
+	return nil
+}
+
+type namespacedFS struct {
+	mountPoint string
+	inner      FileSystem
+}
+
+func (f namespacedFS) Open(ctx context.Context, name string) (File, error) {
+	file, err := f.inner.Open(ctx, name)
+	return file, namespaceError(err, f.mountPoint)
+}
+
+func (f namespacedFS) OpenFile(ctx context.Context, name string, flag int, perm stdfs.FileMode) (File, error) {
+	file, err := f.inner.OpenFile(ctx, name, flag, perm)
+	return file, namespaceError(err, f.mountPoint)
+}
+
+func (f namespacedFS) Stat(ctx context.Context, name string) (stdfs.FileInfo, error) {
+	info, err := f.inner.Stat(ctx, name)
+	return info, namespaceError(err, f.mountPoint)
+}
+
+func (f namespacedFS) Lstat(ctx context.Context, name string) (stdfs.FileInfo, error) {
+	info, err := f.inner.Lstat(ctx, name)
+	return info, namespaceError(err, f.mountPoint)
+}
+
+func (f namespacedFS) ReadDir(ctx context.Context, name string) ([]stdfs.DirEntry, error) {
+	entries, err := f.inner.ReadDir(ctx, name)
+	return entries, namespaceError(err, f.mountPoint)
+}
+
+func (f namespacedFS) Readlink(ctx context.Context, name string) (string, error) {
+	target, err := f.inner.Readlink(ctx, name)
+	return target, namespaceError(err, f.mountPoint)
+}
+
+func (f namespacedFS) Realpath(ctx context.Context, name string) (string, error) {
+	resolved, err := f.inner.Realpath(ctx, name)
+	if err != nil {
+		return "", namespaceError(err, f.mountPoint)
+	}
+	return prefixMountPath(f.mountPoint, resolved), nil
+}
+
+func (f namespacedFS) Symlink(ctx context.Context, target, linkName string) error {
+	return namespaceError(f.inner.Symlink(ctx, target, linkName), f.mountPoint)
+}
+
+func (f namespacedFS) Link(ctx context.Context, oldName, newName string) error {
+	return namespaceError(f.inner.Link(ctx, oldName, newName), f.mountPoint)
+}
+
+func (f namespacedFS) Chown(ctx context.Context, name string, uid, gid uint32, follow bool) error {
+	return namespaceError(f.inner.Chown(ctx, name, uid, gid, follow), f.mountPoint)
+}
+
+func (f namespacedFS) Chmod(ctx context.Context, name string, mode stdfs.FileMode) error {
+	return namespaceError(f.inner.Chmod(ctx, name, mode), f.mountPoint)
+}
+
+func (f namespacedFS) Chtimes(ctx context.Context, name string, atime, mtime time.Time) error {
+	return namespaceError(f.inner.Chtimes(ctx, name, atime, mtime), f.mountPoint)
+}
+
+func (f namespacedFS) MkdirAll(ctx context.Context, name string, perm stdfs.FileMode) error {
+	return namespaceError(f.inner.MkdirAll(ctx, name, perm), f.mountPoint)
+}
+
+func (f namespacedFS) Remove(ctx context.Context, name string, recursive bool) error {
+	return namespaceError(f.inner.Remove(ctx, name, recursive), f.mountPoint)
+}
+
+func (f namespacedFS) Rename(ctx context.Context, oldName, newName string) error {
+	return namespaceError(f.inner.Rename(ctx, oldName, newName), f.mountPoint)
+}
+
+func (f namespacedFS) Getwd() string {
+	return prefixMountPath(f.mountPoint, f.inner.Getwd())
+}
+
+func (f namespacedFS) Chdir(name string) error {
+	return namespaceError(f.inner.Chdir(name), f.mountPoint)
+}
+
+func namespaceError(err error, mountPoint string) error {
+	if err == nil || mountPoint == "" {
+		return err
+	}
+
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		return &os.PathError{
+			Op:   pathErr.Op,
+			Path: prefixMountPath(mountPoint, pathErr.Path),
+			Err:  pathErr.Err,
+		}
+	}
+
+	var linkErr *os.LinkError
+	if errors.As(err, &linkErr) {
+		return &os.LinkError{
+			Op:  linkErr.Op,
+			Old: prefixMountPath(mountPoint, linkErr.Old),
+			New: prefixMountPath(mountPoint, linkErr.New),
+			Err: linkErr.Err,
+		}
+	}
+
+	return err
+}
+
+func prefixMountPath(mountPoint, pathValue string) string {
+	pathValue = Clean(pathValue)
+	if pathValue == "/" {
+		return mountPoint
+	}
+	return Resolve(mountPoint, strings.TrimPrefix(pathValue, "/"))
+}
+
+func syntheticDirInfo(abs string) stdfs.FileInfo {
+	name := path.Base(abs)
+	if abs == "/" {
+		name = "/"
+	}
+	return mountableStaticInfo{
+		name:    name,
+		mode:    stdfs.ModeDir | 0o755,
+		modTime: time.Time{},
+	}
+}
+
+func remapFileInfoName(name string, info stdfs.FileInfo) stdfs.FileInfo {
+	return mountableNamedInfo{name: name, info: info}
+}
+
+type mountableNamedInfo struct {
+	name string
+	info stdfs.FileInfo
+}
+
+func (i mountableNamedInfo) Name() string         { return i.name }
+func (i mountableNamedInfo) Size() int64          { return i.info.Size() }
+func (i mountableNamedInfo) Mode() stdfs.FileMode { return i.info.Mode() }
+func (i mountableNamedInfo) ModTime() time.Time   { return i.info.ModTime() }
+func (i mountableNamedInfo) IsDir() bool          { return i.info.IsDir() }
+func (i mountableNamedInfo) Sys() any             { return i.info.Sys() }
+func (i mountableNamedInfo) Ownership() (FileOwnership, bool) {
+	return OwnershipFromFileInfo(i.info)
+}
+
+type mountableStaticInfo struct {
+	name    string
+	size    int64
+	mode    stdfs.FileMode
+	modTime time.Time
+}
+
+func (i mountableStaticInfo) Name() string         { return i.name }
+func (i mountableStaticInfo) Size() int64          { return i.size }
+func (i mountableStaticInfo) Mode() stdfs.FileMode { return i.mode }
+func (i mountableStaticInfo) ModTime() time.Time   { return i.modTime }
+func (i mountableStaticInfo) IsDir() bool          { return i.mode.IsDir() }
+func (i mountableStaticInfo) Sys() any             { return nil }
+func (i mountableStaticInfo) Ownership() (FileOwnership, bool) {
+	return DefaultOwnership(), true
+}
+
+var _ FileSystem = (*MountableFS)(nil)

--- a/fs/mountable_lazy_test.go
+++ b/fs/mountable_lazy_test.go
@@ -1,0 +1,452 @@
+package fs
+
+import (
+	"context"
+	"errors"
+	stdfs "io/fs"
+	"os"
+	"slices"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestMountableFSRejectsInvalidMountsAndAllowsRemount(t *testing.T) {
+	t.Parallel()
+
+	fs := NewMountable(NewMemory())
+
+	if err := fs.Mount("/", NewMemory()); err == nil {
+		t.Fatal("Mount(/) error = nil, want rejection")
+	}
+	if err := fs.Mount("relative", NewMemory()); err == nil {
+		t.Fatal("Mount(relative) error = nil, want rejection")
+	}
+	if err := fs.Mount("/mnt/../data", NewMemory()); err == nil {
+		t.Fatal("Mount(/mnt/../data) error = nil, want rejection")
+	}
+
+	first := NewMemory()
+	if err := fs.Mount("/mnt/data", first); err != nil {
+		t.Fatalf("Mount(first) error = %v", err)
+	}
+	if err := fs.Mount("/mnt/data/sub", NewMemory()); err == nil {
+		t.Fatal("Mount(nested child) error = nil, want rejection")
+	}
+	if err := fs.Mount("/mnt", NewMemory()); err == nil {
+		t.Fatal("Mount(parent) error = nil, want rejection")
+	}
+
+	second := NewMemory()
+	if err := fs.Mount("/mnt/data", second); err != nil {
+		t.Fatalf("Mount(remount) error = %v", err)
+	}
+
+	mounts := fs.Mounts()
+	if len(mounts) != 1 {
+		t.Fatalf("len(Mounts()) = %d, want 1", len(mounts))
+	}
+	if mounts[0].FileSystem != second {
+		t.Fatalf("Mounts()[0].FileSystem = %T, want remounted filesystem", mounts[0].FileSystem)
+	}
+}
+
+func TestMountableFSSynthesizesParentsAndRoutesToMountedRoots(t *testing.T) {
+	t.Parallel()
+
+	base := seededMemory(t, map[string]string{
+		"/mnt/base.txt": "base\n",
+	})
+	mounted := seededMemory(t, map[string]string{
+		"/mounted.txt": "mounted\n",
+	})
+
+	fs := NewMountable(base)
+	if err := fs.Mount("/mnt/data", mounted); err != nil {
+		t.Fatalf("Mount() error = %v", err)
+	}
+
+	info, err := fs.Stat(context.Background(), "/mnt")
+	if err != nil {
+		t.Fatalf("Stat(/mnt) error = %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("Stat(/mnt).IsDir() = false, want true")
+	}
+
+	entries, err := fs.ReadDir(context.Background(), "/mnt")
+	if err != nil {
+		t.Fatalf("ReadDir(/mnt) error = %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	if got, want := names, []string{"base.txt", "data"}; !slices.Equal(got, want) {
+		t.Fatalf("ReadDir(/mnt) names = %v, want %v", got, want)
+	}
+
+	if err := fs.Chdir("/mnt"); err != nil {
+		t.Fatalf("Chdir(/mnt) error = %v", err)
+	}
+	if got, want := fs.Getwd(), "/mnt"; got != want {
+		t.Fatalf("Getwd() = %q, want %q", got, want)
+	}
+
+	if got, want := readTestFile(t, fs, "/mnt/data/mounted.txt"), "mounted\n"; got != want {
+		t.Fatalf("mounted read = %q, want %q", got, want)
+	}
+
+	rootEntries, err := fs.ReadDir(context.Background(), "/mnt/data")
+	if err != nil {
+		t.Fatalf("ReadDir(/mnt/data) error = %v", err)
+	}
+	if len(rootEntries) != 1 || rootEntries[0].Name() != "mounted.txt" {
+		t.Fatalf("ReadDir(/mnt/data) = %v, want mounted.txt", rootEntries)
+	}
+}
+
+func TestMountableFSMkdirAllMountAndSyntheticParentsIsNoop(t *testing.T) {
+	t.Parallel()
+
+	fs := NewMountable(NewMemory())
+	if err := fs.Mount("/mnt/data", NewMemory()); err != nil {
+		t.Fatalf("Mount() error = %v", err)
+	}
+
+	if err := fs.MkdirAll(context.Background(), "/mnt", 0o755); err != nil {
+		t.Fatalf("MkdirAll(/mnt) error = %v", err)
+	}
+	if err := fs.MkdirAll(context.Background(), "/mnt/data", 0o755); err != nil {
+		t.Fatalf("MkdirAll(/mnt/data) error = %v", err)
+	}
+}
+
+func TestMountableFSRemoveAndRenameRejectBusyMountPaths(t *testing.T) {
+	t.Parallel()
+
+	base := seededMemory(t, map[string]string{
+		"/plain.txt": "plain\n",
+	})
+	fs := NewMountable(base)
+	if err := fs.Mount("/mnt/data", seededMemory(t, map[string]string{"/x.txt": "x\n"})); err != nil {
+		t.Fatalf("Mount() error = %v", err)
+	}
+
+	if err := fs.Remove(context.Background(), "/mnt/data", true); !errors.Is(err, syscall.EBUSY) {
+		t.Fatalf("Remove(mount) error = %v, want EBUSY", err)
+	}
+	if err := fs.Remove(context.Background(), "/mnt", true); !errors.Is(err, syscall.EBUSY) {
+		t.Fatalf("Remove(parent) error = %v, want EBUSY", err)
+	}
+	if err := fs.Rename(context.Background(), "/mnt", "/elsewhere"); !errors.Is(err, syscall.EBUSY) {
+		t.Fatalf("Rename(parent) error = %v, want EBUSY", err)
+	}
+	if err := fs.Rename(context.Background(), "/plain.txt", "/mnt/data"); !errors.Is(err, syscall.EBUSY) {
+		t.Fatalf("Rename(dest mount) error = %v, want EBUSY", err)
+	}
+}
+
+func TestMountableFSCrossMountRenameCopiesAndDeletes(t *testing.T) {
+	t.Parallel()
+
+	srcMount := seededMemory(t, map[string]string{
+		"/dir/a.txt": "a\n",
+		"/dir/b.txt": "b\n",
+	})
+	dstMount := NewMemory()
+
+	fs := NewMountable(NewMemory())
+	if err := fs.Mount("/src", srcMount); err != nil {
+		t.Fatalf("Mount(src) error = %v", err)
+	}
+	if err := fs.Mount("/dst", dstMount); err != nil {
+		t.Fatalf("Mount(dst) error = %v", err)
+	}
+
+	if err := fs.Rename(context.Background(), "/src/dir", "/dst/copied"); err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+
+	if got, want := readTestFile(t, fs, "/dst/copied/a.txt"), "a\n"; got != want {
+		t.Fatalf("copied a.txt = %q, want %q", got, want)
+	}
+	if got, want := readTestFile(t, fs, "/dst/copied/b.txt"), "b\n"; got != want {
+		t.Fatalf("copied b.txt = %q, want %q", got, want)
+	}
+	if _, err := fs.Stat(context.Background(), "/src/dir"); !errors.Is(err, stdfs.ErrNotExist) {
+		t.Fatalf("Stat(/src/dir) error = %v, want not exist", err)
+	}
+}
+
+func TestMountableFSCrossMountLinkRejected(t *testing.T) {
+	t.Parallel()
+
+	fs := NewMountable(NewMemory())
+	if err := fs.Mount("/a", seededMemory(t, map[string]string{"/file.txt": "a\n"})); err != nil {
+		t.Fatalf("Mount(/a) error = %v", err)
+	}
+	if err := fs.Mount("/b", NewMemory()); err != nil {
+		t.Fatalf("Mount(/b) error = %v", err)
+	}
+
+	err := fs.Link(context.Background(), "/a/file.txt", "/b/file.txt")
+	if err == nil {
+		t.Fatal("Link() error = nil, want EXDEV")
+	}
+	var linkErr *os.LinkError
+	if !errors.As(err, &linkErr) || !errors.Is(linkErr.Err, syscall.EXDEV) {
+		t.Fatalf("Link() error = %v, want LinkError with EXDEV", err)
+	}
+}
+
+func TestMountableFSMountSnapshotSortedAndUnmountBusy(t *testing.T) {
+	t.Parallel()
+
+	fs := NewMountable(NewMemory())
+	if err := fs.Mount("/mnt/b", NewMemory()); err != nil {
+		t.Fatalf("Mount(/mnt/b) error = %v", err)
+	}
+	if err := fs.Mount("/mnt/a", NewMemory()); err != nil {
+		t.Fatalf("Mount(/mnt/a) error = %v", err)
+	}
+
+	mounts := fs.Mounts()
+	if got := []string{mounts[0].MountPoint, mounts[1].MountPoint}; !slices.Equal(got, []string{"/mnt/a", "/mnt/b"}) {
+		t.Fatalf("Mounts() order = %v, want sorted order", got)
+	}
+
+	if err := fs.Chdir("/mnt/a"); err != nil {
+		t.Fatalf("Chdir(/mnt/a) error = %v", err)
+	}
+	if err := fs.Unmount("/mnt/a"); !errors.Is(err, syscall.EBUSY) {
+		t.Fatalf("Unmount(/mnt/a) error = %v, want EBUSY", err)
+	}
+
+	if err := fs.Chdir("/"); err != nil {
+		t.Fatalf("Chdir(/) error = %v", err)
+	}
+	if err := fs.Unmount("/mnt/a"); err != nil {
+		t.Fatalf("Unmount(/mnt/a) error = %v", err)
+	}
+	if fs.IsMountPoint("/mnt/a") {
+		t.Fatal("IsMountPoint(/mnt/a) = true, want false")
+	}
+}
+
+func TestLazyInitialFilesMaterializeOnDemand(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	factory := SeededMemory(InitialFiles{
+		"/lazy.txt": {
+			Lazy: func(context.Context) ([]byte, error) {
+				calls.Add(1)
+				return []byte("lazy\n"), nil
+			},
+		},
+		"/dir/info.txt": {
+			Lazy: func(context.Context) ([]byte, error) {
+				calls.Add(1)
+				return []byte("dir-info\n"), nil
+			},
+		},
+	})
+
+	fsys, err := factory.New(context.Background())
+	if err != nil {
+		t.Fatalf("SeededMemory.New() error = %v", err)
+	}
+
+	rootEntries, err := fsys.ReadDir(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("ReadDir(/) error = %v", err)
+	}
+	if got, want := calls.Load(), int32(0); got != want {
+		t.Fatalf("provider calls after ReadDir = %d, want %d", got, want)
+	}
+
+	info, err := fsys.Stat(context.Background(), "/lazy.txt")
+	if err != nil {
+		t.Fatalf("Stat(/lazy.txt) error = %v", err)
+	}
+	if got, want := info.Size(), int64(len("lazy\n")); got != want {
+		t.Fatalf("Stat(/lazy.txt).Size() = %d, want %d", got, want)
+	}
+	if got, want := calls.Load(), int32(1); got != want {
+		t.Fatalf("provider calls after Stat = %d, want %d", got, want)
+	}
+
+	dirEntries, err := fsys.ReadDir(context.Background(), "/dir")
+	if err != nil {
+		t.Fatalf("ReadDir(/dir) error = %v", err)
+	}
+	if len(dirEntries) != 1 {
+		t.Fatalf("len(ReadDir(/dir)) = %d, want 1", len(dirEntries))
+	}
+	if _, err := dirEntries[0].Info(); err != nil {
+		t.Fatalf("DirEntry.Info() error = %v", err)
+	}
+	if got, want := calls.Load(), int32(2); got != want {
+		t.Fatalf("provider calls after DirEntry.Info = %d, want %d", got, want)
+	}
+
+	if got, want := readTestFile(t, fsys, "/lazy.txt"), "lazy\n"; got != want {
+		t.Fatalf("Open(/lazy.txt) = %q, want %q", got, want)
+	}
+	if got, want := calls.Load(), int32(2); got != want {
+		t.Fatalf("provider calls after read = %d, want %d", got, want)
+	}
+
+	_ = rootEntries
+}
+
+func TestLazyInitialFilesWriteRemoveRenameAndHardLinkInteractions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("write before read bypasses provider", func(t *testing.T) {
+		var calls atomic.Int32
+		fsys, err := SeededMemory(InitialFiles{
+			"/lazy.txt": {
+				Lazy: func(context.Context) ([]byte, error) {
+					calls.Add(1)
+					return []byte("lazy\n"), nil
+				},
+			},
+		}).New(context.Background())
+		if err != nil {
+			t.Fatalf("SeededMemory.New() error = %v", err)
+		}
+
+		writeTestFile(t, fsys, "/lazy.txt", "written\n")
+		if got, want := readTestFile(t, fsys, "/lazy.txt"), "written\n"; got != want {
+			t.Fatalf("read after write = %q, want %q", got, want)
+		}
+		if got, want := calls.Load(), int32(0); got != want {
+			t.Fatalf("provider calls = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("remove before read bypasses provider", func(t *testing.T) {
+		var calls atomic.Int32
+		fsys, err := SeededMemory(InitialFiles{
+			"/lazy.txt": {
+				Lazy: func(context.Context) ([]byte, error) {
+					calls.Add(1)
+					return []byte("lazy\n"), nil
+				},
+			},
+		}).New(context.Background())
+		if err != nil {
+			t.Fatalf("SeededMemory.New() error = %v", err)
+		}
+
+		if err := fsys.Remove(context.Background(), "/lazy.txt", false); err != nil {
+			t.Fatalf("Remove() error = %v", err)
+		}
+		if got, want := calls.Load(), int32(0); got != want {
+			t.Fatalf("provider calls = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("rename preserves laziness until new path is read", func(t *testing.T) {
+		var calls atomic.Int32
+		fsys, err := SeededMemory(InitialFiles{
+			"/lazy.txt": {
+				Lazy: func(context.Context) ([]byte, error) {
+					calls.Add(1)
+					return []byte("lazy\n"), nil
+				},
+			},
+		}).New(context.Background())
+		if err != nil {
+			t.Fatalf("SeededMemory.New() error = %v", err)
+		}
+
+		if err := fsys.Rename(context.Background(), "/lazy.txt", "/moved.txt"); err != nil {
+			t.Fatalf("Rename() error = %v", err)
+		}
+		if got, want := calls.Load(), int32(0); got != want {
+			t.Fatalf("provider calls after rename = %d, want %d", got, want)
+		}
+		if got, want := readTestFile(t, fsys, "/moved.txt"), "lazy\n"; got != want {
+			t.Fatalf("read moved file = %q, want %q", got, want)
+		}
+		if got, want := calls.Load(), int32(1); got != want {
+			t.Fatalf("provider calls after read = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("hard links share one provider-backed node", func(t *testing.T) {
+		var calls atomic.Int32
+		fsys, err := SeededMemory(InitialFiles{
+			"/lazy.txt": {
+				Lazy: func(context.Context) ([]byte, error) {
+					calls.Add(1)
+					return []byte("lazy\n"), nil
+				},
+			},
+		}).New(context.Background())
+		if err != nil {
+			t.Fatalf("SeededMemory.New() error = %v", err)
+		}
+
+		if err := fsys.Link(context.Background(), "/lazy.txt", "/lazy-link.txt"); err != nil {
+			t.Fatalf("Link() error = %v", err)
+		}
+		if got, want := readTestFile(t, fsys, "/lazy-link.txt"), "lazy\n"; got != want {
+			t.Fatalf("read hard link = %q, want %q", got, want)
+		}
+		if got, want := calls.Load(), int32(1); got != want {
+			t.Fatalf("provider calls = %d, want %d", got, want)
+		}
+	})
+}
+
+func TestLazyInitialFilesRetryAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	modTime := time.Unix(1_700_000_000, 0).UTC()
+	var calls atomic.Int32
+	fsys, err := SeededMemory(InitialFiles{
+		"/retry.txt": {
+			Lazy: func(context.Context) ([]byte, error) {
+				if calls.Add(1) == 1 {
+					return nil, errors.New("boom")
+				}
+				return []byte("ok\n"), nil
+			},
+			Mode:    0o640,
+			ModTime: modTime,
+		},
+	}).New(context.Background())
+	if err != nil {
+		t.Fatalf("SeededMemory.New() error = %v", err)
+	}
+
+	if _, err := fsys.Open(context.Background(), "/retry.txt"); err == nil {
+		t.Fatal("first Open() error = nil, want provider failure")
+	}
+	if got, want := calls.Load(), int32(1); got != want {
+		t.Fatalf("provider calls after first failure = %d, want %d", got, want)
+	}
+
+	if got, want := readTestFile(t, fsys, "/retry.txt"), "ok\n"; got != want {
+		t.Fatalf("read after retry = %q, want %q", got, want)
+	}
+	if got, want := calls.Load(), int32(2); got != want {
+		t.Fatalf("provider calls after retry = %d, want %d", got, want)
+	}
+
+	info, err := fsys.Stat(context.Background(), "/retry.txt")
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got, want := info.Mode().Perm(), stdfs.FileMode(0o640); got != want {
+		t.Fatalf("Mode().Perm() = %v, want %v", got, want)
+	}
+	if got, want := info.ModTime(), modTime; !got.Equal(want) {
+		t.Fatalf("ModTime() = %v, want %v", got, want)
+	}
+}

--- a/gbash_mountable_test.go
+++ b/gbash_mountable_test.go
@@ -1,0 +1,127 @@
+package gbash_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/ewhauser/gbash"
+	gbfs "github.com/ewhauser/gbash/fs"
+)
+
+func TestSeededInMemoryFileSystemHelper(t *testing.T) {
+	t.Parallel()
+
+	rt, err := gbash.New(
+		gbash.WithFileSystem(gbash.SeededInMemoryFileSystem(gbfs.InitialFiles{
+			"/home/agent/lazy.txt": {
+				Lazy: func(context.Context) ([]byte, error) {
+					return []byte("seeded\n"), nil
+				},
+			},
+		})),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result, err := rt.Run(context.Background(), &gbash.ExecutionRequest{
+		Script: "cat /home/agent/lazy.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got, want := result.Stdout, "seeded\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestMountableFileSystemSupportsShellMvAcrossMounts(t *testing.T) {
+	t.Parallel()
+
+	rt, err := gbash.New(
+		gbash.WithFileSystem(gbash.MountableFileSystem(gbash.MountableFileSystemOptions{
+			Mounts: []gbfs.MountConfig{
+				{MountPoint: "/src", Factory: seededFactory(map[string]string{"/dir/a.txt": "a\n"})},
+				{MountPoint: "/dst", Factory: gbfs.Memory()},
+			},
+		})),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result, err := rt.Run(context.Background(), &gbash.ExecutionRequest{
+		Script: "mv /src/dir /dst/copied\ncat /dst/copied/a.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0, stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "a\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestSessionFileSystemExposesConcreteMountableFS(t *testing.T) {
+	t.Parallel()
+
+	rt, err := gbash.New(
+		gbash.WithFileSystem(gbash.MountableFileSystem(gbash.MountableFileSystemOptions{
+			Mounts: []gbfs.MountConfig{
+				{MountPoint: "/src", Factory: gbfs.Memory()},
+			},
+		})),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	session, err := rt.NewSession(context.Background())
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+
+	mountable, ok := session.FileSystem().(*gbfs.MountableFS)
+	if !ok {
+		t.Fatalf("Session.FileSystem() = %T, want *fs.MountableFS", session.FileSystem())
+	}
+	if err := mountable.Mount("/dynamic", gbfs.NewMemory()); err != nil {
+		t.Fatalf("Mount(/dynamic) error = %v", err)
+	}
+
+	result, err := session.Exec(context.Background(), &gbash.ExecutionRequest{
+		Script: "echo hi > /dynamic/note.txt\ncat /dynamic/note.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+	if got, want := result.Stdout, "hi\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func seededFactory(files map[string]string) gbfs.Factory {
+	return gbfs.FactoryFunc(func(ctx context.Context) (gbfs.FileSystem, error) {
+		mem := gbfs.NewMemory()
+		for name, contents := range files {
+			if err := writeFSFile(ctx, mem, name, contents); err != nil {
+				return nil, err
+			}
+		}
+		return mem, nil
+	})
+}
+
+func writeFSFile(ctx context.Context, fsys gbfs.FileSystem, name, contents string) error {
+	file, err := fsys.OpenFile(ctx, name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	_, err = io.WriteString(file, contents)
+	return err
+}

--- a/internal/runtime/filesystem.go
+++ b/internal/runtime/filesystem.go
@@ -13,6 +13,13 @@ type FileSystemConfig struct {
 	WorkingDir string
 }
 
+// MountableFileSystemOptions configures a multi-mount sandbox filesystem.
+type MountableFileSystemOptions struct {
+	Base       gbfs.Factory
+	Mounts     []gbfs.MountConfig
+	WorkingDir string
+}
+
 // HostProjectOptions configures the high-level host-project sandbox helper.
 type HostProjectOptions struct {
 	VirtualRoot      string
@@ -33,10 +40,34 @@ func InMemoryFileSystem() FileSystemConfig {
 	}
 }
 
+// SeededInMemoryFileSystem returns an in-memory filesystem preloaded with the
+// provided files.
+func SeededInMemoryFileSystem(files gbfs.InitialFiles) FileSystemConfig {
+	return FileSystemConfig{
+		Factory:    gbfs.SeededMemory(files),
+		WorkingDir: defaultHomeDir,
+	}
+}
+
 // CustomFileSystem wires an arbitrary filesystem factory into the runtime.
 func CustomFileSystem(factory gbfs.Factory, workingDir string) FileSystemConfig {
 	return FileSystemConfig{
 		Factory:    factory,
+		WorkingDir: workingDir,
+	}
+}
+
+// MountableFileSystem returns a multi-mount filesystem configuration.
+func MountableFileSystem(opts MountableFileSystemOptions) FileSystemConfig {
+	workingDir := strings.TrimSpace(opts.WorkingDir)
+	if workingDir == "" {
+		workingDir = defaultHomeDir
+	}
+	return FileSystemConfig{
+		Factory: gbfs.Mountable(gbfs.MountableOptions{
+			Base:   opts.Base,
+			Mounts: append([]gbfs.MountConfig(nil), opts.Mounts...),
+		}),
 		WorkingDir: workingDir,
 	}
 }

--- a/internal/runtime/mountable_test.go
+++ b/internal/runtime/mountable_test.go
@@ -1,0 +1,40 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	gbfs "github.com/ewhauser/gbash/fs"
+)
+
+func TestMountableFileSystemHelperSupportsCrossMountMove(t *testing.T) {
+	rt := newRuntime(t, &Config{
+		FileSystem: MountableFileSystem(MountableFileSystemOptions{
+			Mounts: []gbfs.MountConfig{
+				{
+					MountPoint: "/src",
+					Factory: seededFSFactory{files: map[string]string{
+						"/dir/file.txt": "moved\n",
+					}},
+				},
+				{
+					MountPoint: "/dst",
+					Factory:    gbfs.Memory(),
+				},
+			},
+		}),
+	})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "mv /src/dir /dst/copied\ncat /dst/copied/file.txt\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0, stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "moved\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}

--- a/packages/gbash-wasm/README.md
+++ b/packages/gbash-wasm/README.md
@@ -17,5 +17,8 @@ The initial API is the same one used by the website example:
 - `new Bash({ cwd, env, files, wasmUrl, wasmExecUrl })`
 - `defineCommand(name, run)`
 
+`files` accepts eager strings, `Uint8Array` values, lazy provider functions, and
+descriptor objects with `{ content, mode?, mtime? }` or `{ lazy, mode?, mtime? }`.
+
 The package currently exposes explicit browser and Node entrypoints for JavaScript
 hosts. It does not yet expose a host-neutral WASI/component-model interface.

--- a/packages/gbash-wasm/src/browser.ts
+++ b/packages/gbash-wasm/src/browser.ts
@@ -17,6 +17,10 @@ export type {
   CommandResult,
   CustomCommand,
   GBashRuntime,
+  FileContent,
+  InitialFile,
+  InitialFiles,
+  LazyFileProvider,
 } from "./shared.js";
 
 declare global {

--- a/packages/gbash-wasm/src/node.ts
+++ b/packages/gbash-wasm/src/node.ts
@@ -26,6 +26,10 @@ export type {
   CommandResult,
   CustomCommand,
   GBashRuntime,
+  FileContent,
+  InitialFile,
+  InitialFiles,
+  LazyFileProvider,
 } from "./shared.js";
 
 type NodeGlobal = typeof globalThis & {

--- a/packages/gbash-wasm/src/shared.ts
+++ b/packages/gbash-wasm/src/shared.ts
@@ -7,6 +7,23 @@ export type CommandResult = {
 
 export type CommandHandler = (args: string[]) => CommandResult | Promise<CommandResult>;
 
+export type FileContent = string | Uint8Array;
+export type LazyFileProvider = () => FileContent | Promise<FileContent>;
+
+export type InitialFile =
+  | {
+      content: FileContent;
+      mode?: number;
+      mtime?: Date;
+    }
+  | {
+      lazy: LazyFileProvider;
+      mode?: number;
+      mtime?: Date;
+    };
+
+export type InitialFiles = Record<string, FileContent | LazyFileProvider | InitialFile>;
+
 export type BridgeShell = {
   exec(command: string): Promise<CommandResult>;
   writeFile(path: string, content: string): void;
@@ -18,7 +35,7 @@ export type GBashRuntime = {
   createShell(options?: {
     cwd?: string;
     env?: Record<string, string>;
-    files?: Record<string, string>;
+    files?: InitialFiles;
   }): Promise<BridgeShell>;
 };
 
@@ -30,7 +47,7 @@ export type CustomCommand = {
 export type BashOptions = {
   cwd?: string;
   env?: Record<string, string>;
-  files?: Record<string, string>;
+  files?: InitialFiles;
   customCommands?: CustomCommand[];
   wasmUrl?: string;
   wasmExecUrl?: string;

--- a/packages/gbash-wasm/test/smoke.test.mjs
+++ b/packages/gbash-wasm/test/smoke.test.mjs
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { Bash } from "../dist/node.js";
+
+test("Bash files supports eager, lazy, and metadata-backed entries", async () => {
+  let syncCalls = 0;
+  let asyncCalls = 0;
+
+  const bash = new Bash({
+    files: {
+      "/home/agent/string.txt": "string\n",
+      "/home/agent/bytes.txt": new TextEncoder().encode("bytes\n"),
+      "/home/agent/lazy-sync.txt": () => {
+        syncCalls += 1;
+        return "lazy-sync\n";
+      },
+      "/home/agent/lazy-async.txt": async () => {
+        asyncCalls += 1;
+        return new TextEncoder().encode("lazy-async\n");
+      },
+      "/home/agent/meta.txt": {
+        content: "meta\n",
+        mode: 0o640,
+        mtime: new Date("2024-01-02T03:04:05Z"),
+      },
+    },
+  });
+
+  await assert.doesNotReject(async () => {
+    const result = await bash.exec(
+      "cat /home/agent/string.txt /home/agent/bytes.txt /home/agent/lazy-sync.txt /home/agent/lazy-async.txt /home/agent/meta.txt",
+    );
+    assert.equal(result.exitCode, 0);
+    assert.equal(
+      result.stdout,
+      "string\nbytes\nlazy-sync\nlazy-async\nmeta\n",
+    );
+  });
+
+  assert.equal(syncCalls, 1);
+  assert.equal(asyncCalls, 1);
+
+  const statResult = await bash.exec("stat -c '%a %Y' /home/agent/meta.txt");
+  assert.equal(statResult.exitCode, 0);
+  assert.equal(statResult.stdout.trim(), "0640 1704164645");
+
+  await bash.dispose();
+});

--- a/packages/gbash-wasm/wasm/main.go
+++ b/packages/gbash-wasm/wasm/main.go
@@ -6,13 +6,16 @@ import (
 	"context"
 	"fmt"
 	"io"
+	stdfs "io/fs"
 	"os"
 	"path"
 	"strings"
 	"sync"
 	"syscall/js"
+	"time"
 
 	"github.com/ewhauser/gbash"
+	gbfs "github.com/ewhauser/gbash/fs"
 )
 
 type browserShell struct {
@@ -48,11 +51,22 @@ func createShell(this js.Value, args []js.Value) any {
 func newBrowserShell(options js.Value) (*browserShell, error) {
 	cwd := cleanPath(valueOrDefault(options, "cwd", "/home/agent"))
 	baseEnv := envFromOptions(options, cwd)
+	initialFiles, err := initialFilesFromOptions(options)
+	if err != nil {
+		return nil, err
+	}
 
-	rt, err := gbash.New(
-		gbash.WithWorkingDir(cwd),
+	runtimeOptions := []gbash.Option{
 		gbash.WithBaseEnv(baseEnv),
-	)
+		gbash.WithWorkingDir(cwd),
+	}
+	if len(initialFiles) > 0 {
+		runtimeOptions = append([]gbash.Option{
+			gbash.WithFileSystem(gbash.SeededInMemoryFileSystem(initialFiles)),
+		}, runtimeOptions...)
+	}
+
+	rt, err := gbash.New(runtimeOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -66,12 +80,6 @@ func newBrowserShell(options js.Value) (*browserShell, error) {
 		session: session,
 		cwd:     cwd,
 		env:     cloneEnv(baseEnv),
-	}
-
-	for filePath, content := range stringMapValue(options, "files") {
-		if err := shell.writeFileSync(filePath, content); err != nil {
-			return nil, err
-		}
 	}
 
 	return shell, nil
@@ -278,6 +286,190 @@ func stringMapValue(value js.Value, key string) map[string]string {
 		out[name] = field.Get(name).String()
 	}
 	return out
+}
+
+func initialFilesFromOptions(value js.Value) (gbfs.InitialFiles, error) {
+	if value.IsUndefined() || value.IsNull() || value.Type() != js.TypeObject {
+		return nil, nil
+	}
+	field := value.Get("files")
+	if field.IsUndefined() || field.IsNull() || field.Type() != js.TypeObject {
+		return nil, nil
+	}
+
+	keys := js.Global().Get("Object").Call("keys", field)
+	out := make(gbfs.InitialFiles, keys.Length())
+	for i := 0; i < keys.Length(); i++ {
+		name := keys.Index(i).String()
+		file, err := initialFileFromJSValue(field.Get(name))
+		if err != nil {
+			return nil, fmt.Errorf("files[%q]: %w", name, err)
+		}
+		out[name] = file
+	}
+	return out, nil
+}
+
+func initialFileFromJSValue(value js.Value) (gbfs.InitialFile, error) {
+	switch {
+	case value.Type() == js.TypeString:
+		return gbfs.InitialFile{Content: []byte(value.String())}, nil
+	case isUint8Array(value):
+		content, err := bytesFromJSValue(value)
+		if err != nil {
+			return gbfs.InitialFile{}, err
+		}
+		return gbfs.InitialFile{Content: content}, nil
+	case value.Type() == js.TypeFunction:
+		return gbfs.InitialFile{Lazy: lazyProviderFromJS(value)}, nil
+	case value.Type() != js.TypeObject || value.IsNull():
+		return gbfs.InitialFile{}, fmt.Errorf("unsupported file value type %s", value.Type())
+	}
+
+	contentField := value.Get("content")
+	lazyField := value.Get("lazy")
+	hasContent := isDefined(contentField)
+	hasLazy := isDefined(lazyField)
+	if hasContent == hasLazy {
+		return gbfs.InitialFile{}, fmt.Errorf("expected exactly one of content or lazy")
+	}
+
+	var file gbfs.InitialFile
+	var err error
+	if hasContent {
+		file.Content, err = bytesFromJSValue(contentField)
+		if err != nil {
+			return gbfs.InitialFile{}, err
+		}
+	} else {
+		if lazyField.Type() != js.TypeFunction {
+			return gbfs.InitialFile{}, fmt.Errorf("lazy must be a function")
+		}
+		file.Lazy = lazyProviderFromJS(lazyField)
+	}
+
+	if modeField := value.Get("mode"); isDefined(modeField) {
+		if modeField.Type() != js.TypeNumber {
+			return gbfs.InitialFile{}, fmt.Errorf("mode must be a number")
+		}
+		file.Mode = stdfs.FileMode(modeField.Int())
+	}
+	if mtimeField := value.Get("mtime"); isDefined(mtimeField) {
+		modTime, err := timeFromJSValue(mtimeField)
+		if err != nil {
+			return gbfs.InitialFile{}, err
+		}
+		file.ModTime = modTime
+	}
+
+	return file, nil
+}
+
+func lazyProviderFromJS(provider js.Value) gbfs.LazyFileProvider {
+	return func(ctx context.Context) ([]byte, error) {
+		type result struct {
+			data []byte
+			err  error
+		}
+
+		done := make(chan result, 1)
+		var once sync.Once
+		resolve := func(data []byte, err error) {
+			once.Do(func() {
+				done <- result{data: data, err: err}
+			})
+		}
+
+		onResolve := js.FuncOf(func(this js.Value, args []js.Value) any {
+			var value js.Value
+			if len(args) > 0 {
+				value = args[0]
+			}
+			data, err := bytesFromJSValue(value)
+			resolve(data, err)
+			return nil
+		})
+		onReject := js.FuncOf(func(this js.Value, args []js.Value) any {
+			reason := "lazy file provider rejected"
+			if len(args) > 0 {
+				reason = jsValueString(args[0])
+			}
+			resolve(nil, fmt.Errorf("%s", reason))
+			return nil
+		})
+		defer onResolve.Release()
+		defer onReject.Release()
+
+		invoked := provider.Invoke()
+		if isPromise(invoked) {
+			invoked.Call("then", onResolve)
+			invoked.Call("catch", onReject)
+		} else {
+			data, err := bytesFromJSValue(invoked)
+			resolve(data, err)
+		}
+
+		select {
+		case result := <-done:
+			return result.data, result.err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func bytesFromJSValue(value js.Value) ([]byte, error) {
+	switch {
+	case value.Type() == js.TypeUndefined || value.Type() == js.TypeNull:
+		return nil, fmt.Errorf("file content must be a string or Uint8Array")
+	case value.Type() == js.TypeString:
+		return []byte(value.String()), nil
+	case isUint8Array(value):
+		buf := make([]byte, value.Get("byteLength").Int())
+		js.CopyBytesToGo(buf, value)
+		return buf, nil
+	default:
+		return nil, fmt.Errorf("unsupported file content type %s", value.Type())
+	}
+}
+
+func isUint8Array(value js.Value) bool {
+	ctor := js.Global().Get("Uint8Array")
+	return ctor.Truthy() && value.Type() == js.TypeObject && value.InstanceOf(ctor)
+}
+
+func isPromise(value js.Value) bool {
+	ctor := js.Global().Get("Promise")
+	return ctor.Truthy() && value.Type() == js.TypeObject && value.InstanceOf(ctor)
+}
+
+func isDefined(value js.Value) bool {
+	return !value.IsUndefined() && !value.IsNull()
+}
+
+func timeFromJSValue(value js.Value) (time.Time, error) {
+	dateCtor := js.Global().Get("Date")
+	if !dateCtor.Truthy() || value.Type() != js.TypeObject || !value.InstanceOf(dateCtor) {
+		return time.Time{}, fmt.Errorf("mtime must be a Date")
+	}
+	return time.UnixMilli(int64(value.Call("getTime").Float())).UTC(), nil
+}
+
+func jsValueString(value js.Value) string {
+	switch value.Type() {
+	case js.TypeString:
+		return value.String()
+	case js.TypeUndefined:
+		return "undefined"
+	case js.TypeNull:
+		return "null"
+	default:
+		text := value.String()
+		if strings.TrimSpace(text) == "" {
+			return value.Type().String()
+		}
+		return text
+	}
 }
 
 func cleanPath(name string) string {

--- a/website/content/api/wasm.mdx
+++ b/website/content/api/wasm.mdx
@@ -20,6 +20,7 @@ const bash = new Bash({
   env: { MY_VAR: "hello" },
   files: {
     "/home/agent/greeting.txt": "hello world\n",
+    "/home/agent/large.txt": async () => "lazy payload\n",
   },
 });
 ```
@@ -30,7 +31,7 @@ const bash = new Bash({
 |--------|------|-------------|
 | `cwd` | `string` | Initial working directory. Defaults to `/home/agent`. |
 | `env` | `Record<string, string>` | Environment variables. |
-| `files` | `Record<string, string>` | Files to pre-populate in the virtual filesystem. |
+| `files` | `InitialFiles` | Files to pre-populate in the virtual filesystem. Supports strings, `Uint8Array`, lazy providers, and descriptor objects with `content` or `lazy` plus optional `mode` and `mtime`. |
 | `customCommands` | `CustomCommand[]` | Custom commands implemented in JavaScript. |
 | `wasmUrl` | `string` | Override URL for `gbash.wasm`. |
 | `wasmExecUrl` | `string` | Override URL for `wasm_exec.js`. |
@@ -61,6 +62,18 @@ type CommandResult = {
 bash.writeFile("/home/agent/data.json", '{"key": "value"}');
 const result = await bash.exec("cat /home/agent/data.json");
 ```
+
+### Initial Files
+
+`files` accepts:
+
+- `string`
+- `Uint8Array`
+- `() => string | Uint8Array | Promise<string | Uint8Array>`
+- `{ content: string | Uint8Array; mode?: number; mtime?: Date }`
+- `{ lazy: () => string | Uint8Array | Promise<string | Uint8Array>; mode?: number; mtime?: Date }`
+
+Lazy providers are materialized on first content-sensitive access inside the sandbox.
 
 ### Custom Commands
 

--- a/website/content/configuration/filesystem.mdx
+++ b/website/content/configuration/filesystem.mdx
@@ -1,6 +1,6 @@
 # Filesystem
 
-gbash provisions a fresh virtual filesystem for each session. Four entry points cover the spectrum from fully isolated to fully mutable host access.
+gbash provisions a fresh virtual filesystem for each session. Six entry points cover the spectrum from fully isolated to fully mutable host access.
 
 ## Default: In-Memory Filesystem
 
@@ -15,6 +15,21 @@ This is equivalent to:
 ```go
 rt, err := gbash.New(
     gbash.WithFileSystem(gbash.InMemoryFileSystem()),
+)
+```
+
+To preload eager or lazy files into that in-memory sandbox, use `SeededInMemoryFileSystem`:
+
+```go
+rt, err := gbash.New(
+    gbash.WithFileSystem(gbash.SeededInMemoryFileSystem(gbfs.InitialFiles{
+        "/home/agent/config.json": {Content: []byte("{\"mode\":\"dev\"}\n")},
+        "/home/agent/large.txt": {
+            Lazy: func(ctx context.Context) ([]byte, error) {
+                return loadLargeFixture(ctx)
+            },
+        },
+    })),
 )
 ```
 
@@ -54,6 +69,29 @@ rt, err := gbash.New(
 ```
 
 Use this when you intentionally want shell commands to modify the host filesystem, for example in compatibility test harnesses or controlled build pipelines.
+
+## Mountable Namespace
+
+`MountableFileSystem` composes a base filesystem with one or more sibling mount points inside the sandbox. This is the productized multi-mount path when you want, for example, a workspace, a scratch area, and a fixture tree under one namespace.
+
+```go
+rt, err := gbash.New(
+    gbash.WithFileSystem(gbash.MountableFileSystem(gbash.MountableFileSystemOptions{
+        Mounts: []gbfs.MountConfig{
+            {
+                MountPoint: "/workspace",
+                Factory: gbfs.Overlay(gbfs.Host(gbfs.HostOptions{
+                    Root:        "/path/to/project",
+                    VirtualRoot: "/",
+                })),
+            },
+            {MountPoint: "/cache", Factory: gbfs.Memory()},
+        },
+    })),
+)
+```
+
+The concrete `*gbfs.MountableFS` also exposes live `Mount`, `Unmount`, `Mounts`, and `IsMountPoint` methods when you need to mutate the namespace through `Session.FileSystem()`.
 
 ## Custom Filesystem
 


### PR DESCRIPTION
## Summary
- add a productized multi-mount namespace via `gbfs.Mountable(...)`, `*gbfs.MountableFS`, and `gbash.MountableFileSystem(...)`
- add eager/lazy seeded in-memory files via `gbfs.InitialFiles`, `gbfs.SeededMemory(...)`, and `gbash.SeededInMemoryFileSystem(...)`
- widen `@ewhauser/gbash-wasm` `files` to accept strings, `Uint8Array`, lazy providers, and metadata-backed descriptors, with docs, tests, and `SPEC.md` updates

## Testing
- `go build ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...`
- `go test ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...`
- `make lint`
- `npm exec --yes pnpm@10.10.0 -- --filter @ewhauser/gbash-wasm build`
- `node --test packages/gbash-wasm/test/smoke.test.mjs`