### PR TITLE
benchmarks: add filesystem backend benchmarks

### DIFF
--- a/.agents/skills/update-benchmarks/SKILL.md
+++ b/.agents/skills/update-benchmarks/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update-benchmarks
 description: >
-  Update the website benchmark data by running the bench-compare harness and transforming results for the website.
+  Update the website benchmark data by running the runtime and filesystem benchmark harnesses.
   Use when the user asks to refresh benchmarks, update benchmark data, rerun performance comparisons,
   or regenerate the benchmarks page. Also use when the user mentions benchmark numbers are stale or out of date.
 ---
@@ -12,7 +12,7 @@ Refreshes the benchmark data displayed on the website's Performance > Benchmarks
 
 ## Steps
 
-### 1. Run the benchmark harness
+### 1. Run the runtime benchmark harness
 
 ```bash
 make bench-compare BENCH_COMPARE_RUNS=50 JSON_OUT=/tmp/bench-compare.json
@@ -20,7 +20,15 @@ make bench-compare BENCH_COMPARE_RUNS=50 JSON_OUT=/tmp/bench-compare.json
 
 The default is 100 runs but 50 is sufficient for stable medians. The user may request a different count.
 
-### 2. Collect machine info
+### 2. Run the filesystem benchmark harness
+
+```bash
+make bench-fs BENCH_FS_RUNS=50 BENCH_FS_JSON_OUT=/tmp/filesystem-benchmark-data.json
+```
+
+This harness already emits website-ready JSON, including machine info.
+
+### 3. Collect machine info for the runtime benchmark
 
 Gather the current machine's specs for the test environment table:
 
@@ -40,7 +48,7 @@ sw_vers -productName && sw_vers -productVersion  # e.g. macOS 15.5
 go version                            # e.g. go1.26.1 darwin/arm64
 ```
 
-### 3. Transform JSON for the website
+### 4. Transform runtime JSON for the website
 
 Use Python to strip individual trial data (keeping only stats) and inject the machine info:
 
@@ -67,7 +75,13 @@ with open("website/content/performance/benchmark-data.json", "w") as f:
     json.dump(data, f, indent=2)
 ```
 
-### 4. Verify the build
+### 5. Move or copy the filesystem JSON into place
+
+```bash
+cp /tmp/filesystem-benchmark-data.json website/content/performance/filesystem-benchmark-data.json
+```
+
+### 6. Verify the build
 
 ```bash
 cd website && npm run build
@@ -79,6 +93,9 @@ Confirm `/docs/performance/benchmarks` appears in the route list.
 
 - `scripts/bench-compare/main.go` — the benchmark harness
 - `website/content/performance/benchmark-data.json` — transformed JSON consumed by the website
+- `examples/bench-fs/main.go` — the filesystem benchmark harness
+- `website/content/performance/filesystem-benchmark-data.json` — filesystem benchmark JSON consumed by the website
 - `website/app/components/docs/BenchmarkChart.tsx` — React component rendering the data
+- `website/app/components/docs/FilesystemBenchmarkChart.tsx` — React component rendering filesystem benchmark data
 - `website/content/performance/benchmarks.mdx` — the benchmarks page content
-- `Makefile` — `bench-compare` target and its variables (`BENCH_COMPARE_RUNS`, `JUST_BASH_SPEC`, `JSON_OUT`)
+- `Makefile` — `bench-compare` and `bench-fs` targets plus their variables

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test build fuzz fuzz-run fuzz-shard fuzz-smoke fuzz-full bench-smoke bench-full bench-compare gnu-test compat-docker-build compat-docker-run website-dev release release-check release-snapshot fix-modules tag-release update-mvdan-sh
+.PHONY: lint test build fuzz fuzz-run fuzz-shard fuzz-smoke fuzz-full bench-smoke bench-full bench-compare bench-fs gnu-test compat-docker-build compat-docker-run website-dev release release-check release-snapshot fix-modules tag-release update-mvdan-sh
 
 GO_PACKAGES := ./... ./contrib/awk/... ./contrib/extras/... ./contrib/htmltomarkdown/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...
 BENCH_PACKAGES := ./internal/runtime ./cmd/gbash ./contrib/jq
@@ -24,6 +24,8 @@ BENCH_FULL_COUNT ?= 10
 BENCH_FULL_TIME ?= 200ms
 BENCH_SMOKE_REGEX ?= Benchmark(NewSession|RuntimeRunSimpleScript|SessionExecWarmSimpleScript|WorkflowCodebaseExploration|CommandRGRecursive|CLIBinary|CommandJQTransform)$$
 BENCH_COMPARE_RUNS ?= 100
+BENCH_FS_RUNS ?= 50
+BENCH_FS_JSON_OUT ?= website/content/performance/filesystem-benchmark-data.json
 JUST_BASH_SPEC ?= just-bash@2.13.0
 JSON_OUT ?=
 GNU_CACHE_DIR ?= .cache/gnu
@@ -216,6 +218,10 @@ bench-compare:
 	else \
 		go run ./scripts/bench-compare --runs "$(BENCH_COMPARE_RUNS)" --just-bash-spec "$(JUST_BASH_SPEC)"; \
 	fi
+
+bench-fs:
+	@set -eu; \
+	go run ./examples/bench-fs --runs "$(BENCH_FS_RUNS)" --json-out "$(BENCH_FS_JSON_OUT)"
 
 gnu-test:
 	GNU_CACHE_DIR='$(GNU_CACHE_DIR)' GNU_RESULTS_DIR='$(GNU_RESULTS_DIR)' GNU_UTILS='$(GNU_UTILS)' GNU_TESTS='$(GNU_TESTS)' GNU_KEEP_WORKDIR='$(GNU_KEEP_WORKDIR)' COMPAT_DOCKER_IMAGE='$(COMPAT_DOCKER_IMAGE)' COMPAT_DOCKER_BASE_IMAGE='$(COMPAT_DOCKER_BASE_IMAGE)' COMPAT_DOCKER_PLATFORM='$(COMPAT_DOCKER_PLATFORM)' COMPAT_DOCKER_PULL='$(COMPAT_DOCKER_PULL)' ./scripts/compat-docker-run.sh

