### PR TITLE
website: add FAQ docs page

### DIFF
--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -4,6 +4,7 @@ import { flattenNav, docsNavigation } from "@/app/lib/docs-navigation";
 
 // Map of slug paths to their MDX imports
 const pages: Record<string, () => Promise<{ default: React.ComponentType; metadata?: { title?: string; description?: string } }>> = {
+  faq: () => import("@/content/faq/index.mdx"),
   "getting-started": () => import("@/content/getting-started/index.mdx"),
   "getting-started/installation": () => import("@/content/getting-started/installation.mdx"),
   "getting-started/quick-start": () => import("@/content/getting-started/quick-start.mdx"),

--- a/website/app/lib/docs-navigation.ts
+++ b/website/app/lib/docs-navigation.ts
@@ -23,6 +23,10 @@ export const docsNavigation: NavItem[] = [
     title: "Performance",
     items: [{ title: "Benchmarks", href: "/docs/performance/benchmarks" }],
   },
+  {
+    title: "FAQ",
+    items: [{ title: "Common Questions", href: "/docs/faq" }],
+  },
 ];
 
 export function flattenNav(items: NavItem[]): NavItem[] {

--- a/website/content/faq/index.mdx
+++ b/website/content/faq/index.mdx
@@ -1,0 +1,5 @@
+# FAQ
+
+## Do you think virtual shells are the future for AI agents?
+
+No. Agents work best when they have a full computer, and virtual shells are limiting. That being said, there are a number of use cases where virtual shells are useful: smaller tool surfaces, local testing, etc.


### PR DESCRIPTION
## Summary
- add a new static FAQ docs page at `/docs/faq`
- register the page in the manual docs route map
- add a top-level FAQ section in the docs sidebar with a Common Questions entry

## Testing
- `make lint`
- `npx -y pnpm@10.32.1 -C website build`

## Notes
- `website/package.json` still uses `next lint`, but the installed Next 16 canary CLI no longer exposes that subcommand; this change does not modify that behavior.