### PR TITLE
grep: use indexed search as prefilter

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -416,6 +416,12 @@ type PolicyEvent struct {
 
 The command-facing `Invocation` is capability-only. Custom commands get sandboxed filesystem and fetch helpers plus nested execution and limits metadata, but they do not receive the raw policy object, raw trace recorder, or raw network client. Policy checks and file-access tracing happen behind `Invocation.FS`, and `Invocation.Fetch` is nil unless network access is configured.
 
+Experimental command-facing search bridge:
+
+- `Invocation.FS.SearchProviderForPath(ctx, name)` is an opt-in capability for built-ins and custom commands that want indexed search without reaching around the command filesystem boundary
+- the bridge resolves `name` against the invocation working directory, applies normal read policy and symlink checks, and returns a scoped provider view rather than the raw backend capability
+- delegated search queries must stay within the scoped root, and returned hits are filtered back to that subtree so commands keep policy enforcement behind `Invocation.FS`
+
 Registry semantics are override-friendly: later registrations replace earlier ones so embedders can swap in custom implementations for built-ins, and `RegisterLazy` defers expensive command setup until first execution while still participating in `PATH` resolution and `Names()`.
 
 Key design decisions:
@@ -600,6 +606,8 @@ Optional experimental search capability:
 - the built-in v1 provider is synchronous, literal-only, and exact for the indexed file paths it tracks; it supports case-insensitive literal queries, root restriction, include/exclude path globs, optional byte offsets, and verified result flags
 - the built-in wrapper performs an initial crawl and may materialize lazy files because full-text search is a content-sensitive capability
 - search remains an accelerator, not the semantic source of truth for `grep`/`rg`; callers may use provider hits as verified matches or as prefiltered candidates and still apply exact userspace verification
+- `grep` may use indexed providers as a per-root prefilter when it can extract safe mandatory literals from the compiled pattern; candidate files are still opened and matched in userspace before output is emitted
+- `grep` falls back per root when a provider is unavailable, stale, unsupported, or the current search mode cannot produce a bounded safe literal set; stdin, invert-match mode, and symlink-directory descendants stay on the direct scan path
 
 Backend boundary for the current implementation:
 

--- a/commands/invocation_capabilities.go
+++ b/commands/invocation_capabilities.go
@@ -8,6 +8,7 @@ import (
 	stdfs "io/fs"
 	"maps"
 	"os"
+	"strings"
 	"time"
 
 	gbfs "github.com/ewhauser/gbash/fs"
@@ -185,6 +186,30 @@ func (fs *CommandFS) ReadDir(ctx context.Context, name string) ([]stdfs.DirEntry
 	return entries, nil
 }
 
+// SearchProviderForPath returns a search provider scoped to name after
+// enforcing read policy.
+//
+// Experimental: This API is experimental and subject to change.
+func (fs *CommandFS) SearchProviderForPath(ctx context.Context, name string) (provider gbfs.SearchProvider, abs string, ok bool, err error) {
+	abs, err = fs.prepare(ctx, policy.FileActionRead, name)
+	if err != nil {
+		return nil, "", false, err
+	}
+	capable, ok := fs.raw().(gbfs.SearchCapable)
+	if !ok {
+		return nil, abs, false, nil
+	}
+	inner, ok := capable.SearchProviderForPath(abs)
+	if !ok {
+		return nil, abs, false, nil
+	}
+	return &commandSearchProvider{
+		fs:    fs,
+		scope: abs,
+		inner: inner,
+	}, abs, true, nil
+}
+
 // Readlink reads the target of the symlink at name after enforcing readlink
 // policy.
 func (fs *CommandFS) Readlink(ctx context.Context, name string) (string, error) {
@@ -344,6 +369,58 @@ func (fs *CommandFS) raw() gbfs.FileSystem {
 	return fs.fsys
 }
 
+type commandSearchProvider struct {
+	fs    *CommandFS
+	scope string
+	inner gbfs.SearchProvider
+}
+
+func (p *commandSearchProvider) Search(ctx context.Context, query *gbfs.SearchQuery) (gbfs.SearchResult, error) {
+	if query == nil {
+		return gbfs.SearchResult{}, fmt.Errorf("commands: search query is required")
+	}
+	root := p.scope
+	if query.Root != "" {
+		root = query.Root
+	}
+	root, err := p.fs.prepare(ctx, policy.FileActionRead, root)
+	if err != nil {
+		return gbfs.SearchResult{}, err
+	}
+	if !commandSearchPathWithinScope(p.scope, root) {
+		return gbfs.SearchResult{}, fmt.Errorf("commands: search root %q is outside scope %q", root, p.scope)
+	}
+
+	innerQuery := *query
+	innerQuery.Root = root
+	result, err := p.inner.Search(ctx, &innerQuery)
+	if err != nil {
+		return gbfs.SearchResult{}, err
+	}
+	if len(result.Hits) == 0 {
+		return result, nil
+	}
+
+	filtered := result.Hits[:0]
+	for _, hit := range result.Hits {
+		if commandSearchPathWithinScope(root, hit.Path) {
+			filtered = append(filtered, hit)
+		}
+	}
+	result.Hits = filtered
+	return result, nil
+}
+
+func (p *commandSearchProvider) SearchCapabilities() gbfs.SearchCapabilities {
+	caps := p.inner.SearchCapabilities()
+	caps.RootRestriction = true
+	return caps
+}
+
+func (p *commandSearchProvider) IndexStatus() gbfs.IndexStatus {
+	return p.inner.IndexStatus()
+}
+
 func (fs *CommandFS) maxFileBytes() int64 {
 	if fs == nil {
 		return 0
@@ -391,6 +468,15 @@ func wrapCommandError(err error) error {
 		return err
 	}
 	return &ExitError{Code: 1, Err: err}
+}
+
+func commandSearchPathWithinScope(scope, target string) bool {
+	scope = gbfs.Clean(scope)
+	target = gbfs.Clean(target)
+	if scope == "/" {
+		return true
+	}
+	return target == scope || strings.HasPrefix(target, scope+"/")
 }
 
 func cloneEnv(src map[string]string) map[string]string {

--- a/commands/invocation_capabilities_test.go
+++ b/commands/invocation_capabilities_test.go
@@ -1,0 +1,145 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	gbfs "github.com/ewhauser/gbash/fs"
+	"github.com/ewhauser/gbash/policy"
+)
+
+func TestCommandFSSearchProviderForPathScopesResults(t *testing.T) {
+	fsys := commandSearchCapableFS{
+		FileSystem: gbfs.NewMemory(),
+		provider: commandFixedHitsProvider{
+			hits: []gbfs.SearchHit{
+				{Path: "/workspace/a.txt", Verified: true},
+				{Path: "/other/b.txt", Verified: true},
+			},
+		},
+	}
+	inv := NewInvocation(&InvocationOptions{
+		Cwd:        "/",
+		FileSystem: fsys,
+	})
+
+	provider, abs, ok, err := inv.FS.SearchProviderForPath(context.Background(), "/workspace")
+	if err != nil {
+		t.Fatalf("SearchProviderForPath() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("SearchProviderForPath() = false, want true")
+	}
+	if got, want := abs, "/workspace"; got != want {
+		t.Fatalf("abs = %q, want %q", got, want)
+	}
+
+	caps := provider.SearchCapabilities()
+	if !caps.RootRestriction {
+		t.Fatal("RootRestriction = false, want true")
+	}
+
+	result, err := provider.Search(context.Background(), &gbfs.SearchQuery{
+		Root:    "/workspace",
+		Literal: "needle",
+	})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if got, want := hitPaths(result.Hits), []string{"/workspace/a.txt"}; !equalStrings(got, want) {
+		t.Fatalf("hits = %v, want %v", got, want)
+	}
+}
+
+func TestCommandFSSearchProviderForPathRejectsOutOfScopeQuery(t *testing.T) {
+	fsys := commandSearchCapableFS{
+		FileSystem: gbfs.NewMemory(),
+		provider:   commandFixedHitsProvider{},
+	}
+	inv := NewInvocation(&InvocationOptions{
+		Cwd:        "/",
+		FileSystem: fsys,
+	})
+
+	provider, _, ok, err := inv.FS.SearchProviderForPath(context.Background(), "/workspace")
+	if err != nil {
+		t.Fatalf("SearchProviderForPath() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("SearchProviderForPath() = false, want true")
+	}
+
+	_, err = provider.Search(context.Background(), &gbfs.SearchQuery{
+		Root:    "/other",
+		Literal: "needle",
+	})
+	if err == nil {
+		t.Fatal("Search() error = nil, want out-of-scope error")
+	}
+}
+
+func TestCommandFSSearchProviderForPathHonorsPolicy(t *testing.T) {
+	fsys := commandSearchCapableFS{
+		FileSystem: gbfs.NewMemory(),
+		provider:   commandFixedHitsProvider{},
+	}
+	inv := NewInvocation(&InvocationOptions{
+		Cwd:        "/",
+		FileSystem: fsys,
+		Policy: policy.NewStatic(&policy.Config{
+			ReadRoots: []string{"/workspace"},
+		}),
+	})
+
+	_, _, _, err := inv.FS.SearchProviderForPath(context.Background(), "/other")
+	if !policy.IsDenied(err) {
+		t.Fatalf("SearchProviderForPath() error = %v, want denied error", err)
+	}
+}
+
+type commandSearchCapableFS struct {
+	gbfs.FileSystem
+	provider gbfs.SearchProvider
+}
+
+func (f commandSearchCapableFS) SearchProviderForPath(string) (gbfs.SearchProvider, bool) {
+	return f.provider, true
+}
+
+type commandFixedHitsProvider struct {
+	hits []gbfs.SearchHit
+}
+
+func (p commandFixedHitsProvider) Search(context.Context, *gbfs.SearchQuery) (gbfs.SearchResult, error) {
+	return gbfs.SearchResult{
+		Hits: p.hits,
+		Status: gbfs.IndexStatus{
+			CurrentGeneration: 1,
+			IndexedGeneration: 1,
+			Backend:           "command-fixed-hits",
+		},
+	}, nil
+}
+
+func (commandFixedHitsProvider) SearchCapabilities() gbfs.SearchCapabilities {
+	return gbfs.SearchCapabilities{
+		LiteralSearch:   true,
+		RootRestriction: false,
+	}
+}
+
+func (commandFixedHitsProvider) IndexStatus() gbfs.IndexStatus {
+	return gbfs.IndexStatus{
+		CurrentGeneration: 1,
+		IndexedGeneration: 1,
+		Backend:           "command-fixed-hits",
+	}
+}
+
+func hitPaths(hits []gbfs.SearchHit) []string {
+	out := make([]string, 0, len(hits))
+	for _, hit := range hits {
+		out = append(out, hit.Path)
+	}
+	return out
+}

--- a/internal/builtins/grep.go
+++ b/internal/builtins/grep.go
@@ -3,11 +3,14 @@ package builtins
 import (
 	"context"
 	"fmt"
+	stdfs "io/fs"
 	"path"
 	"regexp"
 	"strconv"
 	"strings"
 
+	gbfs "github.com/ewhauser/gbash/fs"
+	"github.com/ewhauser/gbash/internal/searchadapter"
 	"github.com/ewhauser/gbash/policy"
 )
 
@@ -45,6 +48,19 @@ type grepRunState struct {
 	filesWithoutMatchAny bool
 	hadError             bool
 	quietMatched         bool
+}
+
+type grepFileRecord struct {
+	abs           string
+	scope         *grepSearchScope
+	indexEligible bool
+}
+
+type grepSearchScope struct {
+	root          string
+	eligiblePaths []string
+	candidates    map[string]struct{}
+	usedIndex     bool
 }
 
 func NewGrep() *Grep {
@@ -122,8 +138,34 @@ func (c *Grep) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCo
 	} else {
 		showNames := (len(files) > 1 || opts.recursive) && !opts.noFilename
 		for _, file := range files {
-			if err := c.processPath(ctx, inv, file, re, opts, showNames, state); err != nil {
+			records := make([]grepFileRecord, 0, 8)
+			scope, err := c.enumerateTopLevelPath(ctx, inv, file, opts, state, &records)
+			if err != nil {
 				return err
+			}
+			if scope != nil {
+				if err := c.prefilterScopes(ctx, inv, []*grepSearchScope{scope}, re, opts); err != nil {
+					return err
+				}
+			}
+			for _, record := range records {
+				if state.quietMatched {
+					return nil
+				}
+				if !grepPathNeedsVerification(record) {
+					if err := writeGrepGuaranteedMiss(inv, record.abs, showNames, opts, state); err != nil {
+						return err
+					}
+					continue
+				}
+
+				data, _, err := readAllFile(ctx, inv, record.abs)
+				if err != nil {
+					return err
+				}
+				if err := writeGrepResult(inv, re, data, record.abs, showNames, opts, state); err != nil {
+					return err
+				}
 			}
 			if state.quietMatched {
 				return nil
@@ -479,48 +521,115 @@ func writeGrepResult(inv *Invocation, re *regexp.Regexp, data []byte, name strin
 	return nil
 }
 
-func (c *Grep) processPath(ctx context.Context, inv *Invocation, file string, re *regexp.Regexp, opts grepOptions, showNames bool, state *grepRunState) error {
-	info, abs, exists, err := statMaybe(ctx, inv, policy.FileActionStat, file)
+func writeGrepGuaranteedMiss(inv *Invocation, name string, showName bool, opts grepOptions, state *grepRunState) error {
+	if opts.filesWithoutMatch {
+		state.filesWithoutMatchAny = true
+		if opts.quiet {
+			return nil
+		}
+		if _, err := fmt.Fprintln(inv.Stdout, name); err != nil {
+			return &ExitError{Code: 1, Err: err}
+		}
+		return nil
+	}
+
+	if opts.listFiles || opts.quiet {
+		return nil
+	}
+
+	if opts.count {
+		prefix := ""
+		if showName {
+			prefix = name + ":"
+		}
+		if _, err := fmt.Fprintf(inv.Stdout, "%s0\n", prefix); err != nil {
+			return &ExitError{Code: 1, Err: err}
+		}
+	}
+	return nil
+}
+
+func (c *Grep) enumerateTopLevelPath(ctx context.Context, inv *Invocation, file string, opts grepOptions, state *grepRunState, records *[]grepFileRecord) (*grepSearchScope, error) {
+	linfo, abs, exists, err := lstatMaybe(ctx, inv, policy.FileActionLstat, file)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if !exists {
 		_, _ = fmt.Fprintf(inv.Stderr, "grep: %s: No such file or directory\n", file)
 		state.hadError = true
-		return nil
+		return nil, nil
+	}
+
+	info := linfo
+	throughSymlinkDir := false
+	if linfo.Mode()&stdfs.ModeSymlink != 0 {
+		info, _, err = statPath(ctx, inv, abs)
+		if err != nil {
+			if errorsIsNotExist(err) {
+				_, _ = fmt.Fprintf(inv.Stderr, "grep: %s: No such file or directory\n", file)
+				state.hadError = true
+				return nil, nil
+			}
+			return nil, err
+		}
+		throughSymlinkDir = info.IsDir()
 	}
 
 	if info.IsDir() {
 		if !opts.recursive {
 			_, _ = fmt.Fprintf(inv.Stderr, "grep: %s: Is a directory\n", file)
 			state.hadError = true
-			return nil
+			return nil, nil
 		}
-		return c.walkRecursive(ctx, inv, abs, re, opts, showNames, state)
+		scope := &grepSearchScope{root: abs}
+		if err := c.enumerateRecursive(ctx, inv, abs, throughSymlinkDir, scope, records); err != nil {
+			return nil, err
+		}
+		return scope, nil
 	}
 
-	data, _, err := readAllFile(ctx, inv, abs)
-	if err != nil {
-		return err
+	scope := &grepSearchScope{root: abs}
+	record := grepFileRecord{
+		abs:           abs,
+		scope:         scope,
+		indexEligible: grepIndexableFileInfo(info),
 	}
-	return writeGrepResult(inv, re, data, abs, showNames, opts, state)
+	if record.indexEligible {
+		scope.eligiblePaths = append(scope.eligiblePaths, abs)
+	}
+	*records = append(*records, record)
+	return scope, nil
 }
 
-func (c *Grep) walkRecursive(ctx context.Context, inv *Invocation, currentAbs string, re *regexp.Regexp, opts grepOptions, showNames bool, state *grepRunState) error {
-	if state.quietMatched {
-		return nil
-	}
-
-	info, _, err := statPath(ctx, inv, currentAbs)
+func (c *Grep) enumerateRecursive(ctx context.Context, inv *Invocation, currentAbs string, throughSymlinkDir bool, scope *grepSearchScope, records *[]grepFileRecord) error {
+	linfo, _, err := lstatPath(ctx, inv, currentAbs)
 	if err != nil {
 		return err
 	}
-	if !info.IsDir() {
-		data, _, err := readAllFile(ctx, inv, currentAbs)
+
+	info := linfo
+	currentThroughSymlinkDir := throughSymlinkDir
+	if linfo.Mode()&stdfs.ModeSymlink != 0 {
+		info, _, err = statPath(ctx, inv, currentAbs)
 		if err != nil {
 			return err
 		}
-		return writeGrepResult(inv, re, data, currentAbs, showNames, opts, state)
+		if info.IsDir() {
+			currentThroughSymlinkDir = true
+		}
+	}
+
+	if !info.IsDir() {
+		record := grepFileRecord{
+			abs:           currentAbs,
+			scope:         scope,
+			indexEligible: grepIndexableFileInfo(info) && !currentThroughSymlinkDir,
+		}
+		if record.indexEligible {
+			scope.eligiblePaths = append(scope.eligiblePaths, currentAbs)
+		}
+		*records = append(*records, record)
+		return nil
 	}
 
 	entries, _, err := readDir(ctx, inv, currentAbs)
@@ -528,15 +637,51 @@ func (c *Grep) walkRecursive(ctx context.Context, inv *Invocation, currentAbs st
 		return err
 	}
 	for _, entry := range entries {
-		if state.quietMatched {
-			return nil
-		}
 		childAbs := path.Join(currentAbs, entry.Name())
-		if err := c.walkRecursive(ctx, inv, childAbs, re, opts, showNames, state); err != nil {
+		if err := c.enumerateRecursive(ctx, inv, childAbs, currentThroughSymlinkDir, scope, records); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (c *Grep) prefilterScopes(ctx context.Context, inv *Invocation, scopes []*grepSearchScope, re *regexp.Regexp, opts grepOptions) error {
+	if opts.invert || inv == nil || inv.FS == nil {
+		return nil
+	}
+	for _, scope := range scopes {
+		if scope == nil || len(scope.eligiblePaths) == 0 {
+			continue
+		}
+		provider, _, ok, err := inv.FS.SearchProviderForPath(ctx, scope.root)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		result, err := searchadapter.PrefilterCandidates(ctx, provider, scope.root, scope.eligiblePaths, re, opts.ignoreCase)
+		if err != nil {
+			return err
+		}
+		if result.UsedIndex {
+			scope.candidates = result.CandidatePaths
+			scope.usedIndex = true
+		}
+	}
+	return nil
+}
+
+func grepIndexableFileInfo(info stdfs.FileInfo) bool {
+	return info != nil && info.Mode().IsRegular()
+}
+
+func grepPathNeedsVerification(record grepFileRecord) bool {
+	if record.scope == nil || !record.scope.usedIndex || !record.indexEligible {
+		return true
+	}
+	_, ok := record.scope.candidates[gbfs.Clean(record.abs)]
+	return ok
 }
 
 var _ Command = (*Grep)(nil)

--- a/internal/builtins/grep_search_test.go
+++ b/internal/builtins/grep_search_test.go
@@ -1,0 +1,470 @@
+package builtins_test
+
+import (
+	"context"
+	"io"
+	stdfs "io/fs"
+	"os"
+	"path"
+	"sync"
+	"testing"
+
+	gbfs "github.com/ewhauser/gbash/fs"
+	"github.com/ewhauser/gbash/policy"
+)
+
+func TestGrepUsesIndexedPrefilterOnSearchableFS(t *testing.T) {
+	fsys, provider := newCountedSearchableFS(t, map[string]string{
+		"/workspace/hit.txt":  "needle\n",
+		"/workspace/miss.txt": "other\n",
+	})
+	session := newSession(t, &Config{
+		FileSystem: CustomFileSystem(factoryForFS(fsys), "/workspace"),
+	})
+
+	result := mustExecSession(t, session, "grep -r needle /workspace\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "/workspace/hit.txt:needle\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+	if provider.SearchCount() == 0 {
+		t.Fatal("SearchCount = 0, want indexed query")
+	}
+	if got := fsys.OpenCount("/workspace/hit.txt"); got == 0 {
+		t.Fatal("OpenCount(hit) = 0, want verification read")
+	}
+	if got := fsys.OpenCount("/workspace/miss.txt"); got != 0 {
+		t.Fatalf("OpenCount(miss) = %d, want 0", got)
+	}
+}
+
+func TestGrepFallsBackWhenProviderIsStale(t *testing.T) {
+	fsys := newCountedSearchCapableFS(t, map[string]string{
+		"/workspace/miss.txt": "other\n",
+	}, grepStaleProvider{})
+	session := newSession(t, &Config{
+		FileSystem: CustomFileSystem(factoryForFS(fsys), "/workspace"),
+	})
+
+	result := mustExecSession(t, session, "grep needle /workspace/miss.txt\n")
+	if result.ExitCode != 1 {
+		t.Fatalf("ExitCode = %d, want 1", result.ExitCode)
+	}
+	if got := fsys.OpenCount("/workspace/miss.txt"); got == 0 {
+		t.Fatal("OpenCount(miss) = 0, want fallback read")
+	}
+}
+
+func TestGrepFallsBackWhenProviderIsUnsupported(t *testing.T) {
+	provider := &grepUnsupportedProvider{}
+	fsys := newCountedSearchCapableFS(t, map[string]string{
+		"/workspace/miss.txt": "other\n",
+	}, provider)
+	session := newSession(t, &Config{
+		FileSystem: CustomFileSystem(factoryForFS(fsys), "/workspace"),
+	})
+
+	result := mustExecSession(t, session, "grep needle /workspace/miss.txt\n")
+	if result.ExitCode != 1 {
+		t.Fatalf("ExitCode = %d, want 1", result.ExitCode)
+	}
+	if provider.SearchCount() == 0 {
+		t.Fatal("SearchCount = 0, want attempted provider search")
+	}
+	if got := fsys.OpenCount("/workspace/miss.txt"); got == 0 {
+		t.Fatal("OpenCount(miss) = 0, want fallback read")
+	}
+}
+
+func TestGrepUsesIndexPerRootOnMountableFS(t *testing.T) {
+	indexedFS, indexedProvider := newCountedSearchableFS(t, map[string]string{
+		"/hit.txt":  "needle\n",
+		"/miss.txt": "other\n",
+	})
+	staleFS := newCountedSearchCapableFS(t, map[string]string{
+		"/hit.txt":  "needle\n",
+		"/miss.txt": "other\n",
+	}, grepStaleProvider{})
+
+	mountable := gbfs.NewMountable(gbfs.NewMemory())
+	if err := mountable.Mount("/indexed", indexedFS); err != nil {
+		t.Fatalf("Mount(/indexed) error = %v", err)
+	}
+	if err := mountable.Mount("/stale", staleFS); err != nil {
+		t.Fatalf("Mount(/stale) error = %v", err)
+	}
+
+	session := newSession(t, &Config{
+		FileSystem: CustomFileSystem(factoryForFS(mountable), "/"),
+	})
+
+	result := mustExecSession(t, session, "grep -r needle /indexed /stale\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	for _, want := range []string{"/indexed/hit.txt:needle", "/stale/hit.txt:needle"} {
+		if !containsLine(lines(result.Stdout), want) {
+			t.Fatalf("Stdout missing %q: %q", want, result.Stdout)
+		}
+	}
+	if indexedProvider.SearchCount() == 0 {
+		t.Fatal("indexed SearchCount = 0, want indexed query")
+	}
+	if got := indexedFS.OpenCount("/hit.txt"); got == 0 {
+		t.Fatal("indexed hit open count = 0, want verification read")
+	}
+	if got := indexedFS.OpenCount("/miss.txt"); got != 0 {
+		t.Fatalf("indexed miss open count = %d, want 0", got)
+	}
+	if got := staleFS.OpenCount("/miss.txt"); got == 0 {
+		t.Fatal("stale miss open count = 0, want fallback read")
+	}
+}
+
+func TestGrepGuaranteedMissModesUseIndexWithoutReadingFile(t *testing.T) {
+	tests := []struct {
+		name       string
+		script     string
+		wantStdout string
+		wantExit   int
+	}{
+		{
+			name:       "default",
+			script:     "grep needle /workspace/miss.txt\n",
+			wantStdout: "",
+			wantExit:   1,
+		},
+		{
+			name:       "count",
+			script:     "grep -c needle /workspace/miss.txt\n",
+			wantStdout: "0\n",
+			wantExit:   1,
+		},
+		{
+			name:       "files-without-match",
+			script:     "grep -L needle /workspace/miss.txt\n",
+			wantStdout: "/workspace/miss.txt\n",
+			wantExit:   0,
+		},
+		{
+			name:       "quiet",
+			script:     "grep -q needle /workspace/miss.txt\n",
+			wantStdout: "",
+			wantExit:   1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fsys, _ := newCountedSearchableFS(t, map[string]string{
+				"/workspace/miss.txt": "other\n",
+			})
+			session := newSession(t, &Config{
+				FileSystem: CustomFileSystem(factoryForFS(fsys), "/workspace"),
+			})
+
+			result := mustExecSession(t, session, tc.script)
+			if result.ExitCode != tc.wantExit {
+				t.Fatalf("ExitCode = %d, want %d; stderr=%q", result.ExitCode, tc.wantExit, result.Stderr)
+			}
+			if got := result.Stdout; got != tc.wantStdout {
+				t.Fatalf("Stdout = %q, want %q", got, tc.wantStdout)
+			}
+			if got := fsys.OpenCount("/workspace/miss.txt"); got != 0 {
+				t.Fatalf("OpenCount(miss) = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestGrepInvertMatchSkipsIndexedPrefilter(t *testing.T) {
+	fsys, _ := newCountedSearchableFS(t, map[string]string{
+		"/workspace/miss.txt": "other\n",
+	})
+	session := newSession(t, &Config{
+		FileSystem: CustomFileSystem(factoryForFS(fsys), "/workspace"),
+	})
+
+	result := mustExecSession(t, session, "grep -v needle /workspace/miss.txt\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "other\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+	if got := fsys.OpenCount("/workspace/miss.txt"); got == 0 {
+		t.Fatal("OpenCount(miss) = 0, want direct read")
+	}
+}
+
+func TestGrepRecursiveSymlinkDirectoryFallsBackToDirectReads(t *testing.T) {
+	fsys, _ := newCountedSearchableFS(t, map[string]string{
+		"/workspace/real/miss.txt": "other\n",
+	})
+	session := newSession(t, &Config{
+		FileSystem: CustomFileSystem(factoryForFS(fsys), "/workspace"),
+		Policy: policy.NewStatic(&policy.Config{
+			SymlinkMode: policy.SymlinkFollow,
+		}),
+	})
+	if err := session.FileSystem().Symlink(context.Background(), "real", "/workspace/linkdir"); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	result := mustExecSession(t, session, "grep -r needle /workspace/linkdir\n")
+	if result.ExitCode != 1 {
+		t.Fatalf("ExitCode = %d, want 1", result.ExitCode)
+	}
+	if got := fsys.OpenCount("/workspace/linkdir/miss.txt"); got == 0 {
+		t.Fatal("OpenCount(linkdir/miss.txt) = 0, want fallback read")
+	}
+}
+
+func TestGrepQuietStopsBeforeLaterOperands(t *testing.T) {
+	fsys, _ := newCountedSearchableFS(t, map[string]string{
+		"/workspace/hit.txt": "needle\n",
+	})
+	session := newSession(t, &Config{
+		FileSystem: CustomFileSystem(factoryForFS(fsys), "/workspace"),
+	})
+
+	result := mustExecSession(t, session, "grep -q needle /workspace/hit.txt /workspace/missing.txt\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("Stderr = %q, want empty", result.Stderr)
+	}
+}
+
+func factoryForFS(fsys gbfs.FileSystem) gbfs.Factory {
+	return gbfs.FactoryFunc(func(context.Context) (gbfs.FileSystem, error) {
+		return fsys, nil
+	})
+}
+
+func newCountedSearchableFS(t *testing.T, files map[string]string) (*countingOpenFS, *countingSearchIndexer) {
+	t.Helper()
+
+	base := seededMemoryFS(t, files)
+	provider := newCountingSearchIndexer()
+	searchable, err := gbfs.NewSearchableFileSystem(context.Background(), base, provider)
+	if err != nil {
+		t.Fatalf("NewSearchableFileSystem() error = %v", err)
+	}
+	return newCountingOpenFS(searchable), provider
+}
+
+func newCountedSearchCapableFS(t *testing.T, files map[string]string, provider gbfs.SearchProvider) *countingOpenFS {
+	t.Helper()
+	return newCountingOpenFS(grepSearchCapableFS{
+		FileSystem: seededMemoryFS(t, files),
+		provider:   provider,
+	})
+}
+
+func seededMemoryFS(t *testing.T, files map[string]string) gbfs.FileSystem {
+	t.Helper()
+
+	mem := gbfs.NewMemory()
+	for name, contents := range files {
+		if err := mem.MkdirAll(context.Background(), path.Dir(name), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", path.Dir(name), err)
+		}
+		file, err := mem.OpenFile(context.Background(), name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			t.Fatalf("OpenFile(%q) error = %v", name, err)
+		}
+		if _, err := io.WriteString(file, contents); err != nil {
+			_ = file.Close()
+			t.Fatalf("WriteString(%q) error = %v", name, err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatalf("Close(%q) error = %v", name, err)
+		}
+	}
+	return mem
+}
+
+func lines(stdout string) []string {
+	if stdout == "" {
+		return nil
+	}
+	return splitLines(stdout)
+}
+
+func splitLines(stdout string) []string {
+	out := make([]string, 0)
+	start := 0
+	for i := 0; i < len(stdout); i++ {
+		if stdout[i] != '\n' {
+			continue
+		}
+		out = append(out, stdout[start:i])
+		start = i + 1
+	}
+	if start < len(stdout) {
+		out = append(out, stdout[start:])
+	}
+	return out
+}
+
+type countingOpenFS struct {
+	gbfs.FileSystem
+
+	mu        sync.Mutex
+	openCount map[string]int
+}
+
+func newCountingOpenFS(fsys gbfs.FileSystem) *countingOpenFS {
+	return &countingOpenFS{
+		FileSystem: fsys,
+		openCount:  make(map[string]int),
+	}
+}
+
+func (f *countingOpenFS) Open(ctx context.Context, name string) (gbfs.File, error) {
+	f.recordOpen(name)
+	return f.FileSystem.Open(ctx, name)
+}
+
+func (f *countingOpenFS) OpenFile(ctx context.Context, name string, flag int, perm stdfs.FileMode) (gbfs.File, error) {
+	if flag&(os.O_WRONLY|os.O_RDWR) != os.O_WRONLY {
+		f.recordOpen(name)
+	}
+	return f.FileSystem.OpenFile(ctx, name, flag, perm)
+}
+
+func (f *countingOpenFS) recordOpen(name string) {
+	f.mu.Lock()
+	f.openCount[gbfs.Clean(name)]++
+	f.mu.Unlock()
+}
+
+func (f *countingOpenFS) SearchProviderForPath(name string) (gbfs.SearchProvider, bool) {
+	capable, ok := f.FileSystem.(gbfs.SearchCapable)
+	if !ok {
+		return nil, false
+	}
+	return capable.SearchProviderForPath(name)
+}
+
+func (f *countingOpenFS) OpenCount(name string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.openCount[gbfs.Clean(name)]
+}
+
+type countingSearchIndexer struct {
+	inner gbfs.SearchIndexer
+
+	mu      sync.Mutex
+	queries []gbfs.SearchQuery
+}
+
+func newCountingSearchIndexer() *countingSearchIndexer {
+	return &countingSearchIndexer{
+		inner: gbfs.NewInMemorySearchProvider(),
+	}
+}
+
+func (p *countingSearchIndexer) Search(ctx context.Context, query *gbfs.SearchQuery) (gbfs.SearchResult, error) {
+	p.mu.Lock()
+	if query != nil {
+		copied := *query
+		copied.IncludeGlobs = append([]string(nil), query.IncludeGlobs...)
+		copied.ExcludeGlobs = append([]string(nil), query.ExcludeGlobs...)
+		p.queries = append(p.queries, copied)
+	}
+	p.mu.Unlock()
+	return p.inner.Search(ctx, query)
+}
+
+func (p *countingSearchIndexer) SearchCapabilities() gbfs.SearchCapabilities {
+	return p.inner.SearchCapabilities()
+}
+
+func (p *countingSearchIndexer) IndexStatus() gbfs.IndexStatus {
+	return p.inner.IndexStatus()
+}
+
+func (p *countingSearchIndexer) ApplySearchMutation(ctx context.Context, mutation *gbfs.SearchMutation) error {
+	return p.inner.ApplySearchMutation(ctx, mutation)
+}
+
+func (p *countingSearchIndexer) SearchCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.queries)
+}
+
+type grepSearchCapableFS struct {
+	gbfs.FileSystem
+	provider gbfs.SearchProvider
+}
+
+func (f grepSearchCapableFS) SearchProviderForPath(string) (gbfs.SearchProvider, bool) {
+	return f.provider, true
+}
+
+type grepStaleProvider struct{}
+
+func (grepStaleProvider) Search(context.Context, *gbfs.SearchQuery) (gbfs.SearchResult, error) {
+	return gbfs.SearchResult{
+		Status: gbfs.IndexStatus{
+			CurrentGeneration: 2,
+			IndexedGeneration: 1,
+			Backend:           "grep-stale",
+		},
+	}, nil
+}
+
+func (grepStaleProvider) SearchCapabilities() gbfs.SearchCapabilities {
+	return gbfs.SearchCapabilities{
+		LiteralSearch:   true,
+		RootRestriction: true,
+	}
+}
+
+func (grepStaleProvider) IndexStatus() gbfs.IndexStatus {
+	return gbfs.IndexStatus{
+		CurrentGeneration: 2,
+		IndexedGeneration: 1,
+		Backend:           "grep-stale",
+	}
+}
+
+type grepUnsupportedProvider struct {
+	mu          sync.Mutex
+	searchCount int
+}
+
+func (p *grepUnsupportedProvider) Search(context.Context, *gbfs.SearchQuery) (gbfs.SearchResult, error) {
+	p.mu.Lock()
+	p.searchCount++
+	p.mu.Unlock()
+	return gbfs.SearchResult{}, gbfs.ErrSearchUnsupported
+}
+
+func (*grepUnsupportedProvider) SearchCapabilities() gbfs.SearchCapabilities {
+	return gbfs.SearchCapabilities{
+		LiteralSearch:   true,
+		RootRestriction: true,
+	}
+}
+
+func (*grepUnsupportedProvider) IndexStatus() gbfs.IndexStatus {
+	return gbfs.IndexStatus{
+		CurrentGeneration: 1,
+		IndexedGeneration: 1,
+		Backend:           "grep-unsupported",
+	}
+}
+
+func (p *grepUnsupportedProvider) SearchCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.searchCount
+}

--- a/internal/searchadapter/searchadapter.go
+++ b/internal/searchadapter/searchadapter.go
@@ -9,6 +9,7 @@ import (
 	stdfs "io/fs"
 	"path"
 	"regexp"
+	"regexp/syntax"
 	"slices"
 	"strings"
 	"unicode/utf8"
@@ -38,6 +39,15 @@ type Result struct {
 	Hits      []gbfs.SearchHit
 	UsedIndex bool
 	Truncated bool
+}
+
+const MaxPrefilterLiterals = 8
+
+// PrefilterResult reports candidate paths selected by indexed literal queries.
+type PrefilterResult struct {
+	CandidatePaths map[string]struct{}
+	Literals       []string
+	UsedIndex      bool
 }
 
 // Search resolves indexed candidates when every requested root exposes a fresh
@@ -124,6 +134,96 @@ func Search(ctx context.Context, fsys gbfs.FileSystem, query *Query, verify Veri
 		Hits:      hits,
 		UsedIndex: true,
 		Truncated: truncated,
+	}, nil
+}
+
+// RegexpPrefilterLiterals extracts a bounded set of literals such that every
+// real regexp match must contain at least one returned literal.
+func RegexpPrefilterLiterals(re *regexp.Regexp) ([]string, bool) {
+	if re == nil {
+		return nil, false
+	}
+
+	literals, ok := extractRegexpPrefilterLiterals(re.String())
+	if !ok || len(literals) == 0 {
+		prefix, _ := re.LiteralPrefix()
+		if prefix == "" {
+			return nil, false
+		}
+		literals = []string{prefix}
+	}
+
+	literals = normalizePrefilterLiterals(literals)
+	if len(literals) == 0 || len(literals) > MaxPrefilterLiterals {
+		return nil, false
+	}
+	return literals, true
+}
+
+// PrefilterCandidates uses a fresh indexed provider to build a candidate set
+// for eligiblePaths under root. It falls back cleanly when indexing is
+// unsupported, stale, or missing required capabilities.
+func PrefilterCandidates(ctx context.Context, provider gbfs.SearchProvider, root string, eligiblePaths []string, re *regexp.Regexp, ignoreCase bool) (PrefilterResult, error) {
+	if provider == nil {
+		return PrefilterResult{}, nil
+	}
+
+	literals, ok := RegexpPrefilterLiterals(re)
+	if !ok {
+		return PrefilterResult{}, nil
+	}
+	caps := provider.SearchCapabilities()
+	if !caps.LiteralSearch || !caps.RootRestriction {
+		return PrefilterResult{}, nil
+	}
+	if ignoreCase && !caps.IgnoreCaseLiteralSearch {
+		return PrefilterResult{}, nil
+	}
+	status := provider.IndexStatus()
+	if status.CurrentGeneration != status.IndexedGeneration {
+		return PrefilterResult{}, nil
+	}
+
+	eligible := make(map[string]struct{}, len(eligiblePaths))
+	for _, name := range eligiblePaths {
+		eligible[gbfs.Clean(name)] = struct{}{}
+	}
+	if len(eligible) == 0 {
+		return PrefilterResult{
+			CandidatePaths: make(map[string]struct{}),
+			Literals:       literals,
+			UsedIndex:      true,
+		}, nil
+	}
+
+	candidates := make(map[string]struct{})
+	for _, literal := range literals {
+		result, err := provider.Search(ctx, &gbfs.SearchQuery{
+			Root:       root,
+			Literal:    literal,
+			IgnoreCase: ignoreCase,
+		})
+		if err != nil {
+			if errors.Is(err, gbfs.ErrSearchUnsupported) {
+				return PrefilterResult{}, nil
+			}
+			return PrefilterResult{}, err
+		}
+		if result.Status.CurrentGeneration != result.Status.IndexedGeneration {
+			return PrefilterResult{}, nil
+		}
+		for _, hit := range result.Hits {
+			pathValue := gbfs.Clean(hit.Path)
+			if _, ok := eligible[pathValue]; ok {
+				candidates[pathValue] = struct{}{}
+			}
+		}
+	}
+
+	return PrefilterResult{
+		CandidatePaths: candidates,
+		Literals:       literals,
+		UsedIndex:      true,
 	}, nil
 }
 
@@ -253,6 +353,127 @@ func normalizedRoots(fsys gbfs.FileSystem, roots []string) []string {
 	for _, root := range roots {
 		out = append(out, gbfs.Resolve(cwd, root))
 	}
+	return out
+}
+
+func extractRegexpPrefilterLiterals(expr string) ([]string, bool) {
+	parsed, err := syntax.Parse(expr, syntax.Perl)
+	if err != nil {
+		return nil, false
+	}
+	parsed = parsed.Simplify()
+	literals := mandatoryLiteralSet(parsed)
+	if len(literals) == 0 {
+		return nil, false
+	}
+	return literals, true
+}
+
+func mandatoryLiteralSet(re *syntax.Regexp) []string {
+	if re == nil {
+		return nil
+	}
+	switch re.Op {
+	case syntax.OpLiteral:
+		if len(re.Rune) == 0 {
+			return nil
+		}
+		return []string{string(re.Rune)}
+	case syntax.OpCapture:
+		if len(re.Sub) == 0 {
+			return nil
+		}
+		return mandatoryLiteralSet(re.Sub[0])
+	case syntax.OpPlus:
+		if len(re.Sub) == 0 {
+			return nil
+		}
+		return mandatoryLiteralSet(re.Sub[0])
+	case syntax.OpRepeat:
+		if re.Min <= 0 || len(re.Sub) == 0 {
+			return nil
+		}
+		return mandatoryLiteralSet(re.Sub[0])
+	case syntax.OpConcat:
+		var best []string
+		for _, sub := range re.Sub {
+			candidate := mandatoryLiteralSet(sub)
+			if betterMandatoryLiteralSet(candidate, best) {
+				best = candidate
+			}
+		}
+		return best
+	case syntax.OpAlternate:
+		out := make([]string, 0, len(re.Sub))
+		for _, sub := range re.Sub {
+			candidate := mandatoryLiteralSet(sub)
+			if len(candidate) == 0 {
+				return nil
+			}
+			out = append(out, bestMandatoryLiteral(candidate))
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func betterMandatoryLiteralSet(candidate, current []string) bool {
+	if len(candidate) == 0 {
+		return false
+	}
+	if len(current) == 0 {
+		return true
+	}
+	candidateLen := len(bestMandatoryLiteral(candidate))
+	currentLen := len(bestMandatoryLiteral(current))
+	if candidateLen != currentLen {
+		return candidateLen > currentLen
+	}
+	if len(candidate) != len(current) {
+		return len(candidate) < len(current)
+	}
+	return strings.Join(candidate, "\x00") < strings.Join(current, "\x00")
+}
+
+func bestMandatoryLiteral(literals []string) string {
+	best := ""
+	for _, literal := range literals {
+		if len(literal) > len(best) || (len(literal) == len(best) && literal < best) {
+			best = literal
+		}
+	}
+	return best
+}
+
+func normalizePrefilterLiterals(literals []string) []string {
+	if len(literals) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(literals))
+	out := make([]string, 0, len(literals))
+	for _, literal := range literals {
+		if literal == "" {
+			continue
+		}
+		if _, ok := seen[literal]; ok {
+			continue
+		}
+		seen[literal] = struct{}{}
+		out = append(out, literal)
+	}
+	slices.SortFunc(out, func(a, b string) int {
+		switch {
+		case len(a) != len(b):
+			return len(b) - len(a)
+		case a < b:
+			return -1
+		case a > b:
+			return 1
+		default:
+			return 0
+		}
+	})
 	return out
 }
 

--- a/internal/searchadapter/searchadapter_test.go
+++ b/internal/searchadapter/searchadapter_test.go
@@ -8,6 +8,7 @@ import (
 	stdfs "io/fs"
 	"os"
 	"path"
+	"regexp"
 	"slices"
 	"testing"
 	"time"
@@ -367,6 +368,109 @@ func TestSearchFallbackWhenProviderWrapsUnsupported(t *testing.T) {
 	}
 }
 
+func TestRegexpPrefilterLiterals(t *testing.T) {
+	tests := []struct {
+		name       string
+		pattern    string
+		want       []string
+		wantUsable bool
+	}{
+		{
+			name:       "fixed-string-alternation",
+			pattern:    "(?:a\\.c|foo)",
+			want:       []string{"a.c", "foo"},
+			wantUsable: true,
+		},
+		{
+			name:       "concat-picks-mandatory-literal",
+			pattern:    "foo.*bar",
+			want:       []string{"bar"},
+			wantUsable: true,
+		},
+		{
+			name:       "alternation-unions-branches",
+			pattern:    "foo|bar",
+			want:       []string{"bar", "foo"},
+			wantUsable: true,
+		},
+		{
+			name:       "optional-pattern-falls-back",
+			pattern:    "a*",
+			want:       nil,
+			wantUsable: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			re := regexp.MustCompile(tc.pattern)
+			got, ok := RegexpPrefilterLiterals(re)
+			if ok != tc.wantUsable {
+				t.Fatalf("RegexpPrefilterLiterals(%q) usable = %v, want %v", tc.pattern, ok, tc.wantUsable)
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("RegexpPrefilterLiterals(%q) = %v, want %v", tc.pattern, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRegexpPrefilterLiteralsRejectsBroadAlternations(t *testing.T) {
+	re := regexp.MustCompile("aa|bb|cc|dd|ee|ff|gg|hh|ii")
+
+	got, ok := RegexpPrefilterLiterals(re)
+	if ok {
+		t.Fatalf("RegexpPrefilterLiterals() usable = true, want false; got %v", got)
+	}
+	if got != nil {
+		t.Fatalf("RegexpPrefilterLiterals() = %v, want nil", got)
+	}
+}
+
+func TestPrefilterCandidatesUsesLiteralUnionAndEligibleIntersection(t *testing.T) {
+	provider := &literalHitsProvider{
+		hitsByLiteral: map[string][]gbfs.SearchHit{
+			"bar": {
+				{Path: "/workspace/bar.txt", Verified: true},
+				{Path: "/workspace/outside.txt", Verified: true},
+			},
+			"foo": {
+				{Path: "/workspace/foo.txt", Verified: true},
+			},
+		},
+	}
+
+	result, err := PrefilterCandidates(context.Background(), provider, "/workspace", []string{
+		"/workspace/foo.txt",
+		"/workspace/miss.txt",
+	}, regexp.MustCompile("foo|bar"), false)
+	if err != nil {
+		t.Fatalf("PrefilterCandidates() error = %v", err)
+	}
+	if !result.UsedIndex {
+		t.Fatal("UsedIndex = false, want true")
+	}
+	if got, want := result.Literals, []string{"bar", "foo"}; !slices.Equal(got, want) {
+		t.Fatalf("Literals = %v, want %v", got, want)
+	}
+	if got, want := sortedCandidatePaths(result.CandidatePaths), []string{"/workspace/foo.txt"}; !slices.Equal(got, want) {
+		t.Fatalf("CandidatePaths = %v, want %v", got, want)
+	}
+	if got, want := provider.queries, []string{"bar", "foo"}; !slices.Equal(got, want) {
+		t.Fatalf("provider queries = %v, want %v", got, want)
+	}
+}
+
+func TestPrefilterCandidatesFallsBackWhenProviderIsStale(t *testing.T) {
+	result, err := PrefilterCandidates(context.Background(), staleProvider{}, "/workspace", []string{"/workspace/a.txt"}, regexp.MustCompile("needle"), false)
+	if err != nil {
+		t.Fatalf("PrefilterCandidates() error = %v", err)
+	}
+	if result.UsedIndex {
+		t.Fatal("UsedIndex = true, want false")
+	}
+}
+
 type searchCapableFS struct {
 	gbfs.FileSystem
 	provider gbfs.SearchProvider
@@ -533,6 +637,39 @@ func (limitedCapabilitiesProvider) IndexStatus() gbfs.IndexStatus {
 	}
 }
 
+type literalHitsProvider struct {
+	hitsByLiteral map[string][]gbfs.SearchHit
+	queries       []string
+}
+
+func (p *literalHitsProvider) Search(_ context.Context, query *gbfs.SearchQuery) (gbfs.SearchResult, error) {
+	p.queries = append(p.queries, query.Literal)
+	hits := append([]gbfs.SearchHit(nil), p.hitsByLiteral[query.Literal]...)
+	return gbfs.SearchResult{
+		Hits: hits,
+		Status: gbfs.IndexStatus{
+			CurrentGeneration: 1,
+			IndexedGeneration: 1,
+			Backend:           "literal-hits",
+		},
+	}, nil
+}
+
+func (*literalHitsProvider) SearchCapabilities() gbfs.SearchCapabilities {
+	return gbfs.SearchCapabilities{
+		LiteralSearch:   true,
+		RootRestriction: true,
+	}
+}
+
+func (*literalHitsProvider) IndexStatus() gbfs.IndexStatus {
+	return gbfs.IndexStatus{
+		CurrentGeneration: 1,
+		IndexedGeneration: 1,
+		Backend:           "literal-hits",
+	}
+}
+
 func seededMemory(t *testing.T, files map[string]string) gbfs.FileSystem {
 	t.Helper()
 	mem := gbfs.NewMemory()
@@ -564,6 +701,15 @@ func hitPaths(hits []gbfs.SearchHit) []string {
 	for _, hit := range hits {
 		out = append(out, hit.Path)
 	}
+	return out
+}
+
+func sortedCandidatePaths(paths map[string]struct{}) []string {
+	out := make([]string, 0, len(paths))
+	for name := range paths {
+		out = append(out, name)
+	}
+	slices.Sort(out)
 	return out
 }
 


### PR DESCRIPTION
## Summary
- add a command-side scoped search bridge so built-ins can use filesystem search without bypassing `Invocation.FS`
- extend the search adapter with regex literal prefilter planning and provider fallback rules
- refactor `grep` to enumerate files first, use indexed prefiltering per root, and skip guaranteed misses while preserving existing output semantics
- add regression coverage for command search scoping, adapter literal extraction, grep indexed hits/misses, per-root fallback, symlink traversal, and quiet-mode short-circuiting
- update `SPEC.md` to document the experimental command-facing search bridge and `grep`'s indexed prefilter behavior

## Testing
- `go test ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...`
- `make lint`
