### PR TITLE
lint: broaden sandbox enforcement to all runtime packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,7 @@ linters:
               desc: Do not access host kernel APIs directly from commands.
         broad_host_packages:
           files:
+            - "*.go"
             - commands/**/*.go
             - internal/**/*.go
             - trace/**/*.go
@@ -129,6 +130,7 @@ linters:
               desc: Use invocation-provided writers instead of host log sinks.
         broad_syscall:
           files:
+            - "*.go"
             - commands/**/*.go
             - internal/**/*.go
             - trace/**/*.go
@@ -149,6 +151,7 @@ linters:
               desc: Do not access host syscalls directly from commands.
         broad_unix:
           files:
+            - "*.go"
             - commands/**/*.go
             - internal/**/*.go
             - trace/**/*.go
@@ -162,6 +165,7 @@ linters:
               desc: Do not access host kernel APIs directly from commands.
         broad_term:
           files:
+            - "*.go"
             - commands/**/*.go
             - internal/**/*.go
             - trace/**/*.go
@@ -175,6 +179,7 @@ linters:
               desc: Use reviewed helpers for terminal detection instead of raw file descriptor probes.
         broad_net:
           files:
+            - "*.go"
             - commands/**/*.go
             - internal/**/*.go
             - trace/**/*.go
@@ -187,6 +192,7 @@ linters:
               desc: Use invocation network capabilities instead of direct host networking.
         broad_net_http:
           files:
+            - "*.go"
             - commands/**/*.go
             - internal/**/*.go
             - trace/**/*.go
@@ -244,16 +250,16 @@ linters:
     paths:
       - ^third_party/mvdan-sh/
     rules:
-      - path-except: ^(commands|internal/|trace/|policy/|network/)/
+      - path-except: ^(commands|internal/|trace/|policy/|network/|contrib/)/|^[^/]+\.go$
         linters:
           - depguard
-      - path-except: ^(commands|internal/|trace/|policy/|network/)/
+      - path-except: ^(commands|internal/|trace/|policy/|network/|contrib/)/|^[^/]+\.go$
         linters:
           - forbidigo
-      - path: ^(commands|internal/|trace/|policy/|network/)/.*_test\.go$
+      - path: ^(commands|internal/|trace/|policy/|network/|contrib/)/.*_test\.go$|^[^/]+_test\.go$
         linters:
           - depguard
-      - path: ^(commands|internal/|trace/|policy/|network/)/.*_test\.go$
+      - path: ^(commands|internal/|trace/|policy/|network/|contrib/)/.*_test\.go$|^[^/]+_test\.go$
         linters:
           - forbidigo
       - path: ^commands/invocation_capabilities\.go$


### PR DESCRIPTION
## Summary
- Extends depguard and forbidigo lint rules from `internal/builtins/` to cover `commands/`, `internal/`, `trace/`, `policy/`, and `network/`
- Adds broad depguard bans for `os/exec`, `path/filepath`, `os/user`, `os/signal`, `plugin`, `crypto/tls`, `unsafe`, `runtime/cgo`, `log`, `syscall`, `golang.org/x/sys/unix`, `golang.org/x/term`, `net`, `net/http` with reviewed exceptions
- Adds forbidigo bans for `os.Stdout`/`os.Stderr`/`os.Stdin` and `fmt.Print`/`Println`/`Printf` to prevent bypassing bounded capture
- Ensures the sandbox contract is enforced by lint across all runtime code, not just command implementations

## Test plan
- [x] `golangci-lint run ./commands/... ./internal/... ./trace/... ./policy/... ./network/...` passes clean
- [ ] CI passes