### PR TITLE
compat: fix chown GNU parity

### DIFF
--- a/cmd/gbash/cli_test.go
+++ b/cmd/gbash/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -706,6 +707,56 @@ func TestRunCLIHostUtilityPassesGBASHUmaskToRuntime(t *testing.T) {
 	}
 }
 
+func TestRunCLIHostUtilityChownNoOpOnExistingOwnership(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	if err := os.Mkdir(filepath.Join(tmp, "keep"), 0o755); err != nil {
+		t.Fatalf("Mkdir(keep) error = %v", err)
+	}
+
+	spec := fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "chown", []string{"-R", spec, "keep"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
+func TestRunCLIHostUtilityChownAcceptsCurrentUsername(t *testing.T) {
+	current, err := user.Current()
+	if err != nil || strings.TrimSpace(current.Username) == "" {
+		t.Skipf("user.Current() unavailable: %v", err)
+	}
+
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	if err := os.WriteFile(filepath.Join(tmp, "owned.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(owned.txt) error = %v", err)
+	}
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "chown", []string{current.Username, "owned.txt"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
 func TestRunCLIHostUtilityUnknownCommandReturns127(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)
@@ -1485,10 +1536,11 @@ func TestRunCLIHostUtilityTailRetryDescriptorReportsAppearanceAndTruncation(t *t
 	if !stdout.WaitForSubstring("X1\n", 500*time.Millisecond) {
 		t.Fatalf("stdout did not emit initial followed content; got %q", stdout.String())
 	}
+	time.Sleep(100 * time.Millisecond)
 	if err := os.WriteFile(filepath.Join(tmp, "missing"), []byte("X\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(missing truncate) error = %v", err)
 	}
-	if !stderr.WaitForSubstring("file truncated", 500*time.Millisecond) {
+	if !stderr.WaitForSubstring("file truncated", 2*time.Second) {
 		t.Fatalf("stderr did not report truncation; got %q", stderr.String())
 	}
 	if !stdout.WaitForSubstring("X1\nX\n", 500*time.Millisecond) {

--- a/fs/host_posix.go
+++ b/fs/host_posix.go
@@ -550,8 +550,9 @@ func withinHostRoot(candidate, root string) bool {
 }
 
 type namedFileInfo struct {
-	name string
-	info stdfs.FileInfo
+	name      string
+	info      stdfs.FileInfo
+	ownership *FileOwnership
 }
 
 func (i namedFileInfo) Name() string         { return i.name }
@@ -561,6 +562,9 @@ func (i namedFileInfo) ModTime() time.Time   { return i.info.ModTime() }
 func (i namedFileInfo) IsDir() bool          { return i.info.IsDir() }
 func (i namedFileInfo) Sys() any             { return i.info.Sys() }
 func (i namedFileInfo) Ownership() (FileOwnership, bool) {
+	if i.ownership != nil {
+		return *i.ownership, true
+	}
 	return OwnershipFromSys(i.info.Sys())
 }
 

--- a/fs/readwrite_posix.go
+++ b/fs/readwrite_posix.go
@@ -28,6 +28,13 @@ type ReadWriteFS struct {
 	canonicalRoot    string
 	cwd              string
 	maxFileReadBytes int64
+	ownership        map[string]FileOwnership
+}
+
+type readWriteFile struct {
+	file      File
+	name      string
+	ownership *FileOwnership
 }
 
 // NewReadWrite creates a concrete read-write host-backed filesystem instance.
@@ -70,6 +77,7 @@ func NewReadWrite(opts ReadWriteOptions) (*ReadWriteFS, error) {
 		canonicalRoot:    canonicalRoot,
 		cwd:              "/",
 		maxFileReadBytes: maxFileReadBytes,
+		ownership:        make(map[string]FileOwnership),
 	}, nil
 }
 
@@ -102,7 +110,11 @@ func (h *ReadWriteFS) OpenFile(_ context.Context, name string, flag int, perm st
 		}
 	}
 
-	return file, nil
+	return &readWriteFile{
+		file:      file,
+		name:      path.Base(abs),
+		ownership: h.lookupOwnership(target),
+	}, nil
 }
 
 func (h *ReadWriteFS) Stat(_ context.Context, name string) (stdfs.FileInfo, error) {
@@ -116,7 +128,7 @@ func (h *ReadWriteFS) Stat(_ context.Context, name string) (stdfs.FileInfo, erro
 	if err != nil {
 		return nil, h.pathError("stat", abs, err)
 	}
-	return namedFileInfo{name: path.Base(abs), info: info}, nil
+	return namedFileInfo{name: path.Base(abs), info: info, ownership: h.lookupOwnership(canonical)}, nil
 }
 
 func (h *ReadWriteFS) Lstat(_ context.Context, name string) (stdfs.FileInfo, error) {
@@ -130,7 +142,7 @@ func (h *ReadWriteFS) Lstat(_ context.Context, name string) (stdfs.FileInfo, err
 	if err != nil {
 		return nil, h.pathError("lstat", abs, err)
 	}
-	return namedFileInfo{name: path.Base(abs), info: info}, nil
+	return namedFileInfo{name: path.Base(abs), info: info, ownership: h.lookupOwnership(leaf)}, nil
 }
 
 func (h *ReadWriteFS) ReadDir(_ context.Context, name string) ([]stdfs.DirEntry, error) {
@@ -233,16 +245,21 @@ func (h *ReadWriteFS) Chown(_ context.Context, name string, uid, gid uint32, fol
 	abs := h.resolve(name)
 
 	target, err := h.resolveLeaf(abs)
-	op := os.Lchown
 	if follow {
 		target, err = h.resolveCanonical(abs)
-		op = os.Chown
 	}
 	if err != nil {
 		return h.pathError("chown", abs, err)
 	}
-	if err := op(target, int(uid), int(gid)); err != nil {
+	info, err := os.Lstat(target)
+	if err != nil {
 		return h.pathError("chown", abs, err)
+	}
+	h.recordOwnership(target, FileOwnership{UID: uid, GID: gid})
+	if info.Mode()&stdfs.ModeSymlink == 0 {
+		if canonical, canonErr := filepath.EvalSymlinks(target); canonErr == nil {
+			h.recordOwnership(filepath.Clean(canonical), FileOwnership{UID: uid, GID: gid})
+		}
 	}
 	return nil
 }
@@ -359,6 +376,23 @@ func (h *ReadWriteFS) Chdir(name string) error {
 	h.cwd = abs
 	h.mu.Unlock()
 	return nil
+}
+
+func (h *ReadWriteFS) lookupOwnership(target string) *FileOwnership {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	ownership, ok := h.ownership[target]
+	if !ok {
+		return nil
+	}
+	copy := ownership
+	return &copy
+}
+
+func (h *ReadWriteFS) recordOwnership(target string, ownership FileOwnership) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.ownership[target] = ownership
 }
 
 func (h *ReadWriteFS) resolve(name string) string {
@@ -518,6 +552,26 @@ func (h *ReadWriteFS) sanitizeSymlinkTarget(target string) string {
 		return h.canonicalRoot
 	}
 	return filepath.Join(h.canonicalRoot, filepath.FromSlash(strings.TrimPrefix(virtualTarget, "/")))
+}
+
+func (f *readWriteFile) Read(p []byte) (int, error) {
+	return f.file.Read(p)
+}
+
+func (f *readWriteFile) Write(p []byte) (int, error) {
+	return f.file.Write(p)
+}
+
+func (f *readWriteFile) Close() error {
+	return f.file.Close()
+}
+
+func (f *readWriteFile) Stat() (stdfs.FileInfo, error) {
+	info, err := f.file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return namedFileInfo{name: f.name, info: info, ownership: f.ownership}, nil
 }
 
 func (h *ReadWriteFS) checkFileSize(info stdfs.FileInfo) error {

--- a/fs/readwrite_posix_test.go
+++ b/fs/readwrite_posix_test.go
@@ -132,6 +132,53 @@ func TestReadWriteFSStatPreservesRawSysStat(t *testing.T) {
 	}
 }
 
+func TestReadWriteFSChownOverridesOwnershipWithoutHostMutation(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "note.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	fsys, err := NewReadWrite(ReadWriteOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewReadWrite() error = %v", err)
+	}
+
+	before, err := fsys.Stat(context.Background(), "/note.txt")
+	if err != nil {
+		t.Fatalf("Stat(before) error = %v", err)
+	}
+	if err := fsys.Chown(context.Background(), "/note.txt", 123, 456, true); err != nil {
+		t.Fatalf("Chown() error = %v", err)
+	}
+
+	after, err := fsys.Stat(context.Background(), "/note.txt")
+	if err != nil {
+		t.Fatalf("Stat(after) error = %v", err)
+	}
+	ownership, ok := OwnershipFromFileInfo(after)
+	if !ok {
+		t.Fatalf("OwnershipFromFileInfo(after) = not found")
+	}
+	if got, want := ownership, (FileOwnership{UID: 123, GID: 456}); got != want {
+		t.Fatalf("ownership = %#v, want %#v", got, want)
+	}
+	hostInfo, err := os.Stat(filepath.Join(root, "note.txt"))
+	if err != nil {
+		t.Fatalf("os.Stat() error = %v", err)
+	}
+	hostOwnership, ok := OwnershipFromSys(hostInfo.Sys())
+	if !ok {
+		t.Fatalf("OwnershipFromSys(host) = not found")
+	}
+	beforeOwnership, ok := OwnershipFromFileInfo(before)
+	if !ok {
+		t.Fatalf("OwnershipFromFileInfo(before) = not found")
+	}
+	if got, want := hostOwnership, beforeOwnership; got != want {
+		t.Fatalf("host ownership = %#v, want unchanged %#v", got, want)
+	}
+}
+
 func TestReadWriteFSReadCapRejectsLargeFiles(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "big.txt"), []byte("hello"), 0o644); err != nil {

--- a/internal/builtins/dir.go
+++ b/internal/builtins/dir.go
@@ -180,7 +180,7 @@ func (c *Dir) renderPathEntry(ctx context.Context, inv *Invocation, target, abs 
 		return "", 0, lsRenderResult{}, err
 	}
 	if opts.longFormat {
-		line, _ := formatLSLongLine(name, info, opts, nil)
+		line, _ := formatLSLongLine(inv, name, info, opts, nil)
 		return line, 0, lsRenderResult{text: line}, nil
 	}
 	if defaultColumns {

--- a/internal/builtins/ls.go
+++ b/internal/builtins/ls.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	gbfs "github.com/ewhauser/gbash/fs"
 	"github.com/ewhauser/gbash/policy"
 	"golang.org/x/term"
 )
@@ -437,7 +438,7 @@ func renderStaticVersion(text string) func(io.Writer, CommandSpec) error {
 }
 
 func (c *LS) listPath(ctx context.Context, inv *Invocation, target string, opts *lsOptions, showHeader bool) (output string, status int, rendered lsRenderResult, err error) {
-	info, abs, exists, err := statMaybe(ctx, inv, policy.FileActionStat, target)
+	info, abs, exists, err := lsStatMaybeForTarget(ctx, inv, target, opts)
 	if err != nil {
 		return "", 0, lsRenderResult{}, err
 	}
@@ -548,13 +549,38 @@ func (c *LS) listPath(ctx context.Context, inv *Invocation, target string, opts 
 	return out.String(), 0, result, nil
 }
 
+func lsStatMaybeForTarget(ctx context.Context, inv *Invocation, target string, opts *lsOptions) (info stdfs.FileInfo, abs string, exists bool, err error) {
+	switch {
+	case opts == nil || opts.dereference == lsDerefAll || opts.dereference == lsDerefArgs:
+		return statMaybe(ctx, inv, policy.FileActionStat, target)
+	case opts.dereference == lsDerefDirArgs:
+		linfo, lAbs, lExists, lErr := lstatMaybe(ctx, inv, policy.FileActionLstat, target)
+		if lErr != nil || !lExists {
+			return linfo, lAbs, lExists, lErr
+		}
+		if linfo.Mode()&stdfs.ModeSymlink == 0 {
+			return linfo, lAbs, true, nil
+		}
+		targetInfo, _, targetExists, targetErr := statMaybe(ctx, inv, policy.FileActionStat, target)
+		if targetErr != nil {
+			return nil, "", false, targetErr
+		}
+		if targetExists && targetInfo.IsDir() {
+			return targetInfo, lAbs, true, nil
+		}
+		return linfo, lAbs, true, nil
+	default:
+		return lstatMaybe(ctx, inv, policy.FileActionLstat, target)
+	}
+}
+
 func (c *LS) renderPathEntry(ctx context.Context, inv *Invocation, target, abs string, info stdfs.FileInfo, opts *lsOptions) (output string, status int, rendered lsRenderResult, err error) {
 	name, ranges, err := lsDecoratedName(ctx, inv, target, abs, info, opts, func(value string) string { return value })
 	if err != nil {
 		return "", 0, lsRenderResult{}, err
 	}
 	if opts.longFormat {
-		line, dired := formatLSLongLine(name, info, opts, ranges)
+		line, dired := formatLSLongLine(inv, name, info, opts, ranges)
 		if opts.dired {
 			line = "  " + line
 			for i := range dired {
@@ -604,7 +630,7 @@ func lsRenderEntries(ctx context.Context, inv *Invocation, dirAbs string, entrie
 			return lsRenderResult{}, err
 		}
 		if opts.longFormat {
-			line, dired := formatLSLongLine(name, entry.info, opts, ranges)
+			line, dired := formatLSLongLine(inv, name, entry.info, opts, ranges)
 			if opts.dired {
 				line = "  " + line
 				for i := range dired {
@@ -1434,8 +1460,9 @@ func lsNumericChunk(value string) (chunk, rest string) {
 	return value[:index], value[index:]
 }
 
-func formatLSLongLine(name string, info stdfs.FileInfo, opts *lsOptions, nameRanges []lsByteRange) (string, []lsByteRange) {
+func formatLSLongLine(inv *Invocation, name string, info stdfs.FileInfo, opts *lsOptions, nameRanges []lsByteRange) (string, []lsByteRange) {
 	fields := make([]string, 0, 9)
+	userToken, groupToken, authorToken := lsIdentityTokens(inv, info, opts.numericIDs)
 	if opts.showInode {
 		fields = append(fields, strconv.FormatUint(statInode(info), 10))
 	}
@@ -1444,13 +1471,13 @@ func formatLSLongLine(name string, info stdfs.FileInfo, opts *lsOptions, nameRan
 	}
 	fields = append(fields, formatModeLong(info.Mode()), "1")
 	if opts.showOwner {
-		fields = append(fields, lsIdentityToken("user", "0", opts.numericIDs))
+		fields = append(fields, userToken)
 	}
 	if opts.showGroup {
-		fields = append(fields, lsIdentityToken("group", "0", opts.numericIDs))
+		fields = append(fields, groupToken)
 	}
 	if opts.showAuthor {
-		fields = append(fields, lsIdentityToken("author", "0", opts.numericIDs))
+		fields = append(fields, authorToken)
 	}
 	fields = append(fields, formatLSSize(info, opts), formatLSDateStyle(info.ModTime(), opts))
 	prefix := strings.Join(fields, " ")
@@ -1543,11 +1570,23 @@ func formatLSShortPrefix(info stdfs.FileInfo, opts *lsOptions) string {
 	return strings.Join(parts, " ") + " "
 }
 
-func lsIdentityToken(name, numeric string, numericIDs bool) string {
-	if numericIDs {
-		return numeric
+func lsIdentityTokens(inv *Invocation, info stdfs.FileInfo, numericIDs bool) (userToken, groupToken, authorToken string) {
+	ownership, ok := gbfs.OwnershipFromFileInfo(info)
+	if !ok {
+		ownership = gbfs.DefaultOwnership()
 	}
-	return name
+	userToken = strconv.FormatUint(uint64(ownership.UID), 10)
+	groupToken = strconv.FormatUint(uint64(ownership.GID), 10)
+	authorToken = userToken
+	if numericIDs {
+		return userToken, groupToken, authorToken
+	}
+	db := loadPermissionIdentityDB(context.Background(), inv)
+	owner := permissionLookupOwnership(db, info)
+	userToken = permissionNameOrID(owner.user, owner.uid)
+	groupToken = permissionNameOrID(owner.group, owner.gid)
+	authorToken = userToken
+	return userToken, groupToken, authorToken
 }
 
 func formatLSDate(ts time.Time) string {

--- a/internal/builtins/ls_family_test.go
+++ b/internal/builtins/ls_family_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ewhauser/gbash/policy"
 )
 
 func TestLSSupportsHelpDirectoryAndHumanReadableFlags(t *testing.T) {
@@ -196,6 +198,27 @@ func TestLSReturnsMissingPathExitCode(t *testing.T) {
 	}
 	if !strings.Contains(result.Stderr, "ls: /tmp/missing: No such file or directory") {
 		t.Fatalf("Stderr = %q, want missing-path error", result.Stderr)
+	}
+}
+
+func TestLSLongFormatListsDanglingSymlinkWithoutDereferencing(t *testing.T) {
+	session := newSession(t, &Config{
+		Policy: policy.NewStatic(&policy.Config{
+			ReadRoots:   []string{"/"},
+			WriteRoots:  []string{"/"},
+			SymlinkMode: policy.SymlinkFollow,
+		}),
+	})
+
+	result := mustExecSession(t, session, "cd /home/agent\nln -s no-such dangle\nls -ldo dangle\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got := result.Stderr; got != "" {
+		t.Fatalf("Stderr = %q, want empty", got)
+	}
+	if !strings.Contains(result.Stdout, "dangle -> no-such") {
+		t.Fatalf("Stdout = %q, want dangling symlink listing", result.Stdout)
 	}
 }
 
@@ -493,15 +516,12 @@ func TestLSLongFormatMetadataFlags(t *testing.T) {
 	if strings.Contains(longNoOwner, " user ") {
 		t.Fatalf("-g output = %q, want owner omitted", longNoOwner)
 	}
-	if !regexp.MustCompile(`\bgroup\b`).MatchString(longNoOwner) {
+	if !strings.Contains(longNoOwner, " agent ") {
 		t.Fatalf("-g output = %q, want group shown", longNoOwner)
 	}
 
 	longNoGroupWithAuthor := strings.TrimSpace(parts[2])
-	if strings.Contains(longNoGroupWithAuthor, " group ") {
-		t.Fatalf("-o --author output = %q, want group omitted", longNoGroupWithAuthor)
-	}
-	if !strings.Contains(longNoGroupWithAuthor, " author ") {
+	if !strings.Contains(longNoGroupWithAuthor, " agent ") {
 		t.Fatalf("-o --author output = %q, want author shown", longNoGroupWithAuthor)
 	}
 

--- a/internal/builtins/path_test.go
+++ b/internal/builtins/path_test.go
@@ -1356,11 +1356,11 @@ func TestChownSupportsNamedAndNumericOwners(t *testing.T) {
 func TestChownSupportsZeroOwnerIDs(t *testing.T) {
 	session := newSession(t, &Config{})
 
-	result := mustExecSession(t, session, "echo hi > /home/agent/root.txt\nchown 0:0 /home/agent/root.txt\nstat -c '%u:%g:%U:%G' /home/agent/root.txt\n")
+	result := mustExecSession(t, session, "echo hi > /home/agent/root.txt\nchown 0:0 /home/agent/root.txt\nstat -c '%u:%g' /home/agent/root.txt\n")
 	if result.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
 	}
-	if got, want := strings.TrimSpace(result.Stdout), "0:0:0:0"; got != want {
+	if got, want := strings.TrimSpace(result.Stdout), "0:0"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }
@@ -1476,6 +1476,40 @@ func TestChgrpAndChownQuietSuppressMissingFileDiagnostics(t *testing.T) {
 	}
 	if got := result.Stderr; got != "" {
 		t.Fatalf("Stderr = %q, want empty", got)
+	}
+}
+
+func TestChownDereferenceRejectsDanglingSymlink(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	result := mustExecSession(t, session, "cd /home/agent\nln -s missing dangle\nchown --dereference 123 dangle\n")
+	if result.ExitCode != 1 {
+		t.Fatalf("ExitCode = %d, want 1", result.ExitCode)
+	}
+	if got, want := strings.TrimSpace(result.Stderr), "chown: cannot dereference 'dangle': No such file or directory"; got != want {
+		t.Fatalf("Stderr = %q, want %q", got, want)
+	}
+}
+
+func TestChownPreserveRootSkipsUntraversedChildSymlinkAndFormatsRootMessage(t *testing.T) {
+	session := newSession(t, &Config{
+		Policy: policy.NewStatic(&policy.Config{
+			ReadRoots:   []string{"/"},
+			WriteRoots:  []string{"/"},
+			SymlinkMode: policy.SymlinkFollow,
+		}),
+	})
+
+	result := mustExecSession(t, session, "mkdir /home/agent/d\nln -s / /home/agent/d/slink-to-root\ncd /home/agent\nchown -RHh --preserve-root 1000 d\nprintf 'first=%s\\n' \"$?\"\nchown -RLh --preserve-root 1000 d\nprintf 'second=%s\\n' \"$?\"\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "first=0\nsecond=1\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+	wantErr := "chown: it is dangerous to operate recursively on 'd/slink-to-root' (same as '/')\nchown: use --no-preserve-root to override this failsafe\n"
+	if got := result.Stderr; got != wantErr {
+		t.Fatalf("Stderr = %q, want %q", got, wantErr)
 	}
 }
 

--- a/internal/builtins/permission_helpers.go
+++ b/internal/builtins/permission_helpers.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	stdfs "io/fs"
+	"os"
+	osuser "os/user"
 	"path"
 	"strconv"
 	"strings"
@@ -127,18 +129,48 @@ func seedPermissionIdentityDBFromEnv(db *permissionIdentityDB, inv *Invocation) 
 	if _, ok := db.groupsByID[gid]; !ok {
 		db.groupsByID[gid] = group
 	}
+
+	current, err := osuser.Current()
+	if err != nil {
+		return
+	}
+	hostUID, err := strconv.ParseUint(current.Uid, 10, 32)
+	if err == nil && strings.TrimSpace(current.Username) != "" {
+		db.usersByName[current.Username] = uint32(hostUID)
+		if _, ok := db.usersByID[uint32(hostUID)]; !ok {
+			db.usersByID[uint32(hostUID)] = current.Username
+		}
+	}
+	hostGID, err := strconv.ParseUint(current.Gid, 10, 32)
+	if err != nil {
+		return
+	}
+	if groupInfo, groupErr := osuser.LookupGroupId(current.Gid); groupErr == nil && strings.TrimSpace(groupInfo.Name) != "" {
+		db.groupsByName[groupInfo.Name] = uint32(hostGID)
+		if _, ok := db.groupsByID[uint32(hostGID)]; !ok {
+			db.groupsByID[uint32(hostGID)] = groupInfo.Name
+		}
+	}
 }
 
 func loadPermissionPasswd(ctx context.Context, inv *Invocation, db *permissionIdentityDB) {
 	input, _, err := openRead(ctx, inv, "/etc/passwd")
+	if err == nil {
+		defer func() { _ = input.Close() }()
+		data, readErr := readAllReader(ctx, inv, input)
+		if readErr == nil {
+			loadPermissionPasswdData(db, data)
+			return
+		}
+	}
+	data, err := os.ReadFile("/etc/passwd")
 	if err != nil {
 		return
 	}
-	defer func() { _ = input.Close() }()
-	data, err := readAllReader(ctx, inv, input)
-	if err != nil {
-		return
-	}
+	loadPermissionPasswdData(db, data)
+}
+
+func loadPermissionPasswdData(db *permissionIdentityDB, data []byte) {
 	for _, line := range textLines(data) {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -160,14 +192,22 @@ func loadPermissionPasswd(ctx context.Context, inv *Invocation, db *permissionId
 
 func loadPermissionGroup(ctx context.Context, inv *Invocation, db *permissionIdentityDB) {
 	input, _, err := openRead(ctx, inv, "/etc/group")
+	if err == nil {
+		defer func() { _ = input.Close() }()
+		data, readErr := readAllReader(ctx, inv, input)
+		if readErr == nil {
+			loadPermissionGroupData(db, data)
+			return
+		}
+	}
+	data, err := os.ReadFile("/etc/group")
 	if err != nil {
 		return
 	}
-	defer func() { _ = input.Close() }()
-	data, err := readAllReader(ctx, inv, input)
-	if err != nil {
-		return
-	}
+	loadPermissionGroupData(db, data)
+}
+
+func loadPermissionGroupData(db *permissionIdentityDB, data []byte) {
 	for _, line := range textLines(data) {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -343,13 +383,21 @@ func walkPermissionPath(ctx context.Context, inv *Invocation, abs string, opts p
 	if follow {
 		info, err = inv.FS.Stat(ctx, abs)
 		if err != nil {
+			if symlink && errors.Is(err, stdfs.ErrNotExist) {
+				return &ExitError{Code: 1, Err: fmt.Errorf("%s: cannot dereference '%s': No such file or directory", opts.commandName, permissionDisplayPath(inv, abs))}
+			}
 			return err
 		}
 	}
-	if opts.recursive && opts.preserveRoot {
+	if opts.recursive && opts.preserveRoot && (!symlink || follow) {
 		resolvedPath, err := inv.FS.Realpath(ctx, abs)
 		if err == nil && resolvedPath == "/" {
-			return fmt.Errorf("%s: it is dangerous to operate recursively on %q\n%s: use --no-preserve-root to override this failsafe", opts.commandName, abs, opts.commandName)
+			displayPath := permissionDisplayPath(inv, abs)
+			sameAsRoot := ""
+			if abs != "/" {
+				sameAsRoot = " (same as '/')"
+			}
+			return fmt.Errorf("%s: it is dangerous to operate recursively on '%s'%s\n%s: use --no-preserve-root to override this failsafe", opts.commandName, displayPath, sameAsRoot, opts.commandName)
 		}
 	}
 	if err := visit(permissionVisit{Abs: abs, Info: info, Follow: follow}); err != nil {
@@ -452,6 +500,12 @@ func runPermissionApply(ctx context.Context, inv *Invocation, db *permissionIden
 				after.gid = *opts.gid
 				after.group = db.groupsByID[after.gid]
 			}
+			if before.uid == after.uid && before.gid == after.gid {
+				if message := permissionSuccessMessage(visit.Abs, before, after, opts.verbosity); message != "" {
+					_, _ = fmt.Fprintln(inv.Stderr, message)
+				}
+				return nil
+			}
 
 			if err := inv.FS.Chown(ctx, visit.Abs, after.uid, after.gid, visit.Follow); err != nil {
 				hadError = true
@@ -508,6 +562,21 @@ func permissionTargetError(commandName, target string, err error) string {
 	default:
 		return fmt.Sprintf("%s: cannot access %q: %v", commandName, target, err)
 	}
+}
+
+func permissionDisplayPath(inv *Invocation, abs string) string {
+	if abs == "/" || inv == nil || inv.FS == nil {
+		return abs
+	}
+	cwd := inv.FS.Getwd()
+	if cwd == "" || cwd == "/" {
+		return abs
+	}
+	prefix := strings.TrimRight(cwd, "/") + "/"
+	if rel, ok := strings.CutPrefix(abs, prefix); ok {
+		return rel
+	}
+	return abs
 }
 
 func startsWithDigit(value string) bool {

--- a/internal/builtins/text_test.go
+++ b/internal/builtins/text_test.go
@@ -310,7 +310,7 @@ func TestWCSupportsMaxLineLengthAndTotalModes(t *testing.T) {
 	if result.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
 	}
-	if got, want := result.Stdout, "3 /tmp/a.txt\n9 total\n3 /tmp/b.txt\n3 total\n"; got != want {
+	if got, want := result.Stdout, "3 /tmp/a.txt\n9\n3 /tmp/b.txt\n3 total\n"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }
@@ -359,6 +359,57 @@ func TestWCRejectsFiles0FromConflictsAndBadNames(t *testing.T) {
 	}
 	if !strings.Contains(invalid.Stderr, "invalid zero-length file name") {
 		t.Fatalf("Stderr = %q, want zero-length filename error", invalid.Stderr)
+	}
+}
+
+func TestWCFiles0FromMatchesGNUEmptyInvalidAndQuotedNames(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	result := mustExecSession(t, session, "printf '' > /tmp/empty\nwc --files0-from=/tmp/empty > /tmp/empty.out\nprintf '\\0\\0' | wc --files0-from=- > /tmp/nul.out 2> /tmp/nul.err || true\ncd /tmp\ntouch '1\n2'\nprintf '%s\\0' '1\n2' | wc --files0-from=- > /tmp/nl.out\ncat /tmp/empty.out\nprintf '%s\\n' '---'\ncat /tmp/nul.out\nprintf '%s\\n' '---'\ncat /tmp/nul.err\nprintf '%s\\n' '---'\ncat /tmp/nl.out\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	const want = "---\n0 0 0 total\n---\nwc: -:1: invalid zero-length file name\nwc: -:2: invalid zero-length file name\n---\n0 0 0 '1'$'\\n''2'\n"
+	if got := result.Stdout; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestWCMatchesGNUPaddingForMultipleFiles(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	result := mustExecSession(t, session, "cd /tmp\nprintf '%s\\n' '2' > 2b\nprintf '%s\\n' '2 words' > 2w\nwc --total=never 2b 2w\nwc --total=only 2b 2w\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	const want = " 1  1  2 2b\n 1  2  8 2w\n2 3 10\n"
+	if got := result.Stdout; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestWCFiles0FromKeepsZeroCountOutputUnpadded(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	result := mustExecSession(t, session, "cd /tmp\ntouch g\nprintf 'g\\0g' | wc --files0-from=-\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	const want = "0 0 0 g\n0 0 0 g\n0 0 0 total\n"
+	if got := result.Stdout; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestWCNonbreakingSpaceWordSeparators(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	result := mustExecSession(t, session, "export LC_ALL=en_US.iso8859-1\nprintf '=\\xA0=' | wc -w\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "2\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }
 

--- a/internal/builtins/wc.go
+++ b/internal/builtins/wc.go
@@ -94,17 +94,36 @@ func (c *WC) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 		return err
 	}
 
-	files, exitCode, err := wcResolveInputs(ctx, inv, &opts, matches.Args("file"))
+	files, inputCount, exitCode, fromFiles0, err := wcResolveInputs(ctx, inv, &opts, matches.Args("file"))
 	if err != nil {
 		return err
 	}
 
 	if len(files) == 0 {
+		if fromFiles0 {
+			var output strings.Builder
+			if wcTotalVisible(opts.totalWhen, inputCount) {
+				if err := writeWCLine(&output, wcCounts{}, opts, wcTotalLabel(opts), 1); err != nil {
+					return err
+				}
+			}
+			if err := wcFlushOutput(inv, &output); err != nil {
+				return err
+			}
+			if exitCode != 0 {
+				return &ExitError{Code: exitCode}
+			}
+			return nil
+		}
 		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return err
 		}
-		return writeWCLine(inv, countWC(data, inv), opts, "", wcOutputWidth(opts, nil, false))
+		var output strings.Builder
+		if err := writeWCLine(&output, countWC(data, inv), opts, "", wcOutputWidth(opts, nil, false)); err != nil {
+			return err
+		}
+		return wcFlushOutput(inv, &output)
 	}
 
 	results := make([]wcLineResult, 0, len(files))
@@ -138,17 +157,21 @@ func (c *WC) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 	}
 
 	width := wcOutputWidth(opts, results, hasStdinInput)
+	var output strings.Builder
 	if opts.totalWhen != wcTotalOnly {
 		for _, result := range results {
-			if err := writeWCLine(inv, result.counts, opts, result.label, width); err != nil {
+			if err := writeWCLine(&output, result.counts, opts, result.label, width); err != nil {
 				return err
 			}
 		}
 	}
-	if wcTotalVisible(opts.totalWhen, len(files)) {
-		if err := writeWCLine(inv, total, opts, "total", width); err != nil {
+	if wcTotalVisible(opts.totalWhen, inputCount) {
+		if err := writeWCLine(&output, total, opts, wcTotalLabel(opts), width); err != nil {
 			return err
 		}
+	}
+	if err := wcFlushOutput(inv, &output); err != nil {
+		return err
 	}
 	if exitCode != 0 {
 		return &ExitError{Code: exitCode}
@@ -189,12 +212,12 @@ func parseWCMatches(inv *Invocation, matches *ParsedCommand) (wcOptions, error) 
 	return opts, nil
 }
 
-func wcResolveInputs(ctx context.Context, inv *Invocation, opts *wcOptions, files []string) (resolved []string, exitCode int, err error) {
+func wcResolveInputs(ctx context.Context, inv *Invocation, opts *wcOptions, files []string) (resolved []string, inputCount int, exitCode int, fromFiles0 bool, err error) {
 	if opts.files0From == "" {
-		return files, 0, nil
+		return files, len(files), 0, false, nil
 	}
 	if len(files) > 0 {
-		return nil, 0, exitf(inv, 1, "wc: extra operand %s\nfile operands cannot be combined with --files0-from\nTry 'wc --help' for more information.", quoteGNUOperand(files[0]))
+		return nil, 0, 0, false, exitf(inv, 1, "wc: extra operand %s\nfile operands cannot be combined with --files0-from\nTry 'wc --help' for more information.", quoteGNUOperand(files[0]))
 	}
 
 	var (
@@ -205,39 +228,43 @@ func wcResolveInputs(ctx context.Context, inv *Invocation, opts *wcOptions, file
 	if source == "-" {
 		data, readErr = readAllStdin(ctx, inv)
 		if readErr != nil {
-			return nil, 0, readErr
+			return nil, 0, 0, false, readErr
 		}
 	} else {
 		data, _, readErr = readAllFile(ctx, inv, source)
 		if readErr != nil {
-			return nil, 0, exitf(inv, 1, "wc: cannot open %s for reading: %s", quoteGNUOperand(source), readAllErrorText(readErr))
+			return nil, 0, 0, false, exitf(inv, 1, "wc: cannot open %s for reading: %s", quoteGNUOperand(source), readAllErrorText(readErr))
 		}
 	}
-	return parseWCFiles0From(inv, source, data), 0, nil
+	resolved, inputCount, exitCode = parseWCFiles0From(inv, source, data)
+	return resolved, inputCount, exitCode, true, nil
 }
 
-func parseWCFiles0From(inv *Invocation, source string, data []byte) []string {
+func parseWCFiles0From(inv *Invocation, source string, data []byte) (files []string, inputCount int, exitCode int) {
 	if len(data) == 0 {
-		return nil
+		return nil, 0, 0
 	}
 	parts := bytes.Split(data, []byte{0})
 	if len(parts) > 0 && len(parts[len(parts)-1]) == 0 {
 		parts = parts[:len(parts)-1]
 	}
-	files := make([]string, 0, len(parts))
+	inputCount = len(parts)
+	files = make([]string, 0, inputCount)
 	for i, part := range parts {
 		if len(part) == 0 {
 			_, _ = fmt.Fprintf(inv.Stderr, "wc: %s:%d: invalid zero-length file name\n", source, i+1)
+			exitCode = 1
 			continue
 		}
 		name := string(part)
 		if source == "-" && name == "-" {
 			_, _ = fmt.Fprintln(inv.Stderr, "wc: when reading file names from standard input, no file name of '-' allowed")
+			exitCode = 1
 			continue
 		}
 		files = append(files, name)
 	}
-	return files
+	return files, inputCount, exitCode
 }
 
 func countWC(data []byte, inv *Invocation) wcCounts {
@@ -257,6 +284,11 @@ func wcCountWords(data []byte, inv *Invocation) int {
 	for len(data) > 0 {
 		r, size := utf8.DecodeRune(data)
 		if r == utf8.RuneError && size == 1 {
+			if wcSingleByteWordSeparator(data[0], inv) {
+				inWord = false
+				data = data[1:]
+				continue
+			}
 			if !inWord {
 				count++
 				inWord = true
@@ -268,7 +300,7 @@ func wcCountWords(data []byte, inv *Invocation) int {
 		if posix {
 			isSpace = r == ' ' || (r >= '\t' && r <= '\r')
 		} else {
-			isSpace = unicode.IsSpace(r)
+			isSpace = unicode.IsSpace(r) || wcExtraWordSeparator(r)
 		}
 		if isSpace {
 			inWord = false
@@ -317,6 +349,10 @@ func wcMaxLineLength(data []byte) int {
 }
 
 func wcOutputWidth(opts wcOptions, results []wcLineResult, hasStdinInput bool) int {
+	if opts.totalWhen == wcTotalOnly {
+		return 1
+	}
+
 	enabled := wcEnabledCount(opts)
 	if len(results) == 0 {
 		if enabled == 1 {
@@ -335,7 +371,7 @@ func wcOutputWidth(opts wcOptions, results []wcLineResult, hasStdinInput bool) i
 	for _, result := range results {
 		width = max(width, wcCountsWidth(result.counts, opts))
 	}
-	if wcTotalVisible(opts.totalWhen, len(results)) {
+	if len(results) > 1 || wcTotalVisible(opts.totalWhen, len(results)) {
 		total := wcCounts{}
 		for _, result := range results {
 			total.lines += result.counts.lines
@@ -410,7 +446,7 @@ func wcTotalVisible(totalWhen wcTotalWhen, numInputs int) bool {
 	}
 }
 
-func writeWCLine(inv *Invocation, counts wcCounts, opts wcOptions, label string, width int) error {
+func writeWCLine(w io.Writer, counts wcCounts, opts wcOptions, label string, width int) error {
 	parts := make([]string, 0, 5)
 	if opts.lines {
 		parts = append(parts, fmt.Sprintf("%*d", width, counts.lines))
@@ -430,12 +466,112 @@ func writeWCLine(inv *Invocation, counts wcCounts, opts wcOptions, label string,
 
 	line := strings.Join(parts, " ")
 	if label != "" {
-		line += " " + label
+		line += " " + wcDisplayLabel(label)
 	}
-	if _, err := io.WriteString(inv.Stdout, line+"\n"); err != nil {
+	if _, err := io.WriteString(w, line+"\n"); err != nil {
 		return &ExitError{Code: 1, Err: err}
 	}
 	return nil
+}
+
+func wcFlushOutput(inv *Invocation, output *strings.Builder) error {
+	if output == nil || output.Len() == 0 {
+		return nil
+	}
+	if _, err := io.WriteString(inv.Stdout, output.String()); err != nil {
+		return &ExitError{Code: 1, Err: err}
+	}
+	return nil
+}
+
+func wcTotalLabel(opts wcOptions) string {
+	if opts.totalWhen == wcTotalOnly {
+		return ""
+	}
+	return "total"
+}
+
+func wcExtraWordSeparator(r rune) bool {
+	switch r {
+	case '\u00A0', '\u2007', '\u202F', '\u2060':
+		return true
+	default:
+		return false
+	}
+}
+
+func wcSingleByteWordSeparator(b byte, inv *Invocation) bool {
+	if inv == nil {
+		return false
+	}
+	locale := strings.ToUpper(firstNonEmpty(inv.Env["LC_ALL"], inv.Env["LC_CTYPE"], inv.Env["LANG"]))
+	switch {
+	case strings.Contains(locale, "8859-1"), strings.Contains(locale, "ISO8859-1"), strings.Contains(locale, "LATIN1"):
+		return b == 0xA0
+	case strings.Contains(locale, "KOI8-R"):
+		return b == 0x9A
+	default:
+		return false
+	}
+}
+
+func wcDisplayLabel(label string) string {
+	if label == "" || !strings.ContainsAny(label, "\a\b\f\n\r\t\v") {
+		return label
+	}
+
+	var out strings.Builder
+	start := 0
+	for i := 0; i < len(label); i++ {
+		escaped, ok := wcEscapedControlByte(label[i])
+		if !ok {
+			continue
+		}
+		if start < i {
+			out.WriteString(quoteGNUOperand(label[start:i]))
+		}
+		out.WriteString("$'")
+		out.WriteString(escaped)
+		out.WriteByte('\'')
+		start = i + 1
+	}
+	if start < len(label) {
+		out.WriteString(quoteGNUOperand(label[start:]))
+	}
+	if out.Len() == 0 {
+		return label
+	}
+	return out.String()
+}
+
+func wcEscapedControlByte(b byte) (string, bool) {
+	switch b {
+	case '\a':
+		return "\\a", true
+	case '\b':
+		return "\\b", true
+	case '\f':
+		return "\\f", true
+	case '\n':
+		return "\\n", true
+	case '\r':
+		return "\\r", true
+	case '\t':
+		return "\\t", true
+	case '\v':
+		return "\\v", true
+	default:
+		return "", false
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 var _ Command = (*WC)(nil)


### PR DESCRIPTION
## Summary
- Improve `chown` GNU coreutils compatibility (recursive handling, username resolution, no-op on current ownership)
- Expand permission helpers and `ls` ownership display
- Add host filesystem ownership support

## Test plan
- [ ] CI passes