### PR TITLE
compat: mark shred as out of scope in GNU harness

### DIFF
--- a/cmd/gbash-gnu/manifest.json
+++ b/cmd/gbash-gnu/manifest.json
@@ -69,6 +69,7 @@
     { "pattern": "tests/chcon/*", "reason": "SELinux command tests are out of scope in v1" },
     { "pattern": "tests/help/*", "reason": "help/version tests are skipped in v1" },
     { "pattern": "tests/runcon/*", "reason": "SELinux command tests are out of scope in v1" },
-    { "pattern": "tests/*/selinux*", "reason": "SELinux tests are out of scope in v1" }
+    { "pattern": "tests/*/selinux*", "reason": "SELinux tests are out of scope in v1" },
+    { "pattern": "tests/shred/*", "reason": "shred command tests are out of scope in v1" }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `tests/shred/*` to `skip_patterns` in the GNU compat manifest so shred command tests are filtered as out of scope in v1.

## Test plan
- [ ] Verify compat report correctly filters shred tests as "out of scope"