--- a/examples/bench-fs/main.go
+++ b/examples/bench-fs/main.go
@@ -1,0 +1,893 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	goruntime "runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ewhauser/gbash/examples/internal/ftsfs"
+	"github.com/ewhauser/gbash/examples/internal/sqlitefs"
+	gbfs "github.com/ewhauser/gbash/fs"
+	"github.com/ewhauser/gbash/internal/searchadapter"
+)
+
+const (
+	defaultRuns         = 50
+	virtualWorkspace    = "/workspace"
+	searchLiteral       = "fulltext-benchmark-needle"
+	mutationCreatePath  = "/workspace/scratch/session/output.txt"
+	mutationCreateBody  = "created in benchmark mutation\n"
+	mutationRewritePath = "/workspace/docs/runbook00.md"
+	mutationRewriteBody = "rewritten benchmark doc\n"
+	mutationRenameSrc   = "/workspace/reports/summary00.csv"
+	mutationRenameDst   = "/workspace/reports/summary00-renamed.csv"
+	mutationRemovePath  = "/workspace/logs/batch00.log"
+)
+
+type options struct {
+	Runs    int
+	JSONOut string
+}
+
+type fixtureSummary struct {
+	FileCount  int   `json:"file_count"`
+	TotalBytes int64 `json:"total_bytes"`
+}
+
+type latencyStats struct {
+	MinNanos    int64 `json:"min_nanos"`
+	MedianNanos int64 `json:"median_nanos"`
+	P95Nanos    int64 `json:"p95_nanos"`
+}
+
+type machineInfo struct {
+	Model     string `json:"model"`
+	Chip      string `json:"chip"`
+	Cores     string `json:"cores"`
+	Memory    string `json:"memory"`
+	OS        string `json:"os"`
+	GoVersion string `json:"go_version"`
+}
+
+type backendInfo struct {
+	Name         string `json:"name"`
+	Label        string `json:"label"`
+	Description  string `json:"description"`
+	Experimental bool   `json:"experimental,omitempty"`
+}
+
+type scenarioResult struct {
+	Backend      string       `json:"backend"`
+	SuccessCount int          `json:"success_count"`
+	FailureCount int          `json:"failure_count"`
+	SearchMode   string       `json:"search_mode,omitempty"`
+	Stats        latencyStats `json:"stats"`
+}
+
+type scenarioReport struct {
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Results     []scenarioResult `json:"results"`
+}
+
+type benchmarkReport struct {
+	GeneratedAt string           `json:"generated_at"`
+	Runs        int              `json:"runs"`
+	Machine     machineInfo      `json:"machine"`
+	Fixture     fixtureSummary   `json:"fixture"`
+	Backends    []backendInfo    `json:"backends"`
+	Scenarios   []scenarioReport `json:"scenarios"`
+}
+
+type benchmarkFixture struct {
+	Files          gbfs.InitialFiles
+	Summary        fixtureSummary
+	DirectoryCount int
+	BulkReadPaths  []string
+	BulkReadBytes  int64
+	SearchLiteral  string
+	SearchHitCount int
+	RenameSource   string
+	RenameTarget   string
+	RenameBody     string
+	RewriteTarget  string
+	RewriteBody    string
+	RemoveTarget   string
+	CreateTarget   string
+	CreateBody     string
+}
+
+type benchmarkEnv struct {
+	tmpRoot          string
+	fixture          benchmarkFixture
+	hostFixtureRoot  string
+	sqliteTemplateDB string
+}
+
+type workloadObservation struct {
+	SearchMode string
+}
+
+type workloadConfig struct {
+	Name        string
+	Description string
+	Run         func(context.Context, gbfs.FileSystem, *benchmarkFixture) (workloadObservation, error)
+}
+
+type backendConfig struct {
+	Info              backendInfo
+	ExpectIndexedMode bool
+	Prepare           func(context.Context, *benchmarkEnv) (gbfs.Factory, func() error, error)
+}
+
+func main() {
+	if err := runMain(context.Background(), os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "bench-fs: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runMain(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	opts, err := parseOptions(args)
+	if err != nil {
+		return err
+	}
+
+	tmpRoot, err := os.MkdirTemp("", "gbash-bench-fs-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpRoot); err != nil {
+			_, _ = fmt.Fprintf(stderr, "bench-fs: remove temp dir: %v\n", err)
+		}
+	}()
+
+	env, err := prepareBenchmarkEnv(ctx, tmpRoot)
+	if err != nil {
+		return err
+	}
+	backends := benchmarkBackends()
+	scenarios := benchmarkScenarios()
+
+	report := benchmarkReport{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Runs:        opts.Runs,
+		Machine:     collectMachineInfo(ctx),
+		Fixture:     env.fixture.Summary,
+	}
+	for _, backend := range backends {
+		report.Backends = append(report.Backends, backend.Info)
+	}
+	for _, scenario := range scenarios {
+		scenarioReport := scenarioReport{
+			Name:        scenario.Name,
+			Description: scenario.Description,
+		}
+		for _, backend := range backends {
+			result, err := runScenarioTrials(ctx, backend, scenario, env, opts.Runs)
+			if err != nil {
+				return fmt.Errorf("%s/%s: %w", scenario.Name, backend.Info.Name, err)
+			}
+			scenarioReport.Results = append(scenarioReport.Results, result)
+		}
+		report.Scenarios = append(report.Scenarios, scenarioReport)
+	}
+
+	if _, err := io.WriteString(stdout, renderTextReport(&report)); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	if opts.JSONOut != "" {
+		if err := writeJSONReport(opts.JSONOut, &report); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(stderr, "wrote JSON report to %s\n", opts.JSONOut)
+	}
+	return nil
+}
+
+func parseOptions(args []string) (options, error) {
+	var opts options
+	fs := flag.NewFlagSet("bench-fs", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.IntVar(&opts.Runs, "runs", defaultRuns, "number of timed trials per backend and scenario")
+	fs.StringVar(&opts.JSONOut, "json-out", "", "optional path to write a JSON report")
+	if err := fs.Parse(args); err != nil {
+		return options{}, err
+	}
+	if fs.NArg() != 0 {
+		return options{}, fmt.Errorf("unexpected arguments: %v", fs.Args())
+	}
+	if opts.Runs <= 0 {
+		return options{}, fmt.Errorf("--runs must be greater than zero")
+	}
+	opts.JSONOut = strings.TrimSpace(opts.JSONOut)
+	return opts, nil
+}
+
+func prepareBenchmarkEnv(ctx context.Context, tmpRoot string) (*benchmarkEnv, error) {
+	fixture := buildBenchmarkFixture()
+
+	hostFixtureRoot := filepath.Join(tmpRoot, "host-fixture")
+	if err := materializeHostFixture(hostFixtureRoot, fixture.Files); err != nil {
+		return nil, fmt.Errorf("materialize host fixture: %w", err)
+	}
+
+	sqliteTemplateDB := filepath.Join(tmpRoot, "sqlite-template.db")
+	if err := sqlitefs.SeedTemplate(ctx, sqliteTemplateDB, fixture.Files); err != nil {
+		return nil, fmt.Errorf("seed sqlite template: %w", err)
+	}
+
+	return &benchmarkEnv{
+		tmpRoot:          tmpRoot,
+		fixture:          fixture,
+		hostFixtureRoot:  hostFixtureRoot,
+		sqliteTemplateDB: sqliteTemplateDB,
+	}, nil
+}
+
+func benchmarkBackends() []backendConfig {
+	seededFactory := gbfs.SeededMemory(buildBenchmarkFixture().Files)
+	return []backendConfig{
+		{
+			Info: backendInfo{
+				Name:        "memory",
+				Label:       "memory",
+				Description: "Core in-memory sandbox filesystem seeded with the benchmark fixture.",
+			},
+			Prepare: func(context.Context, *benchmarkEnv) (gbfs.Factory, func() error, error) {
+				return seededFactory, noopCleanup, nil
+			},
+		},
+		{
+			Info: backendInfo{
+				Name:        "overlay",
+				Label:       "overlay",
+				Description: "Core read-only host workspace with an in-memory writable upper layer.",
+			},
+			Prepare: func(_ context.Context, env *benchmarkEnv) (gbfs.Factory, func() error, error) {
+				return gbfs.Overlay(gbfs.Host(gbfs.HostOptions{
+					Root:        env.hostFixtureRoot,
+					VirtualRoot: virtualWorkspace,
+				})), noopCleanup, nil
+			},
+		},
+		{
+			Info: backendInfo{
+				Name:         "sqlite",
+				Label:        "sqlite",
+				Description:  "Experimental SQLite-backed example filesystem using a host database file.",
+				Experimental: true,
+			},
+			Prepare: func(ctx context.Context, env *benchmarkEnv) (gbfs.Factory, func() error, error) {
+				dbPath, err := cloneSQLiteTemplate(ctx, env.tmpRoot, env.sqliteTemplateDB)
+				if err != nil {
+					return nil, nil, err
+				}
+				return sqlitefs.Factory{DBPath: dbPath}, func() error { return os.Remove(dbPath) }, nil
+			},
+		},
+		{
+			Info: backendInfo{
+				Name:         "fts",
+				Label:        "fts",
+				Description:  "Experimental full-text-search example filesystem over seeded in-memory data.",
+				Experimental: true,
+			},
+			ExpectIndexedMode: true,
+			Prepare: func(context.Context, *benchmarkEnv) (gbfs.Factory, func() error, error) {
+				return ftsfs.NewFactory(seededFactory), noopCleanup, nil
+			},
+		},
+	}
+}
+
+func benchmarkScenarios() []workloadConfig {
+	return []workloadConfig{
+		{
+			Name:        "metadata_walk",
+			Description: "Recursive ReadDir and Lstat traversal across the canonical /workspace fixture.",
+			Run:         runMetadataWalk,
+		},
+		{
+			Name:        "bulk_read",
+			Description: "Open and read the full fixture workload, verifying total bytes.",
+			Run:         runBulkRead,
+		},
+		{
+			Name:        "mutation_roundtrip",
+			Description: "Create, overwrite, rename, and remove files inside /workspace with verification.",
+			Run:         runMutationRoundTrip,
+		},
+		{
+			Name:        "literal_search",
+			Description: "Indexed-or-scan literal search over /workspace using the full-text example path when available.",
+			Run:         runLiteralSearch,
+		},
+	}
+}
+
+func runScenarioTrials(ctx context.Context, backend backendConfig, scenario workloadConfig, env *benchmarkEnv, runs int) (scenarioResult, error) {
+	durations := make([]time.Duration, 0, runs)
+	searchMode := ""
+
+	for range runs {
+		factory, cleanup, err := backend.Prepare(ctx, env)
+		if err != nil {
+			return scenarioResult{}, err
+		}
+		if cleanup == nil {
+			cleanup = noopCleanup
+		}
+
+		start := time.Now()
+		fsys, err := factory.New(ctx)
+		if err != nil {
+			_ = cleanup()
+			return scenarioResult{}, err
+		}
+		observation, runErr := scenario.Run(ctx, fsys, &env.fixture)
+		duration := time.Since(start)
+		closeErr := closeIfPossible(fsys)
+		cleanupErr := cleanup()
+
+		if runErr != nil {
+			return scenarioResult{}, runErr
+		}
+		if closeErr != nil {
+			return scenarioResult{}, closeErr
+		}
+		if cleanupErr != nil {
+			return scenarioResult{}, cleanupErr
+		}
+
+		if observation.SearchMode != "" {
+			if observation.SearchMode == "index" && !backend.ExpectIndexedMode {
+				return scenarioResult{}, fmt.Errorf("unexpected indexed search mode")
+			}
+			if observation.SearchMode == "scan" && backend.ExpectIndexedMode {
+				return scenarioResult{}, fmt.Errorf("expected indexed search mode")
+			}
+			if searchMode == "" {
+				searchMode = observation.SearchMode
+			} else if searchMode != observation.SearchMode {
+				return scenarioResult{}, fmt.Errorf("search mode changed across trials: %q vs %q", searchMode, observation.SearchMode)
+			}
+		}
+
+		durations = append(durations, duration)
+	}
+
+	stats, ok := summarizeDurations(durations)
+	if !ok {
+		return scenarioResult{}, fmt.Errorf("no durations recorded")
+	}
+	return scenarioResult{
+		Backend:      backend.Info.Name,
+		SuccessCount: runs,
+		FailureCount: 0,
+		SearchMode:   searchMode,
+		Stats:        stats,
+	}, nil
+}
+
+func buildBenchmarkFixture() benchmarkFixture {
+	const (
+		sourceFiles = 180
+		docsFiles   = 24
+		reportFiles = 12
+		logFiles    = 24
+		noteFiles   = 12
+	)
+
+	files := make(gbfs.InitialFiles, sourceFiles+docsFiles+reportFiles+logFiles+noteFiles)
+	dirs := map[string]struct{}{virtualWorkspace: {}}
+	summary := fixtureSummary{}
+	modTime := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	searchHitCount := 0
+
+	addFile := func(name, body string) {
+		files[name] = gbfs.InitialFile{
+			Content: []byte(body),
+			Mode:    0o644,
+			ModTime: modTime,
+		}
+		summary.FileCount++
+		summary.TotalBytes += int64(len(body))
+		for dir := path.Dir(name); dir != "/" && dir != "."; dir = path.Dir(dir) {
+			dirs[dir] = struct{}{}
+			if dir == virtualWorkspace {
+				break
+			}
+		}
+	}
+
+	for i := range sourceFiles {
+		var body strings.Builder
+		fmt.Fprintf(&body, "package pkg%02d\n\n", i%12)
+		if i < 36 {
+			fmt.Fprintf(&body, "// %s source-%03d\n", searchLiteral, i)
+			searchHitCount++
+		}
+		for line := range 14 {
+			fmt.Fprintf(&body, "func File%03dLine%02d() string { return \"benchmark-%03d-%02d\" }\n", i, line, i, line)
+		}
+		addFile(fmt.Sprintf("/workspace/src/pkg%02d/file%03d.go", i%12, i), body.String())
+	}
+
+	for i := range docsFiles {
+		body := fmt.Sprintf("# Runbook %02d\nowner=team-%02d\nnote=follow-up-%02d\n", i, i%6, i)
+		if i < 12 {
+			body += fmt.Sprintf("search=%s-doc-%02d\n", searchLiteral, i)
+			searchHitCount++
+		}
+		body += strings.Repeat("stability-check\n", 10)
+		addFile(fmt.Sprintf("/workspace/docs/runbook%02d.md", i), body)
+	}
+
+	for i := range reportFiles {
+		var body strings.Builder
+		body.WriteString("service,owner,tier,score\n")
+		for row := range 10 {
+			fmt.Fprintf(&body, "svc-%02d,team-%02d,%d,%d\n", i*10+row, (i+row)%4, 1+(row%3), 80+row)
+		}
+		addFile(fmt.Sprintf("/workspace/reports/summary%02d.csv", i), body.String())
+	}
+
+	for i := range logFiles {
+		var body strings.Builder
+		for row := range 30 {
+			fmt.Fprintf(&body, "ts=%02d:%02d level=info batch=%02d row=%02d message=steady-state\n", i, row, i, row)
+		}
+		if i < 12 {
+			fmt.Fprintf(&body, "level=warn marker=%s-log-%02d\n", searchLiteral, i)
+			searchHitCount++
+		}
+		addFile(fmt.Sprintf("/workspace/logs/batch%02d.log", i), body.String())
+	}
+
+	for i := range noteFiles {
+		body := fmt.Sprintf("note-%02d\n%s\n", i, strings.Repeat("analysis ", 30))
+		addFile(fmt.Sprintf("/workspace/notes/topic%02d.txt", i), body)
+	}
+
+	bulkReadPaths := make([]string, 0, len(files))
+	for name := range files {
+		bulkReadPaths = append(bulkReadPaths, name)
+	}
+	slices.Sort(bulkReadPaths)
+
+	return benchmarkFixture{
+		Files:          files,
+		Summary:        summary,
+		DirectoryCount: len(dirs),
+		BulkReadPaths:  bulkReadPaths,
+		BulkReadBytes:  summary.TotalBytes,
+		SearchLiteral:  searchLiteral,
+		SearchHitCount: searchHitCount,
+		RenameSource:   mutationRenameSrc,
+		RenameTarget:   mutationRenameDst,
+		RenameBody:     string(files[mutationRenameSrc].Content),
+		RewriteTarget:  mutationRewritePath,
+		RewriteBody:    mutationRewriteBody,
+		RemoveTarget:   mutationRemovePath,
+		CreateTarget:   mutationCreatePath,
+		CreateBody:     mutationCreateBody,
+	}
+}
+
+func materializeHostFixture(root string, files gbfs.InitialFiles) error {
+	for name, initial := range files {
+		rel := strings.TrimPrefix(name, virtualWorkspace)
+		if rel == "" || rel == name {
+			return fmt.Errorf("fixture path %q is outside %s", name, virtualWorkspace)
+		}
+		target := filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(rel, "/")))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		mode := initial.Mode.Perm()
+		if mode == 0 {
+			mode = 0o644
+		}
+		if err := os.WriteFile(target, initial.Content, mode); err != nil {
+			return err
+		}
+		if !initial.ModTime.IsZero() {
+			if err := os.Chtimes(target, initial.ModTime, initial.ModTime); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func cloneSQLiteTemplate(ctx context.Context, tmpRoot, templatePath string) (string, error) {
+	file, err := os.CreateTemp(tmpRoot, "sqlite-bench-*.db")
+	if err != nil {
+		return "", err
+	}
+	dbPath := file.Name()
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	if err := copyFile(dbPath, templatePath); err != nil {
+		return "", err
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return dbPath, nil
+}
+
+func runMetadataWalk(ctx context.Context, fsys gbfs.FileSystem, fixture *benchmarkFixture) (workloadObservation, error) {
+	files, dirs, totalBytes, err := walkWorkspace(ctx, fsys, virtualWorkspace)
+	if err != nil {
+		return workloadObservation{}, err
+	}
+	if files != fixture.Summary.FileCount {
+		return workloadObservation{}, fmt.Errorf("walk file count = %d, want %d", files, fixture.Summary.FileCount)
+	}
+	if dirs != fixture.DirectoryCount {
+		return workloadObservation{}, fmt.Errorf("walk dir count = %d, want %d", dirs, fixture.DirectoryCount)
+	}
+	if totalBytes != fixture.Summary.TotalBytes {
+		return workloadObservation{}, fmt.Errorf("walk bytes = %d, want %d", totalBytes, fixture.Summary.TotalBytes)
+	}
+	return workloadObservation{}, nil
+}
+
+func runBulkRead(ctx context.Context, fsys gbfs.FileSystem, fixture *benchmarkFixture) (workloadObservation, error) {
+	var total int64
+	for _, name := range fixture.BulkReadPaths {
+		data, err := readSandboxFile(ctx, fsys, name)
+		if err != nil {
+			return workloadObservation{}, err
+		}
+		total += int64(len(data))
+	}
+	if total != fixture.BulkReadBytes {
+		return workloadObservation{}, fmt.Errorf("bulk read bytes = %d, want %d", total, fixture.BulkReadBytes)
+	}
+	return workloadObservation{}, nil
+}
+
+func runMutationRoundTrip(ctx context.Context, fsys gbfs.FileSystem, fixture *benchmarkFixture) (workloadObservation, error) {
+	if err := writeSandboxFile(ctx, fsys, fixture.CreateTarget, fixture.CreateBody); err != nil {
+		return workloadObservation{}, err
+	}
+	if err := writeSandboxFile(ctx, fsys, fixture.RewriteTarget, fixture.RewriteBody); err != nil {
+		return workloadObservation{}, err
+	}
+	if err := fsys.Rename(ctx, fixture.RenameSource, fixture.RenameTarget); err != nil {
+		return workloadObservation{}, err
+	}
+	if err := fsys.Remove(ctx, fixture.RemoveTarget, false); err != nil {
+		return workloadObservation{}, err
+	}
+
+	if got, err := readSandboxText(ctx, fsys, fixture.CreateTarget); err != nil || got != fixture.CreateBody {
+		if err != nil {
+			return workloadObservation{}, err
+		}
+		return workloadObservation{}, fmt.Errorf("created file = %q, want %q", got, fixture.CreateBody)
+	}
+	if got, err := readSandboxText(ctx, fsys, fixture.RewriteTarget); err != nil || got != fixture.RewriteBody {
+		if err != nil {
+			return workloadObservation{}, err
+		}
+		return workloadObservation{}, fmt.Errorf("rewritten file = %q, want %q", got, fixture.RewriteBody)
+	}
+	if _, err := fsys.Stat(ctx, fixture.RenameSource); !isNotExist(err) {
+		return workloadObservation{}, fmt.Errorf("stat old rename path error = %v, want not exist", err)
+	}
+	if got, err := readSandboxText(ctx, fsys, fixture.RenameTarget); err != nil || got != fixture.RenameBody {
+		if err != nil {
+			return workloadObservation{}, err
+		}
+		return workloadObservation{}, fmt.Errorf("renamed file = %q, want original body", got)
+	}
+	if _, err := fsys.Stat(ctx, fixture.RemoveTarget); !isNotExist(err) {
+		return workloadObservation{}, fmt.Errorf("stat removed file error = %v, want not exist", err)
+	}
+
+	files, _, _, err := walkWorkspace(ctx, fsys, virtualWorkspace)
+	if err != nil {
+		return workloadObservation{}, err
+	}
+	if files != fixture.Summary.FileCount {
+		return workloadObservation{}, fmt.Errorf("post-mutation file count = %d, want %d", files, fixture.Summary.FileCount)
+	}
+	return workloadObservation{}, nil
+}
+
+func runLiteralSearch(ctx context.Context, fsys gbfs.FileSystem, fixture *benchmarkFixture) (workloadObservation, error) {
+	result, err := searchadapter.Search(ctx, fsys, &searchadapter.Query{
+		Roots:         []string{virtualWorkspace},
+		Literal:       fixture.SearchLiteral,
+		IndexEligible: true,
+	}, nil)
+	if err != nil {
+		return workloadObservation{}, err
+	}
+	if len(result.Hits) != fixture.SearchHitCount {
+		return workloadObservation{}, fmt.Errorf("search hit count = %d, want %d", len(result.Hits), fixture.SearchHitCount)
+	}
+	mode := "scan"
+	if result.UsedIndex {
+		mode = "index"
+	}
+	return workloadObservation{SearchMode: mode}, nil
+}
+
+func walkWorkspace(ctx context.Context, fsys gbfs.FileSystem, root string) (files, dirs int, totalBytes int64, err error) {
+	var walk func(string) error
+	walk = func(current string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		info, err := fsys.Lstat(ctx, current)
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			dirs++
+			entries, err := fsys.ReadDir(ctx, current)
+			if err != nil {
+				return err
+			}
+			for _, entry := range entries {
+				if err := walk(path.Join(current, entry.Name())); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		files++
+		totalBytes += info.Size()
+		return nil
+	}
+	if err := walk(root); err != nil {
+		return 0, 0, 0, err
+	}
+	return files, dirs, totalBytes, nil
+}
+
+func writeSandboxFile(ctx context.Context, fsys gbfs.FileSystem, name, body string) error {
+	if err := fsys.MkdirAll(ctx, path.Dir(name), 0o755); err != nil {
+		return err
+	}
+	file, err := fsys.OpenFile(ctx, name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.WriteString(file, body); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+func readSandboxFile(ctx context.Context, fsys gbfs.FileSystem, name string) ([]byte, error) {
+	file, err := fsys.Open(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	return io.ReadAll(file)
+}
+
+func readSandboxText(ctx context.Context, fsys gbfs.FileSystem, name string) (string, error) {
+	data, err := readSandboxFile(ctx, fsys, name)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func isNotExist(err error) bool {
+	return err != nil && os.IsNotExist(err)
+}
+
+func closeIfPossible(fsys gbfs.FileSystem) error {
+	type closer interface {
+		Close() error
+	}
+	c, ok := fsys.(closer)
+	if !ok {
+		return nil
+	}
+	return c.Close()
+}
+
+func summarizeDurations(durations []time.Duration) (latencyStats, bool) {
+	if len(durations) == 0 {
+		return latencyStats{}, false
+	}
+
+	values := make([]time.Duration, len(durations))
+	copy(values, durations)
+	slices.Sort(values)
+
+	stats := latencyStats{
+		MinNanos: values[0].Nanoseconds(),
+		P95Nanos: values[percentileIndex(len(values), 0.95)].Nanoseconds(),
+	}
+	mid := len(values) / 2
+	if len(values)%2 == 0 {
+		stats.MedianNanos = (values[mid-1] + values[mid]).Nanoseconds() / 2
+	} else {
+		stats.MedianNanos = values[mid].Nanoseconds()
+	}
+	return stats, true
+}
+
+func percentileIndex(length int, percentile float64) int {
+	if length <= 1 {
+		return 0
+	}
+	index := int(math.Ceil(percentile*float64(length))) - 1
+	if index < 0 {
+		return 0
+	}
+	if index >= length {
+		return length - 1
+	}
+	return index
+}
+
+func renderTextReport(report *benchmarkReport) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Filesystem backend benchmark\n")
+	fmt.Fprintf(&b, "Generated: %s\n", report.GeneratedAt)
+	fmt.Fprintf(&b, "Runs per scenario: %d\n", report.Runs)
+	fmt.Fprintf(&b, "Fixture: %d files, %s\n", report.Fixture.FileCount, formatBytes(report.Fixture.TotalBytes))
+	for _, scenario := range report.Scenarios {
+		fmt.Fprintf(&b, "\n[%s]\n", scenario.Name)
+		fmt.Fprintf(&b, "%s\n", scenario.Description)
+		for _, result := range scenario.Results {
+			fmt.Fprintf(
+				&b,
+				"  %-8s min=%-8s median=%-8s p95=%-8s",
+				result.Backend,
+				formatNanos(result.Stats.MinNanos),
+				formatNanos(result.Stats.MedianNanos),
+				formatNanos(result.Stats.P95Nanos),
+			)
+			if result.SearchMode != "" {
+				fmt.Fprintf(&b, " search=%s", result.SearchMode)
+			}
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func formatNanos(nanos int64) string {
+	switch {
+	case nanos >= 1_000_000_000:
+		return fmt.Sprintf("%.2fs", float64(nanos)/1_000_000_000)
+	case nanos >= 1_000_000:
+		return fmt.Sprintf("%.1fms", float64(nanos)/1_000_000)
+	case nanos >= 1_000:
+		return fmt.Sprintf("%.1fµs", float64(nanos)/1_000)
+	default:
+		return fmt.Sprintf("%dns", nanos)
+	}
+}
+
+func formatBytes(bytes int64) string {
+	switch {
+	case bytes >= 1024*1024*1024:
+		return fmt.Sprintf("%.1f GiB", float64(bytes)/(1024*1024*1024))
+	case bytes >= 1024*1024:
+		return fmt.Sprintf("%.1f MiB", float64(bytes)/(1024*1024))
+	case bytes >= 1024:
+		return fmt.Sprintf("%.1f KiB", float64(bytes)/1024)
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}
+
+func writeJSONReport(target string, report *benchmarkReport) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal json report: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("create json dir: %w", err)
+	}
+	if err := os.WriteFile(target, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write json report: %w", err)
+	}
+	return nil
+}
+
+func collectMachineInfo(ctx context.Context) machineInfo {
+	info := machineInfo{
+		Model:     "Unknown",
+		Chip:      "Unknown",
+		Cores:     strconv.Itoa(goruntime.NumCPU()),
+		Memory:    "Unknown",
+		OS:        fmt.Sprintf("%s/%s", goruntime.GOOS, goruntime.GOARCH),
+		GoVersion: fmt.Sprintf("%s %s/%s", goruntime.Version(), goruntime.GOOS, goruntime.GOARCH),
+	}
+
+	if goruntime.GOOS == "darwin" {
+		if model := strings.TrimSpace(runCommand(ctx, "sysctl", "-n", "hw.model")); model != "" {
+			info.Model = model
+		}
+		if chip := strings.TrimSpace(runCommand(ctx, "sysctl", "-n", "machdep.cpu.brand_string")); chip != "" {
+			info.Chip = chip
+		}
+		if perf := parseInt(runCommand(ctx, "sysctl", "-n", "hw.perflevel0.physicalcpu")); perf > 0 {
+			eff := parseInt(runCommand(ctx, "sysctl", "-n", "hw.perflevel1.physicalcpu"))
+			total := perf + eff
+			info.Cores = fmt.Sprintf("%d (%d performance + %d efficiency)", total, perf, eff)
+		}
+		if memBytes := parseInt64(runCommand(ctx, "sysctl", "-n", "hw.memsize")); memBytes > 0 {
+			info.Memory = fmt.Sprintf("%d GB", memBytes/(1024*1024*1024))
+		}
+		productName := strings.TrimSpace(runCommand(ctx, "sw_vers", "-productName"))
+		productVersion := strings.TrimSpace(runCommand(ctx, "sw_vers", "-productVersion"))
+		if productName != "" || productVersion != "" {
+			info.OS = strings.TrimSpace(productName + " " + productVersion)
+		}
+	}
+
+	return info
+}
+
+func runCommand(ctx context.Context, name string, args ...string) string {
+	cmd := exec.CommandContext(ctx, name, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return string(output)
+}
+
+func parseInt(value string) int {
+	n, _ := strconv.Atoi(strings.TrimSpace(value))
+	return n
+}
+
+func parseInt64(value string) int64 {
+	n, _ := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	return n
+}
+
+func copyFile(dst, src string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func noopCleanup() error { return nil }

--- a/examples/bench-fs/main_test.go
+++ b/examples/bench-fs/main_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gbfs "github.com/ewhauser/gbash/fs"
+)
+
+func TestBuildBenchmarkFixture(t *testing.T) {
+	fixture := buildBenchmarkFixture()
+
+	if fixture.Summary.FileCount == 0 {
+		t.Fatal("fixture file count = 0, want non-zero")
+	}
+	if fixture.Summary.TotalBytes == 0 {
+		t.Fatal("fixture total bytes = 0, want non-zero")
+	}
+	if fixture.SearchHitCount == 0 {
+		t.Fatal("fixture search hit count = 0, want non-zero")
+	}
+	if _, ok := fixture.Files[fixture.RenameSource]; !ok {
+		t.Fatalf("fixture missing rename source %q", fixture.RenameSource)
+	}
+	if _, ok := fixture.Files[fixture.RewriteTarget]; !ok {
+		t.Fatalf("fixture missing rewrite target %q", fixture.RewriteTarget)
+	}
+	if _, ok := fixture.Files[fixture.RemoveTarget]; !ok {
+		t.Fatalf("fixture missing remove target %q", fixture.RemoveTarget)
+	}
+}
+
+func TestPrepareBenchmarkEnvSeedsSQLiteTemplate(t *testing.T) {
+	env, err := prepareBenchmarkEnv(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("prepareBenchmarkEnv() error = %v", err)
+	}
+
+	factory, cleanup, err := benchmarkBackends()[2].Prepare(context.Background(), env)
+	if err != nil {
+		t.Fatalf("sqlite Prepare() error = %v", err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			t.Fatalf("cleanup() error = %v", err)
+		}
+	}()
+
+	fsys, err := factory.New(context.Background())
+	if err != nil {
+		t.Fatalf("factory.New() error = %v", err)
+	}
+	defer func() {
+		if err := closeIfPossible(fsys); err != nil {
+			t.Fatalf("closeIfPossible() error = %v", err)
+		}
+	}()
+
+	got, err := readSandboxText(context.Background(), fsys, mutationRewritePath)
+	if err != nil {
+		t.Fatalf("readSandboxText() error = %v", err)
+	}
+	want := string(env.fixture.Files[mutationRewritePath].Content)
+	if got != want {
+		t.Fatalf("template read = %q, want %q", got, want)
+	}
+}
+
+func TestWorkloadsPassOnMemoryBackend(t *testing.T) {
+	fixture := buildBenchmarkFixture()
+	factory := gbfs.SeededMemory(fixture.Files)
+
+	for _, scenario := range benchmarkScenarios() {
+		fsys, err := factory.New(context.Background())
+		if err != nil {
+			t.Fatalf("factory.New() error = %v", err)
+		}
+		observation, err := scenario.Run(context.Background(), fsys, &fixture)
+		if err != nil {
+			t.Fatalf("%s Run() error = %v", scenario.Name, err)
+		}
+		if scenario.Name == "literal_search" && observation.SearchMode != "scan" {
+			t.Fatalf("%s SearchMode = %q, want scan", scenario.Name, observation.SearchMode)
+		}
+	}
+}
+
+func TestFTSUsesIndexedSearch(t *testing.T) {
+	fixture := buildBenchmarkFixture()
+	factory, cleanup, err := benchmarkBackends()[3].Prepare(context.Background(), &benchmarkEnv{fixture: fixture})
+	if err != nil {
+		t.Fatalf("fts Prepare() error = %v", err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			t.Fatalf("cleanup() error = %v", err)
+		}
+	}()
+
+	fsys, err := factory.New(context.Background())
+	if err != nil {
+		t.Fatalf("factory.New() error = %v", err)
+	}
+	observation, err := runLiteralSearch(context.Background(), fsys, &fixture)
+	if err != nil {
+		t.Fatalf("runLiteralSearch() error = %v", err)
+	}
+	if observation.SearchMode != "index" {
+		t.Fatalf("SearchMode = %q, want index", observation.SearchMode)
+	}
+}
+
+func TestRunMainWritesJSONReport(t *testing.T) {
+	jsonPath := filepath.Join(t.TempDir(), "filesystem-bench.json")
+	if err := runMain(context.Background(), []string{"--runs", "1", "--json-out", jsonPath}, io.Discard, io.Discard); err != nil {
+		t.Fatalf("runMain() error = %v", err)
+	}
+
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", jsonPath, err)
+	}
+	var report benchmarkReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if len(report.Backends) != 4 {
+		t.Fatalf("backend count = %d, want 4", len(report.Backends))
+	}
+	if len(report.Scenarios) != 4 {
+		t.Fatalf("scenario count = %d, want 4", len(report.Scenarios))
+	}
+}

--- a/examples/internal/ftsfs/ftsfs.go
+++ b/examples/internal/ftsfs/ftsfs.go
@@ -1,0 +1,10 @@
+package ftsfs
+
+import gbfs "github.com/ewhauser/gbash/fs"
+
+// NewFactory returns the searchable/full-text example's filesystem shape.
+//
+// When base is nil, it defaults to an in-memory filesystem.
+func NewFactory(base gbfs.Factory) gbfs.Factory {
+	return gbfs.NewSearchableFactory(base, nil)
+}

--- a/examples/internal/ftsfs/ftsfs_test.go
+++ b/examples/internal/ftsfs/ftsfs_test.go
@@ -1,0 +1,73 @@
+package ftsfs
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	gbfs "github.com/ewhauser/gbash/fs"
+	"github.com/ewhauser/gbash/internal/searchadapter"
+)
+
+func TestNewFactoryProvidesIndexedSearch(t *testing.T) {
+	factory := NewFactory(gbfs.SeededMemory(gbfs.InitialFiles{
+		"/workspace/docs/readme.txt": {Content: []byte("guide needle\n")},
+		"/workspace/logs/app.log":    {Content: []byte("log needle\n")},
+		"/workspace/notes/todo.txt":  {Content: []byte("nothing here\n")},
+	}))
+
+	fsys, err := factory.New(context.Background())
+	if err != nil {
+		t.Fatalf("factory.New() error = %v", err)
+	}
+	capable, ok := fsys.(gbfs.SearchCapable)
+	if !ok {
+		t.Fatalf("filesystem %T does not implement SearchCapable", fsys)
+	}
+	provider, ok := capable.SearchProviderForPath("/workspace")
+	if !ok {
+		t.Fatal("SearchProviderForPath(/workspace) = false, want true")
+	}
+	result, err := provider.Search(context.Background(), &gbfs.SearchQuery{
+		Root:        "/workspace",
+		Literal:     "needle",
+		WantOffsets: true,
+	})
+	if err != nil {
+		t.Fatalf("provider.Search() error = %v", err)
+	}
+	if len(result.Hits) != 2 {
+		t.Fatalf("provider.Search() hit count = %d, want 2", len(result.Hits))
+	}
+
+	adapted, err := searchadapter.Search(context.Background(), fsys, &searchadapter.Query{
+		Roots:         []string{"/workspace"},
+		Literal:       "needle",
+		IndexEligible: true,
+	}, func(ctx context.Context, hit gbfs.SearchHit) (bool, error) {
+		data, err := readFile(ctx, fsys, hit.Path)
+		if err != nil {
+			return false, err
+		}
+		return bytes.Contains(data, []byte("needle")), nil
+	})
+	if err != nil {
+		t.Fatalf("searchadapter.Search() error = %v", err)
+	}
+	if !adapted.UsedIndex {
+		t.Fatal("searchadapter.Search() UsedIndex = false, want true")
+	}
+	if len(adapted.Hits) != 2 {
+		t.Fatalf("searchadapter.Search() hit count = %d, want 2", len(adapted.Hits))
+	}
+}
+
+func readFile(ctx context.Context, fsys gbfs.FileSystem, name string) ([]byte, error) {
+	file, err := fsys.Open(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	return io.ReadAll(file)
+}

--- a/examples/internal/sqlitefs/helpers.go
+++ b/examples/internal/sqlitefs/helpers.go
@@ -1,0 +1,68 @@
+package sqlitefs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+
+	gbfs "github.com/ewhauser/gbash/fs"
+)
+
+// SeedTemplate initializes dbPath with the provided initial files so benchmark
+// runs can copy a single prepared SQLite database outside the timed region.
+func SeedTemplate(ctx context.Context, dbPath string, files gbfs.InitialFiles) error {
+	fsys, err := newSQLiteFS(ctx, dbPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = fsys.close() }()
+
+	for name, initial := range files {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		parent := path.Dir(name)
+		if err := fsys.MkdirAll(ctx, parent, 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", parent, err)
+		}
+
+		contents := initial.Content
+		if initial.Lazy != nil {
+			loaded, err := initial.Lazy(ctx)
+			if err != nil {
+				return fmt.Errorf("load %s: %w", name, err)
+			}
+			contents = loaded
+		}
+
+		mode := initial.Mode.Perm()
+		if mode == 0 {
+			mode = 0o644
+		}
+		file, err := fsys.OpenFile(ctx, name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+		if err != nil {
+			return fmt.Errorf("open %s: %w", name, err)
+		}
+		if len(contents) > 0 {
+			if _, err := file.Write(contents); err != nil {
+				_ = file.Close()
+				return fmt.Errorf("write %s: %w", name, err)
+			}
+		}
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", name, err)
+		}
+		if initial.Mode != 0 {
+			if err := fsys.Chmod(ctx, name, initial.Mode.Perm()); err != nil {
+				return fmt.Errorf("chmod %s: %w", name, err)
+			}
+		}
+		if !initial.ModTime.IsZero() {
+			if err := fsys.Chtimes(ctx, name, initial.ModTime, initial.ModTime); err != nil {
+				return fmt.Errorf("chtimes %s: %w", name, err)
+			}
+		}
+	}
+	return nil
+}

--- a/examples/internal/sqlitefs/sqlitefs.go
+++ b/examples/internal/sqlitefs/sqlitefs.go
@@ -1,4 +1,4 @@
-package main
+package sqlitefs
 
 import (
 	"context"
@@ -24,12 +24,12 @@ const (
 
 var errTooManySymlinks = errors.New("too many levels of symbolic links")
 
-type sqliteFSFactory struct {
-	dbPath string
+type Factory struct {
+	DBPath string
 }
 
-func (f sqliteFSFactory) New(ctx context.Context) (gbfs.FileSystem, error) {
-	return newSQLiteFS(ctx, f.dbPath)
+func (f Factory) New(ctx context.Context) (gbfs.FileSystem, error) {
+	return newSQLiteFS(ctx, f.DBPath)
 }
 
 type sqliteFS struct {
@@ -143,6 +143,10 @@ func (s *sqliteFS) close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.conn.Close()
+}
+
+func (s *sqliteFS) Close() error {
+	return s.close()
 }
 
 func (s *sqliteFS) Open(ctx context.Context, name string) (gbfs.File, error) {
@@ -1230,7 +1234,7 @@ func canWrite(flag int) bool {
 	}
 }
 
-var _ gbfs.Factory = sqliteFSFactory{}
+var _ gbfs.Factory = Factory{}
 var _ gbfs.FileSystem = (*sqliteFS)(nil)
 var _ gbfs.File = (*sqliteFile)(nil)
 var _ stdfs.FileInfo = sqliteFileInfo{}

--- a/examples/internal/sqlitefs/sqlitefs_test.go
+++ b/examples/internal/sqlitefs/sqlitefs_test.go
@@ -1,7 +1,6 @@
-package main
+package sqlitefs
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -271,191 +270,6 @@ func TestSQLiteBackedRuntimePersistsAcrossRuns(t *testing.T) {
 	}
 }
 
-func TestRunRequiresDB(t *testing.T) {
-	_, err := run(context.Background(), strings.NewReader(""), io.Discard, io.Discard, nil)
-	if err == nil {
-		t.Fatal("run() error = nil, want required db error")
-	}
-	if !strings.Contains(err.Error(), "--db is required") {
-		t.Fatalf("run() error = %v, want db requirement", err)
-	}
-}
-
-func TestRunUsesScriptFlagAndStdin(t *testing.T) {
-	t.Run("script flag", func(t *testing.T) {
-		dbPath := filepath.Join(t.TempDir(), "flag.db")
-		var stdout bytes.Buffer
-		var stderr bytes.Buffer
-
-		exitCode, err := run(context.Background(), strings.NewReader("ignored\n"), &stdout, &stderr, []string{
-			"--db", dbPath,
-			"--script", "printf 'flag\\n'\n",
-		})
-		if err != nil {
-			t.Fatalf("run() error = %v", err)
-		}
-		if exitCode != 0 {
-			t.Fatalf("exitCode = %d, want 0; stderr=%q", exitCode, stderr.String())
-		}
-		if got, want := stdout.String(), "flag\n"; got != want {
-			t.Fatalf("stdout = %q, want %q", got, want)
-		}
-	})
-
-	t.Run("stdin", func(t *testing.T) {
-		dbPath := filepath.Join(t.TempDir(), "stdin.db")
-		var stdout bytes.Buffer
-		var stderr bytes.Buffer
-
-		exitCode, err := run(context.Background(), strings.NewReader("printf 'stdin\\n'\n"), &stdout, &stderr, []string{
-			"--db", dbPath,
-		})
-		if err != nil {
-			t.Fatalf("run() error = %v", err)
-		}
-		if exitCode != 0 {
-			t.Fatalf("exitCode = %d, want 0; stderr=%q", exitCode, stderr.String())
-		}
-		if got, want := stdout.String(), "stdin\n"; got != want {
-			t.Fatalf("stdout = %q, want %q", got, want)
-		}
-	})
-}
-
-func TestRunREPLPersistsCWDAndEnvAcrossEntries(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "repl.db")
-	input := strings.NewReader("pwd\ncd /tmp\npwd\nexport FOO=bar\necho $FOO\nexit\n")
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
-	exitCode, err := run(context.Background(), input, &stdout, &stderr, []string{
-		"--db", dbPath,
-		"--repl",
-	})
-	if err != nil {
-		t.Fatalf("run() error = %v", err)
-	}
-	if exitCode != 0 {
-		t.Fatalf("exitCode = %d, want 0", exitCode)
-	}
-	if got := stderr.String(); got != "" {
-		t.Fatalf("stderr = %q, want empty", got)
-	}
-
-	out := stdout.String()
-	for _, want := range []string{
-		"~$ /home/agent\n",
-		"/tmp$ /tmp\n",
-		"bar\n/tmp$ ",
-	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("stdout = %q, want substring %q", out, want)
-		}
-	}
-}
-
-func TestRunREPLSupportsMultilineStatements(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "multiline.db")
-	input := &chunkReader{
-		chunks: []string{
-			"if true; then\n",
-			" echo hi\n",
-			"fi\n",
-			"exit\n",
-		},
-	}
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
-	exitCode, err := run(context.Background(), input, &stdout, &stderr, []string{
-		"--db", dbPath,
-		"--repl",
-	})
-	if err != nil {
-		t.Fatalf("run() error = %v", err)
-	}
-	if exitCode != 0 {
-		t.Fatalf("exitCode = %d, want 0", exitCode)
-	}
-	if got := stderr.String(); got != "" {
-		t.Fatalf("stderr = %q, want empty", got)
-	}
-
-	out := stdout.String()
-	if strings.Count(out, sqliteContinuationPrompt) < 2 {
-		t.Fatalf("stdout = %q, want at least two continuation prompts", out)
-	}
-	if !strings.Contains(out, "hi\n~$ ") {
-		t.Fatalf("stdout = %q, want multiline command output", out)
-	}
-}
-
-func TestRunREPLHonorsExitStatus(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "exit.db")
-	input := strings.NewReader("echo hi\nexit 7\necho later\n")
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
-	exitCode, err := run(context.Background(), input, &stdout, &stderr, []string{
-		"--db", dbPath,
-		"--repl",
-	})
-	if err != nil {
-		t.Fatalf("run() error = %v", err)
-	}
-	if exitCode != 7 {
-		t.Fatalf("exitCode = %d, want 7", exitCode)
-	}
-	if got := stderr.String(); got != "" {
-		t.Fatalf("stderr = %q, want empty", got)
-	}
-
-	out := stdout.String()
-	if !strings.Contains(out, "hi\n~$ ") {
-		t.Fatalf("stdout = %q, want first command output", out)
-	}
-	if strings.Contains(out, "later") {
-		t.Fatalf("stdout = %q, did not expect commands after exit", out)
-	}
-}
-
-func TestRunRejectsREPLAndScriptTogether(t *testing.T) {
-	_, err := run(context.Background(), strings.NewReader(""), io.Discard, io.Discard, []string{
-		"--db", filepath.Join(t.TempDir(), "conflict.db"),
-		"--repl",
-		"--script", "pwd\n",
-	})
-	if err == nil {
-		t.Fatal("run() error = nil, want repl/script conflict")
-	}
-	if !strings.Contains(err.Error(), "--repl and --script cannot be used together") {
-		t.Fatalf("run() error = %v, want repl/script conflict", err)
-	}
-}
-
-func TestRunPropagatesExitCodeAndStderr(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "stderr.db")
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
-	exitCode, err := run(context.Background(), strings.NewReader(""), &stdout, &stderr, []string{
-		"--db", dbPath,
-		"--script", "echo nope >&2\nexit 7\n",
-	})
-	if err != nil {
-		t.Fatalf("run() error = %v", err)
-	}
-	if exitCode != 7 {
-		t.Fatalf("exitCode = %d, want 7", exitCode)
-	}
-	if got := stdout.String(); got != "" {
-		t.Fatalf("stdout = %q, want empty", got)
-	}
-	if got := stderr.String(); !strings.Contains(got, "nope\n") {
-		t.Fatalf("stderr = %q, want message", got)
-	}
-}
-
 func newTestSQLiteFS(t *testing.T) *sqliteFS {
 	t.Helper()
 	return newTestSQLiteFSAt(t, filepath.Join(t.TempDir(), "sandbox.db"))
@@ -481,8 +295,8 @@ func newSQLiteRuntime(t *testing.T, dbPath string) *gbruntime.Runtime {
 
 	rt, err := gbruntime.New(gbruntime.WithFileSystem(
 		gbruntime.CustomFileSystem(
-			sqliteFSFactory{dbPath: dbPath},
-			defaultWorkDir,
+			Factory{DBPath: dbPath},
+			"/home/agent",
 		),
 	))
 	if err != nil {
@@ -520,21 +334,4 @@ func readFSFile(t *testing.T, fsys gbfs.FileSystem, name string) string {
 		t.Fatalf("ReadAll(%q) error = %v", name, err)
 	}
 	return string(data)
-}
-
-type chunkReader struct {
-	chunks []string
-	index  int
-}
-
-func (r *chunkReader) Read(p []byte) (int, error) {
-	if r.index >= len(r.chunks) {
-		return 0, io.EOF
-	}
-	n := copy(p, r.chunks[r.index])
-	r.chunks[r.index] = r.chunks[r.index][n:]
-	if r.chunks[r.index] == "" {
-		r.index++
-	}
-	return n, nil
 }

--- a/examples/searchable-fs/main.go
+++ b/examples/searchable-fs/main.go
@@ -9,6 +9,7 @@ import (
 	"path"
 
 	"github.com/ewhauser/gbash"
+	"github.com/ewhauser/gbash/examples/internal/ftsfs"
 	gbfs "github.com/ewhauser/gbash/fs"
 	"github.com/ewhauser/gbash/internal/searchadapter"
 )
@@ -22,7 +23,7 @@ func main() {
 
 func run(ctx context.Context, stdout io.Writer) error {
 	rt, err := gbash.New(gbash.WithFileSystem(gbash.CustomFileSystem(
-		gbfs.NewSearchableFactory(gbfs.Memory(), nil),
+		ftsfs.NewFactory(gbfs.Memory()),
 		"/workspace",
 	)))
 	if err != nil {

--- a/examples/sqlite-backed-fs/main.go
+++ b/examples/sqlite-backed-fs/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/ewhauser/gbash"
+	"github.com/ewhauser/gbash/examples/internal/sqlitefs"
 )
 
 const defaultWorkDir = "/home/agent"
@@ -33,7 +34,7 @@ func run(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, args []
 
 	gb, err := gbash.New(gbash.WithFileSystem(
 		gbash.CustomFileSystem(
-			sqliteFSFactory{dbPath: opts.dbPath},
+			sqlitefs.Factory{DBPath: opts.dbPath},
 			opts.workDir,
 		),
 	))

--- a/examples/sqlite-backed-fs/main_test.go
+++ b/examples/sqlite-backed-fs/main_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRequiresDB(t *testing.T) {
+	_, err := run(context.Background(), strings.NewReader(""), io.Discard, io.Discard, nil)
+	if err == nil {
+		t.Fatal("run() error = nil, want required db error")
+	}
+	if !strings.Contains(err.Error(), "--db is required") {
+		t.Fatalf("run() error = %v, want db requirement", err)
+	}
+}
+
+func TestRunUsesScriptFlagAndStdin(t *testing.T) {
+	t.Run("script flag", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "flag.db")
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+
+		exitCode, err := run(context.Background(), strings.NewReader("ignored\n"), &stdout, &stderr, []string{
+			"--db", dbPath,
+			"--script", "printf 'flag\\n'\n",
+		})
+		if err != nil {
+			t.Fatalf("run() error = %v", err)
+		}
+		if exitCode != 0 {
+			t.Fatalf("exitCode = %d, want 0; stderr=%q", exitCode, stderr.String())
+		}
+		if got, want := stdout.String(), "flag\n"; got != want {
+			t.Fatalf("stdout = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("stdin", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "stdin.db")
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+
+		exitCode, err := run(context.Background(), strings.NewReader("printf 'stdin\\n'\n"), &stdout, &stderr, []string{
+			"--db", dbPath,
+		})
+		if err != nil {
+			t.Fatalf("run() error = %v", err)
+		}
+		if exitCode != 0 {
+			t.Fatalf("exitCode = %d, want 0; stderr=%q", exitCode, stderr.String())
+		}
+		if got, want := stdout.String(), "stdin\n"; got != want {
+			t.Fatalf("stdout = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestRunREPLPersistsCWDAndEnvAcrossEntries(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "repl.db")
+	input := strings.NewReader("pwd\ncd /tmp\npwd\nexport FOO=bar\necho $FOO\nexit\n")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode, err := run(context.Background(), input, &stdout, &stderr, []string{
+		"--db", dbPath,
+		"--repl",
+	})
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0", exitCode)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"~$ /home/agent\n",
+		"/tmp$ /tmp\n",
+		"bar\n/tmp$ ",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, want substring %q", out, want)
+		}
+	}
+}
+
+func TestRunREPLSupportsMultilineStatements(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "multiline.db")
+	input := &chunkReader{
+		chunks: []string{
+			"if true; then\n",
+			" echo hi\n",
+			"fi\n",
+			"exit\n",
+		},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode, err := run(context.Background(), input, &stdout, &stderr, []string{
+		"--db", dbPath,
+		"--repl",
+	})
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0", exitCode)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+
+	out := stdout.String()
+	if strings.Count(out, sqliteContinuationPrompt) < 2 {
+		t.Fatalf("stdout = %q, want at least two continuation prompts", out)
+	}
+	if !strings.Contains(out, "hi\n~$ ") {
+		t.Fatalf("stdout = %q, want multiline command output", out)
+	}
+}
+
+func TestRunREPLHonorsExitStatus(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "exit.db")
+	input := strings.NewReader("echo hi\nexit 7\necho later\n")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode, err := run(context.Background(), input, &stdout, &stderr, []string{
+		"--db", dbPath,
+		"--repl",
+	})
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if exitCode != 7 {
+		t.Fatalf("exitCode = %d, want 7", exitCode)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "hi\n~$ ") {
+		t.Fatalf("stdout = %q, want first command output", out)
+	}
+	if strings.Contains(out, "later") {
+		t.Fatalf("stdout = %q, did not expect commands after exit", out)
+	}
+}
+
+func TestRunRejectsREPLAndScriptTogether(t *testing.T) {
+	_, err := run(context.Background(), strings.NewReader(""), io.Discard, io.Discard, []string{
+		"--db", filepath.Join(t.TempDir(), "conflict.db"),
+		"--repl",
+		"--script", "pwd\n",
+	})
+	if err == nil {
+		t.Fatal("run() error = nil, want repl/script conflict")
+	}
+	if !strings.Contains(err.Error(), "--repl and --script cannot be used together") {
+		t.Fatalf("run() error = %v, want repl/script conflict", err)
+	}
+}
+
+func TestRunPropagatesExitCodeAndStderr(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "stderr.db")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode, err := run(context.Background(), strings.NewReader(""), &stdout, &stderr, []string{
+		"--db", dbPath,
+		"--script", "echo nope >&2\nexit 7\n",
+	})
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if exitCode != 7 {
+		t.Fatalf("exitCode = %d, want 7", exitCode)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "nope\n") {
+		t.Fatalf("stderr = %q, want message", got)
+	}
+}
+
+type chunkReader struct {
+	chunks []string
+	index  int
+}
+
+func (r *chunkReader) Read(p []byte) (int, error) {
+	if r.index >= len(r.chunks) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.chunks[r.index])
+	r.chunks[r.index] = r.chunks[r.index][n:]
+	if r.chunks[r.index] == "" {
+		r.index++
+	}
+	return n, nil
+}

--- a/website/app/components/docs/FilesystemBenchmarkChart.tsx
+++ b/website/app/components/docs/FilesystemBenchmarkChart.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import benchmarkData from "@/content/performance/filesystem-benchmark-data.json";
+
+interface Stats {
+  min_nanos: number;
+  median_nanos: number;
+  p95_nanos: number;
+}
+
+interface MachineInfo {
+  model: string;
+  chip: string;
+  cores: string;
+  memory: string;
+  os: string;
+  go_version: string;
+}
+
+interface FixtureSummary {
+  file_count: number;
+  total_bytes: number;
+}
+
+interface BackendInfo {
+  name: string;
+  label: string;
+  description: string;
+  experimental?: boolean;
+}
+
+interface ScenarioResult {
+  backend: string;
+  success_count: number;
+  failure_count: number;
+  search_mode?: string;
+  stats: Stats;
+}
+
+interface Scenario {
+  name: string;
+  description: string;
+  results: ScenarioResult[];
+}
+
+interface BenchmarkReport {
+  generated_at: string;
+  runs: number;
+  machine: MachineInfo;
+  fixture: FixtureSummary;
+  backends: BackendInfo[];
+  scenarios: Scenario[];
+}
+
+const data = benchmarkData as BenchmarkReport;
+
+function formatNanos(nanos: number): string {
+  if (nanos >= 1_000_000_000) return `${(nanos / 1_000_000_000).toFixed(2)}s`;
+  if (nanos >= 1_000_000) return `${(nanos / 1_000_000).toFixed(1)}ms`;
+  if (nanos >= 1_000) return `${(nanos / 1_000).toFixed(1)}µs`;
+  return `${nanos}ns`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GiB`;
+  if (bytes >= 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${bytes} B`;
+}
+
+const backendByName = new Map(data.backends.map((backend) => [backend.name, backend]));
+
+function MachineTable() {
+  const m = data.machine;
+  return (
+    <div className="mb-8">
+      <h3 className="text-lg font-semibold text-[var(--fg-primary)]">
+        Filesystem Test Environment
+      </h3>
+      <div className="overflow-x-auto">
+        <table>
+          <tbody>
+            {[
+              ["Machine", m.model],
+              ["Chip", m.chip],
+              ["Cores", m.cores],
+              ["Memory", m.memory],
+              ["OS", m.os],
+              ["Go", m.go_version],
+              ["Runs per scenario", `${data.runs}`],
+              [
+                "Fixture",
+                `${data.fixture.file_count} files, ${formatBytes(data.fixture.total_bytes)}`,
+              ],
+              [
+                "Generated",
+                new Date(data.generated_at).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                }),
+              ],
+            ].map(([label, value]) => (
+              <tr key={label}>
+                <td className="font-medium">{label}</td>
+                <td>{value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function BackendTable() {
+  return (
+    <div className="mb-8">
+      <h3 className="text-lg font-semibold text-[var(--fg-primary)]">Backends</h3>
+      <p className="text-sm text-[var(--fg-secondary)] mt-1 mb-3">
+        `memory` and `overlay` are core modes. `sqlite` and `fts` are experimental
+        example-backed filesystems.
+      </p>
+      <div className="overflow-x-auto">
+        <table>
+          <thead>
+            <tr>
+              <th>Backend</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.backends.map((backend) => (
+              <tr key={backend.name}>
+                <td>
+                  <div>{backend.label}</div>
+                  {backend.experimental && (
+                    <div className="text-xs text-[var(--fg-secondary)] mt-1">
+                      Experimental example backend
+                    </div>
+                  )}
+                </td>
+                <td>{backend.description}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function ScenarioTable({ scenario }: { scenario: Scenario }) {
+  return (
+    <div className="mb-8">
+      <h3 className="text-lg font-semibold text-[var(--fg-primary)]">
+        {scenario.name.replace(/_/g, " ")}
+      </h3>
+      <p className="text-sm text-[var(--fg-secondary)] mt-1 mb-3">
+        {scenario.description}
+      </p>
+      <div className="overflow-x-auto">
+        <table>
+          <thead>
+            <tr>
+              <th>Backend</th>
+              <th>Min</th>
+              <th>Median</th>
+              <th>p95</th>
+            </tr>
+          </thead>
+          <tbody>
+            {scenario.results.map((result) => {
+              const backend = backendByName.get(result.backend);
+              return (
+                <tr key={result.backend}>
+                  <td>
+                    <div>{backend?.label ?? result.backend}</div>
+                    {result.search_mode && (
+                      <div className="text-xs text-[var(--fg-secondary)] mt-1">
+                        Search mode: {result.search_mode}
+                      </div>
+                    )}
+                  </td>
+                  <td>{formatNanos(result.stats.min_nanos)}</td>
+                  <td>{formatNanos(result.stats.median_nanos)}</td>
+                  <td>{formatNanos(result.stats.p95_nanos)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default function FilesystemBenchmarkChart() {
+  return (
+    <div>
+      <MachineTable />
+      <BackendTable />
+      {data.scenarios.map((scenario) => (
+        <ScenarioTable key={scenario.name} scenario={scenario} />
+      ))}
+    </div>
+  );
+}

--- a/website/content/guides/contributing.mdx
+++ b/website/content/guides/contributing.mdx
@@ -81,6 +81,8 @@ Run comparison benchmarks locally:
 ```bash
 make bench-compare
 make bench-compare JSON_OUT=bench-compare.json  # JSON output
+make bench-fs
+make bench-fs BENCH_FS_JSON_OUT=/tmp/filesystem-bench.json
 ```
 
 The benchmark compares five runtimes: native `gbash`, GNU bash, `gbash-extras`, `gbash-node-wasm` (WASM in Node.js), and `just-bash` (npm).
@@ -88,6 +90,8 @@ The benchmark compares five runtimes: native `gbash`, GNU bash, `gbash-extras`, 
 Some scenarios require optional commands such as `jq`. Those scenarios keep the full
 runtime table on the website, but unsupported runtimes are shown as skipped with a
 reason instead of being counted as failures.
+
+`make bench-fs` refreshes the filesystem benchmark dataset used on the same page. It compares the `memory`, `overlay`, `sqlite`, and `fts` filesystem backends, and writes the website JSON to `website/content/performance/filesystem-benchmark-data.json` by default.
 
 ## GNU compatibility testing
 

--- a/website/content/performance/benchmarks.mdx
+++ b/website/content/performance/benchmarks.mdx
@@ -20,13 +20,14 @@ Cross-runtime comparison of gbash against GNU bash and alternative sandboxed-she
   </tbody>
 </table>
 
-## Results
-
 import BenchmarkChart from "@/app/components/docs/BenchmarkChart";
+import FilesystemBenchmarkChart from "@/app/components/docs/FilesystemBenchmarkChart";
+
+## Runtime Results
 
 <BenchmarkChart />
 
-## Methodology
+### Runtime Methodology
 
 - Each scenario runs the command as a fresh process invocation (cold start).
 - A single untimed warmup run precedes the timed trials to prime OS caches.
@@ -37,3 +38,17 @@ import BenchmarkChart from "@/app/components/docs/BenchmarkChart";
 - The harness source is at [`scripts/bench-compare/main.go`](https://github.com/ewhauser/gbash/blob/main/scripts/bench-compare/main.go).
 
 > **Note:** just-bash ships significantly more functionality than gbash today — Python and lightweight JavaScript runtimes are bundled in the core — so the artifact sizes and startup costs are not directly comparable.
+
+## Filesystem Results
+
+These numbers compare gbash filesystem backends directly rather than measuring shell process startup. The core rows are `memory` and `overlay`; `sqlite` and `fts` are experimental example-backed filesystems included for side-by-side comparison.
+
+<FilesystemBenchmarkChart />
+
+### Filesystem Methodology
+
+- Each trial starts from a clean backend state with the same canonical `/workspace` fixture.
+- Latency is measured from `Factory.New(...)` through workload verification, so backend open/index-build costs are included.
+- The benchmark uses direct filesystem operations instead of shell command execution.
+- `literal_search` uses `searchadapter.Search(..., IndexEligible=true)` so `fts` can take the indexed path while the other rows fall back to scan.
+- The harness source is at [`examples/bench-fs`](https://github.com/ewhauser/gbash/tree/main/examples/bench-fs).

--- a/website/content/performance/filesystem-benchmark-data.json
+++ b/website/content/performance/filesystem-benchmark-data.json
@@ -1,0 +1,230 @@
+{
+  "generated_at": "2026-03-15T21:33:09Z",
+  "runs": 50,
+  "machine": {
+    "model": "Mac15,8",
+    "chip": "Apple M3 Max",
+    "cores": "16 (12 performance + 4 efficiency)",
+    "memory": "64 GB",
+    "os": "macOS 15.5",
+    "go_version": "go1.26.1 darwin/arm64"
+  },
+  "fixture": {
+    "file_count": 252,
+    "total_bytes": 203420
+  },
+  "backends": [
+    {
+      "name": "memory",
+      "label": "memory",
+      "description": "Core in-memory sandbox filesystem seeded with the benchmark fixture."
+    },
+    {
+      "name": "overlay",
+      "label": "overlay",
+      "description": "Core read-only host workspace with an in-memory writable upper layer."
+    },
+    {
+      "name": "sqlite",
+      "label": "sqlite",
+      "description": "Experimental SQLite-backed example filesystem using a host database file.",
+      "experimental": true
+    },
+    {
+      "name": "fts",
+      "label": "fts",
+      "description": "Experimental full-text-search example filesystem over seeded in-memory data.",
+      "experimental": true
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "metadata_walk",
+      "description": "Recursive ReadDir and Lstat traversal across the canonical /workspace fixture.",
+      "results": [
+        {
+          "backend": "memory",
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 361625,
+            "median_nanos": 405916,
+            "p95_nanos": 513334
+          }
+        },
+        {
+          "backend": "overlay",
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 4440542,
+            "median_nanos": 4989291,
+            "p95_nanos": 6599000
+          }
+        },
+        {
+          "backend": "sqlite",
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 27873792,
+            "median_nanos": 28564687,
+            "p95_nanos": 29864667
+          }
+        },
+        {
+          "backend": "fts",
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 1213792,
+            "median_nanos": 1431875,
+            "p95_nanos": 1662458
+          }
+        }
+      ]
+    },
+    {
+      "name": "bulk_read",
+      "description": "Open and read the full fixture workload, verifying total bytes.",
+      "results": [
+        {
+          "backend": "memory",
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 410208,
+            "median_nanos": 479875,
+            "p95_nanos": 752333
+          }
+        },
+        {
+          "backend": "overlay",
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 7373625,
+            "median_nanos": 8116520,
+            "p95_nanos": 9763667
+          }
+        },
+        {
+          "backend": "sqlite",
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 104047167,
+            "median_nanos": 105746041,
+            "p95_nanos": 113003166
+          }
+        },
+        {
+          "backend": "fts",
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 1316750,
+            "median_nanos": 1648833,
+            "p95_nanos": 1952750
+          }
+        }
+      ]
+    },
+    {
+      "name": "mutation_roundtrip",
+      "description": "Create, overwrite, rename, and remove files inside /workspace with verification.",
+      "results": [
+        {
+          "backend": "memory",
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 363125,
+            "median_nanos": 393687,
+            "p95_nanos": 625792
+          }
+        },
+        {
+          "backend": "overlay",
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 4615875,
+            "median_nanos": 5024666,
+            "p95_nanos": 10641083
+          }
+        },
+        {
+          "backend": "sqlite",
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 32179416,
+            "median_nanos": 33075250,
+            "p95_nanos": 35167750
+          }
+        },
+        {
+          "backend": "fts",
+          "success_count": 50,
+          "failure_count": 0,
+          "stats": {
+            "min_nanos": 1321917,
+            "median_nanos": 1525625,
+            "p95_nanos": 1757917
+          }
+        }
+      ]
+    },
+    {
+      "name": "literal_search",
+      "description": "Indexed-or-scan literal search over /workspace using the full-text example path when available.",
+      "results": [
+        {
+          "backend": "memory",
+          "success_count": 50,
+          "failure_count": 0,
+          "search_mode": "scan",
+          "stats": {
+            "min_nanos": 626042,
+            "median_nanos": 688104,
+            "p95_nanos": 905250
+          }
+        },
+        {
+          "backend": "overlay",
+          "success_count": 50,
+          "failure_count": 0,
+          "search_mode": "scan",
+          "stats": {
+            "min_nanos": 12423541,
+            "median_nanos": 13038896,
+            "p95_nanos": 14283625
+          }
+        },
+        {
+          "backend": "sqlite",
+          "success_count": 50,
+          "failure_count": 0,
+          "search_mode": "scan",
+          "stats": {
+            "min_nanos": 130373708,
+            "median_nanos": 132095167,
+            "p95_nanos": 142439166
+          }
+        },
+        {
+          "backend": "fts",
+          "success_count": 50,
+          "failure_count": 0,
+          "search_mode": "index",
+          "stats": {
+            "min_nanos": 1102875,
+            "median_nanos": 1309854,
+            "p95_nanos": 1512250
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add an `examples/bench-fs` generator plus `make bench-fs` for `memory`, `overlay`, `sqlite`, and `fts` filesystem backend benchmarks
- extract the sqlite and full-text example backends into shared `examples/internal` helpers used by both the examples and the benchmark harness
- add checked-in filesystem benchmark data and a new benchmarks-page section, and update contributor benchmark docs/skill instructions

## Validation
- `make lint`
- `go test ./examples/...`
- `npx --yes pnpm@10.32.1 --dir /Users/ewhauser/.codex/worktrees/2243/gbash/website exec next build`

## Notes
- No `SPEC.md` update is needed because this changes tooling, examples, and website content only.
