### PR TITLE
fs: fix gofmt formatting in OpenFile condition

### DIFF
--- a/fs/memory.go
+++ b/fs/memory.go
@@ -264,7 +264,7 @@ func (m *MemoryFS) Open(ctx context.Context, name string) (File, error) {
 }
 
 func (m *MemoryFS) OpenFile(ctx context.Context, name string, flag int, perm stdfs.FileMode) (File, error) {
-	if (flag&os.O_TRUNC == 0 || !canWrite(flag)) && flag&(os.O_CREATE|os.O_EXCL) != (os.O_CREATE | os.O_EXCL) {
+	if (flag&os.O_TRUNC == 0 || !canWrite(flag)) && flag&(os.O_CREATE|os.O_EXCL) != (os.O_CREATE|os.O_EXCL) {
 		if _, _, err := m.materializePath(ctx, name, true); err != nil {
 			if flag&os.O_CREATE == 0 || !errors.Is(err, stdfs.ErrNotExist) {
 				return nil, &os.PathError{Op: "open", Path: Resolve(m.Getwd(), name), Err: err}


### PR DESCRIPTION
## Summary
- Remove extra space in bitwise OR expression on line 267 of `fs/memory.go` to satisfy `gofmt`

## Test plan
- [x] `make lint` passes with 0 issues