### PR TITLE
fs: materialize lazy content before non-truncating writes; resolve wasm file paths

### DIFF
--- a/fs/memory.go
+++ b/fs/memory.go
@@ -264,9 +264,11 @@ func (m *MemoryFS) Open(ctx context.Context, name string) (File, error) {
 }
 
 func (m *MemoryFS) OpenFile(ctx context.Context, name string, flag int, perm stdfs.FileMode) (File, error) {
-	if !hasWriteIntent(flag) && flag&os.O_CREATE == 0 {
+	if flag&os.O_TRUNC == 0 || !canWrite(flag) {
 		if _, _, err := m.materializePath(ctx, name, true); err != nil {
-			return nil, &os.PathError{Op: "open", Path: Resolve(m.Getwd(), name), Err: err}
+			if flag&os.O_CREATE == 0 || !errors.Is(err, stdfs.ErrNotExist) {
+				return nil, &os.PathError{Op: "open", Path: Resolve(m.Getwd(), name), Err: err}
+			}
 		}
 	}
 
@@ -796,8 +798,15 @@ func (f *memoryFile) Write(p []byte) (int, error) {
 		return 0, &os.PathError{Op: "write", Path: f.path, Err: stdfs.ErrInvalid}
 	}
 	if isLazyFileNode(node) {
-		node.lazy = nil
-		node.data = nil
+		f.fs.mu.Unlock()
+		if err := f.fs.materializeResolvedPath(context.Background(), f.path); err != nil {
+			return 0, &os.PathError{Op: "write", Path: f.path, Err: err}
+		}
+		f.fs.mu.Lock()
+		node, ok = f.fs.nodes[f.path]
+		if !ok {
+			return 0, &os.PathError{Op: "write", Path: f.path, Err: stdfs.ErrNotExist}
+		}
 	}
 
 	if f.flag&os.O_APPEND != 0 {

--- a/packages/gbash-wasm/wasm/main.go
+++ b/packages/gbash-wasm/wasm/main.go
@@ -297,6 +297,7 @@ func initialFilesFromOptions(value js.Value) (gbfs.InitialFiles, error) {
 		return nil, nil
 	}
 
+	cwd := cleanPath(valueOrDefault(value, "cwd", "/home/agent"))
 	keys := js.Global().Get("Object").Call("keys", field)
 	out := make(gbfs.InitialFiles, keys.Length())
 	for i := 0; i < keys.Length(); i++ {
@@ -305,7 +306,7 @@ func initialFilesFromOptions(value js.Value) (gbfs.InitialFiles, error) {
 		if err != nil {
 			return nil, fmt.Errorf("files[%q]: %w", name, err)
 		}
-		out[name] = file
+		out[resolvePath(cwd, name)] = file
 	}
 	return out, nil
 }


### PR DESCRIPTION
## Summary

- **P1 fix**: `memoryFile.Write` now materializes lazy file content before non-truncating writes instead of discarding it. Also updated `OpenFile` to eagerly materialize for non-truncating write modes (e.g. `O_APPEND`). This fixes `>>` and in-place writes on lazy-seeded files silently replacing content instead of appending.
- **P2 fix**: `initialFilesFromOptions` in the wasm bridge now resolves relative file keys against the configured `cwd`, matching the previous `writeFileSync` behavior. Previously, relative names were normalized under `/` by `Clean`, causing startup files to be missing from the working directory.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Lazy file tests pass (`TestLazyInitialFiles*`)
- [ ] Verify `>>` append on a lazy-seeded file preserves existing content
- [ ] Verify wasm shell with relative file keys in `files` option places them under cwd