### PR TITLE
server: add shared session daemon mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Shell parsing is delegated to [`mvdan/sh`](https://github.com/mvdan/sh), with pr
 - 90+ built-in commands with GNU coreutils compatibility coverage ([compatibility report](https://ewhauser.github.io/gbash/docs/performance/compatibility/))
 - Optional allowlisted network access via `curl`
 - Persistent sessions with shared filesystem state across executions
+- Shared Unix-socket server mode for session-oriented hosts and wrapper binaries
 - Host directory mounting with read-only overlay for real project workspaces
 - Execution budgets — command count, loop iterations, glob expansion, stdout/stderr limits
 - Opt-in structured trace events and lifecycle logs for debugging and agent orchestration
@@ -44,6 +45,7 @@ Shell parsing is delegated to [`mvdan/sh`](https://github.com/mvdan/sh), with pr
 ## Public Packages
 
 - `github.com/ewhauser/gbash`: the core Go runtime and embedding API
+- `github.com/ewhauser/gbash/server`: shared Unix-socket server mode for hosting persistent gbash sessions
 - `github.com/ewhauser/gbash/contrib/...`: optional Go command modules
 - `@ewhauser/gbash-wasm/browser`: the explicit browser entrypoint for the `js/wasm` package. It is versioned in-repo today; npm publishing remains disabled in the release workflow for now.
 - `@ewhauser/gbash-wasm/node`: the explicit Node entrypoint for the same `js/wasm` package.
@@ -219,13 +221,23 @@ gbash -c 'echo hello' --json
 
 The JSON payload includes `stdout`, `stderr`, `exitCode`, truncation flags, timing metadata, and trace metadata when the wrapper enables tracing on the underlying runtime.
 
+For long-lived agent or editor integrations, the same shared CLI frontend can serve a Unix domain socket protocol instead of executing one script:
+
+```bash
+gbash --server --socket /tmp/gbash.sock --session-ttl 30m
+```
+
+The protocol models `session_id` as a persistent sandbox session and treats `exec.start` and `shell.start` as child streams inside that session. Stream output is asynchronous event data keyed by `session_id`, `stream_id`, `channel`, and per-channel sequence numbers. Filesystem shape is still chosen at server startup through the normal CLI/runtime options such as `--root`, `--readwrite-root`, and `--cwd`; it is not configured over the wire.
+
 Install `gbash-extras` when you want the same CLI surface with the stable official contrib commands (`awk`, `html-to-markdown`, `jq`, `sqlite3`, and `yq`) pre-registered:
 
 ```bash
 gbash-extras -c 'jq -r .name data.json'
 ```
 
-The shared frontend is also exposed as the public `github.com/ewhauser/gbash/cli` package. Call `cli.Run` with a `cli.Config` to reuse the stock flag parsing, interactive mode, and runtime setup from your own wrapper binary.
+`gbash-extras --server --socket /tmp/gbash-extras.sock` exposes the same protocol with the stable extras registry already installed.
+
+The shared frontend is also exposed as the public `github.com/ewhauser/gbash/cli` package. Call `cli.Run` with a `cli.Config` to reuse the stock flag parsing, interactive mode, server mode, and runtime setup from your own wrapper binary. For direct embedding without going through the CLI package, use `github.com/ewhauser/gbash/server`.
 ## Configuration
 
 ### Filesystem

--- a/SPEC.md
+++ b/SPEC.md
@@ -140,6 +140,9 @@ The normal CLI entrypoint also accepts filesystem selection flags before the she
 - `gbash --cwd <dir> ...` sets the initial sandbox working directory
 - `gbash --readwrite-root <dir> ...` mounts `<dir>` as sandbox `/` so writes persist back to the host, but only when `<dir>` is inside the system temp directory
 - `gbash --json ...` emits one JSON object for a non-interactive execution with `stdout`, `stderr`, `exitCode`, truncation flags, timing metadata, and optional trace metadata when tracing is enabled
+- `gbash --server --socket <path>` serves a long-lived Unix domain socket protocol instead of executing a script
+- `gbash --session-ttl <duration>` controls how long detached server sessions survive without active work
+- `gbash --replay-bytes <n>` controls how many bytes per stream channel the server retains for replay on reattach
 - when `--cwd` is omitted, `--root` starts at `/home/agent/project` and `--readwrite-root` starts at `/`
 
 External test harnesses should use the normal CLI entrypoint together with the filesystem selection flags above. In particular, GNU-style wrapper scripts may invoke `gbash --readwrite-root <tempdir> --cwd <dir> -c 'exec "$@"' _ <utility> ...` so the harness exercises the same shell and runtime path as normal `gbash` execution.
@@ -148,6 +151,7 @@ That frontend is also exposed as a public `cli` package so shipped binaries can 
 
 - `cmd/gbash` is a thin wrapper over `github.com/ewhauser/gbash/cli`
 - `contrib/extras/cmd/gbash-extras` is a thin wrapper over the same package with `contrib/extras` pre-registered into the runtime
+- `github.com/ewhauser/gbash/server` is the shared public server surface used by both wrapper binaries to host the same session protocol over Unix sockets
 
 ### 6.1 Session model
 
@@ -163,7 +167,42 @@ That frontend is also exposed as a public `cli` package so shipped binaries can 
 
 This matches the agent workflow we care about: a sequence of shell calls operating on a shared sandboxed workspace, without requiring shell-local state to leak between calls unless we explicitly add that feature later.
 
-### 6.2 Default sandbox layout
+### 6.2 Server mode
+
+`gbash` should also expose a local-first server mode for hosts that want a long-lived control connection instead of direct in-process method calls.
+
+- the server transport is a Unix domain socket in v1, but the message framing should stay transport-agnostic
+- `session_id` maps 1:1 to a persistent `Session`
+- child streams inside one session are first-class and represent either `exec.start` or `shell.start`
+- multiple sessions may be active concurrently over one connection
+- a single session permits at most one active child stream at a time because `Session.Exec` and `Session.Interact` are serialized
+- filesystem shape is configured once at server startup through the normal runtime options and is not part of the wire protocol
+- the protocol is JSON message envelopes with request/response correlation plus async events
+- every routed message carries explicit `session_id`, and stream-scoped messages also carry `stream_id`
+- stream output is evented data, not response bodies; stdout and stderr use explicit `channel` values and per-channel `seq` numbers
+- reconnect and detach/reattach are first-class via `stream.attach`, bounded replay buffers, and per-channel replay cursors
+- multiple read-only attachments are allowed, but only one attachment may own stdin writes for a running stream
+
+Recommended v1 methods:
+
+- `hello`, `ping`
+- `session.create`, `session.get`, `session.list`, `session.destroy`
+- `exec.start`, `shell.start`
+- `stream.attach`, `stream.detach`, `stream.write`, `stream.close`, `stream.cancel`
+
+Recommended v1 events:
+
+- `session.created`, `session.updated`
+- `stream.data`, `stream.exit`, `stream.error`
+
+Explicit v1 non-goals:
+
+- filesystem RPC
+- PTY resize and host TTY emulation
+- signal forwarding and job control
+- restart-persistent sessions
+
+### 6.3 Default sandbox layout
 
 The default in-memory sandbox should look Unix-like enough for agent scripts:
 
@@ -186,6 +225,7 @@ Because `mvdan/sh` currently validates `interp.Dir(...)` against the host filesy
 ```text
 cli/                   reusable CLI frontend shared by shipped binaries
 cmd/gbash/             CLI entrypoint for local execution
+server/                public Unix-socket server surface shared by wrapper binaries
 internal/runtime/      internal runtime implementation and execution orchestration
 shell/                mvdan/sh integration and handler wiring
 fs/                   project-owned filesystem interfaces and virtual backends
@@ -202,6 +242,7 @@ tests/                integration fixtures and compatibility-style harnesses
 Package responsibilities:
 
 - `cli/`: reusable CLI frontend that parses shell flags, renders help/version output, handles interactive mode, and provisions runtimes for thin wrapper binaries
+- `server/`: public shared server implementation that owns Unix-socket listeners, protocol framing, session registries, replay buffers, and stream attachment semantics for both shipped CLIs and external hosts
 - `internal/runtime/`: internal runtime/session creation, run configuration, result collection, output capture
 - `shell/`: parser and runner adapter; no product policy lives here
 - `fs/`: POSIX-like path normalization, memory filesystem, host-backed lower layers, overlay, and snapshot backends

--- a/cli/json_output.go
+++ b/cli/json_output.go
@@ -126,6 +126,13 @@ func formatCLIError(name string, err error) string {
 	return fmt.Sprintf("%s: %v", name, err)
 }
 
+func writeCLIJSONError(stdout io.Writer, name string, exitCode int, err error) (int, error) {
+	if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(exitCode, nil, formatCLIError(name, err))); jsonErr != nil {
+		return 1, jsonErr
+	}
+	return exitCode, nil
+}
+
 func writerOrDiscard(w io.Writer) io.Writer {
 	if w == nil {
 		return io.Discard

--- a/cli/run.go
+++ b/cli/run.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/ewhauser/gbash"
 	"github.com/ewhauser/gbash/internal/builtins"
+	gbserver "github.com/ewhauser/gbash/server"
 	"golang.org/x/term"
 )
 
@@ -59,6 +61,17 @@ func run(ctx context.Context, cfg Config, argv0 string, args []string, stdin io.
 		_, _ = io.WriteString(stdout, versionText(cfg))
 		return 0, nil
 	}
+	if runtimeOpts.server {
+		if runtimeOpts.json {
+			return writeCLIJSONError(stdout, cfg.Name, 2, fmt.Errorf("--server and --json are mutually exclusive"))
+		}
+		if parsed.Source != builtins.BashSourceStdin || parsed.Interactive {
+			return 2, fmt.Errorf("--server cannot be combined with script execution or interactive shell flags")
+		}
+		if strings.TrimSpace(runtimeOpts.socket) == "" {
+			return 2, fmt.Errorf("--socket is required when --server is set")
+		}
+	}
 	if runtimeOpts.json && parsed.Source == builtins.BashSourceStdin && (parsed.Interactive || stdinTTY) {
 		if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(2, nil, formatCLIError(cfg.Name, fmt.Errorf("--json is only supported for non-interactive executions")))); jsonErr != nil {
 			return 1, jsonErr
@@ -66,7 +79,7 @@ func run(ctx context.Context, cfg Config, argv0 string, args []string, stdin io.
 		return 2, nil
 	}
 
-	rt, err := newRuntime(cfg, runtimeOpts)
+	rt, err := newRuntime(cfg, &runtimeOpts)
 	if err != nil {
 		if runtimeOpts.json {
 			if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(1, nil, formatCLIError(cfg.Name, fmt.Errorf("init runtime: %w", err)))); jsonErr != nil {
@@ -75,6 +88,20 @@ func run(ctx context.Context, cfg Config, argv0 string, args []string, stdin io.
 			return 1, nil
 		}
 		return 1, fmt.Errorf("init runtime: %w", err)
+	}
+	if runtimeOpts.server {
+		meta := currentBuildInfo(cfg.Build)
+		err = gbserver.ListenAndServeUnix(ctx, runtimeOpts.socket, gbserver.Config{
+			Runtime:     rt,
+			Name:        cfg.Name,
+			Version:     meta.Version,
+			SessionTTL:  runtimeOpts.sessionTTL,
+			ReplayBytes: runtimeOpts.replayBytes,
+		})
+		if err != nil {
+			return 1, fmt.Errorf("server error: %w", err)
+		}
+		return 0, nil
 	}
 
 	if parsed.Source == builtins.BashSourceStdin && (parsed.Interactive || stdinTTY) {

--- a/cli/runtime_options.go
+++ b/cli/runtime_options.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ewhauser/gbash"
 	"github.com/ewhauser/gbash/internal/builtins"
@@ -17,6 +19,10 @@ type runtimeOptions struct {
 	readWriteRoot string
 	cwd           string
 	json          bool
+	server        bool
+	socket        string
+	sessionTTL    time.Duration
+	replayBytes   int
 }
 
 func parseRuntimeOptions(args []string) (runtimeOptions, []string, error) {
@@ -58,6 +64,48 @@ func parseRuntimeOptions(args []string) (runtimeOptions, []string, error) {
 			opts.cwd = strings.TrimPrefix(arg, "--cwd=")
 		case arg == "--json":
 			opts.json = true
+		case arg == "--server":
+			opts.server = true
+		case arg == "--socket":
+			if i+1 >= len(args) {
+				return opts, nil, fmt.Errorf("--socket requires a path")
+			}
+			i++
+			opts.socket = args[i]
+		case strings.HasPrefix(arg, "--socket="):
+			opts.socket = strings.TrimPrefix(arg, "--socket=")
+		case arg == "--session-ttl":
+			if i+1 >= len(args) {
+				return opts, nil, fmt.Errorf("--session-ttl requires a duration")
+			}
+			i++
+			ttl, err := time.ParseDuration(args[i])
+			if err != nil {
+				return opts, nil, fmt.Errorf("parse --session-ttl: %w", err)
+			}
+			opts.sessionTTL = ttl
+		case strings.HasPrefix(arg, "--session-ttl="):
+			ttl, err := time.ParseDuration(strings.TrimPrefix(arg, "--session-ttl="))
+			if err != nil {
+				return opts, nil, fmt.Errorf("parse --session-ttl: %w", err)
+			}
+			opts.sessionTTL = ttl
+		case arg == "--replay-bytes":
+			if i+1 >= len(args) {
+				return opts, nil, fmt.Errorf("--replay-bytes requires an integer")
+			}
+			i++
+			replayBytes, err := strconv.Atoi(args[i])
+			if err != nil {
+				return opts, nil, fmt.Errorf("parse --replay-bytes: %w", err)
+			}
+			opts.replayBytes = replayBytes
+		case strings.HasPrefix(arg, "--replay-bytes="):
+			replayBytes, err := strconv.Atoi(strings.TrimPrefix(arg, "--replay-bytes="))
+			if err != nil {
+				return opts, nil, fmt.Errorf("parse --replay-bytes: %w", err)
+			}
+			opts.replayBytes = replayBytes
 		case arg == "--":
 			rest = append(rest, args[i:]...)
 			return opts, rest, nil
@@ -88,7 +136,10 @@ func bashInvocationValueCount(arg string) int {
 	return count
 }
 
-func (opts runtimeOptions) gbashOptions() ([]gbash.Option, error) {
+func (opts *runtimeOptions) gbashOptions() ([]gbash.Option, error) {
+	if opts == nil {
+		return nil, nil
+	}
 	rootValue := strings.TrimSpace(opts.root)
 	readWriteRoot := strings.TrimSpace(opts.readWriteRoot)
 	cwdValue := strings.TrimSpace(opts.cwd)
@@ -171,7 +222,7 @@ func normalizeSandboxPath(value string) string {
 	return path.Clean(value)
 }
 
-func newRuntime(cfg Config, opts runtimeOptions) (*gbash.Runtime, error) {
+func newRuntime(cfg Config, opts *runtimeOptions) (*gbash.Runtime, error) {
 	runtimeOpts, err := opts.gbashOptions()
 	if err != nil {
 		return nil, err
@@ -195,6 +246,11 @@ func renderHelp(w io.Writer, name string) error {
 		"  --cwd DIR             set the initial sandbox working directory\n"+
 		"  --readwrite-root DIR  mount DIR as sandbox / with writes persisted back to the host filesystem\n"+
 		"\nCLI output options:\n"+
-		"  --json                emit one JSON result object for a non-interactive execution\n")
+		"  --json                emit one JSON result object for a non-interactive execution\n"+
+		"\nCLI server options:\n"+
+		"  --server              run the shared gbash server instead of executing a script\n"+
+		"  --socket PATH         listen on PATH for Unix domain socket clients\n"+
+		"  --session-ttl DURATION  keep detached sessions alive for DURATION before expiry\n"+
+		"  --replay-bytes N      retain up to N bytes per stream channel for replay on reattach\n")
 	return err
 }

--- a/cmd/gbash/cli_test.go
+++ b/cmd/gbash/cli_test.go
@@ -110,6 +110,27 @@ func TestRunCLIHelpRendersFilesystemFlags(t *testing.T) {
 	}
 }
 
+func TestRunCLIHelpRendersServerFlags(t *testing.T) {
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), "gbash", []string{"--help"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0", exitCode)
+	}
+	for _, want := range []string{"CLI server options:", "--server", "--socket PATH", "--session-ttl DURATION", "--replay-bytes N"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want help to contain %q", stdout.String(), want)
+		}
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
 func TestRunCLIJSONOutputEncodesExecutionResult(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
@@ -191,6 +212,58 @@ func TestRunCLIJSONOutputRejectsInteractiveShell(t *testing.T) {
 	payload := mustParseCLIJSONResult(t, stdout.String())
 	if !strings.Contains(payload.Stderr, "only supported for non-interactive executions") {
 		t.Fatalf("stderr = %q, want non-interactive rejection", payload.Stderr)
+	}
+}
+
+func TestRunCLIServerRequiresSocket(t *testing.T) {
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), "gbash", []string{"--server"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err == nil {
+		t.Fatal("runCLI() error = nil, want socket requirement")
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d, want 2", exitCode)
+	}
+	if !strings.Contains(err.Error(), "--socket is required") {
+		t.Fatalf("error = %v, want socket requirement", err)
+	}
+}
+
+func TestRunCLIServerRejectsScriptExecutionFlags(t *testing.T) {
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), "gbash", []string{"--server", "--socket", filepath.Join(t.TempDir(), "gbash.sock"), "-c", "echo hi"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err == nil {
+		t.Fatal("runCLI() error = nil, want server/script rejection")
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d, want 2", exitCode)
+	}
+	if !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("error = %v, want server/script rejection", err)
+	}
+}
+
+func TestRunCLIServerRejectsJSONMode(t *testing.T) {
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), "gbash", []string{"--server", "--socket", filepath.Join(t.TempDir(), "gbash.sock"), "--json"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d, want 2", exitCode)
+	}
+	payload := mustParseCLIJSONResult(t, stdout.String())
+	if !strings.Contains(payload.Stderr, "--server and --json are mutually exclusive") {
+		t.Fatalf("stderr = %q, want server/json rejection", payload.Stderr)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
 	}
 }
 

--- a/contrib/extras/cmd/gbash-extras/main_test.go
+++ b/contrib/extras/cmd/gbash-extras/main_test.go
@@ -2,9 +2,16 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"io"
+	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	rootcli "github.com/ewhauser/gbash/cli"
 )
@@ -96,5 +103,148 @@ func TestCLIDoesNotRegisterNodeJSByDefault(t *testing.T) {
 	}
 	if got := stderr.String(); !strings.Contains(got, "nodejs: command not found") {
 		t.Fatalf("stderr = %q, want nodejs command-not-found", got)
+	}
+}
+
+func TestCLIServerServesStableExtrasRegistry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	socket := filepath.Join(os.TempDir(), fmt.Sprintf("gbash-extras-%d.sock", time.Now().UnixNano()))
+	t.Cleanup(func() { _ = os.Remove(socket) })
+	var stdout strings.Builder
+	var stderr strings.Builder
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := runCLI(ctx, "gbash-extras", []string{"--server", "--socket", socket}, strings.NewReader(""), &stdout, &stderr, false)
+		errCh <- err
+	}()
+
+	var conn net.Conn
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-errCh:
+			cancel()
+			t.Fatalf("server exited before socket became ready: %v", err)
+		default:
+		}
+		dialed, err := net.DialTimeout("unix", socket, 50*time.Millisecond)
+		if err == nil {
+			conn = dialed
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if conn == nil {
+		t.Fatal("timed out waiting for gbash-extras server socket")
+	}
+	defer func() { _ = conn.Close() }()
+
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+	send := func(id, method, sessionID, streamID string, payload any) {
+		t.Helper()
+		if err := enc.Encode(map[string]any{
+			"version":    "1",
+			"type":       "request",
+			"id":         id,
+			"method":     method,
+			"session_id": sessionID,
+			"stream_id":  streamID,
+			"payload":    payload,
+		}); err != nil {
+			t.Fatalf("Encode(%s) error = %v", method, err)
+		}
+	}
+	readUntilResponse := func(id string) map[string]any {
+		t.Helper()
+		for {
+			if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				t.Fatalf("SetReadDeadline() error = %v", err)
+			}
+			var msg map[string]any
+			if err := dec.Decode(&msg); err != nil {
+				t.Fatalf("Decode() error = %v", err)
+			}
+			if got, _ := msg["type"].(string); got == "response" && msg["id"] == id {
+				return msg
+			}
+		}
+	}
+
+	send("1", "session.create", "", "", nil)
+	createResp := readUntilResponse("1")
+	if ok, _ := createResp["ok"].(bool); !ok {
+		t.Fatalf("session.create response = %#v, want ok", createResp)
+	}
+	sessionID, ok := createResp["session_id"].(string)
+	if !ok || sessionID == "" {
+		t.Fatalf("session.create response = %#v, want session_id", createResp)
+	}
+
+	send("2", "exec.start", sessionID, "", map[string]any{
+		"script": "printf 'a,b\\n' | awk -F, '{print $2}'\n",
+	})
+	execResp := readUntilResponse("2")
+	if ok, _ := execResp["ok"].(bool); !ok {
+		t.Fatalf("exec.start response = %#v, want ok", execResp)
+	}
+	streamID, ok := execResp["stream_id"].(string)
+	if !ok || streamID == "" {
+		t.Fatalf("exec.start response = %#v, want stream_id", execResp)
+	}
+
+	var gotStdout strings.Builder
+	for {
+		if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+			t.Fatalf("SetReadDeadline() error = %v", err)
+		}
+		var msg struct {
+			Type     string `json:"type"`
+			Event    string `json:"event"`
+			StreamID string `json:"stream_id"`
+			Channel  string `json:"channel"`
+			Payload  struct {
+				Data string `json:"data"`
+			} `json:"payload"`
+		}
+		if err := dec.Decode(&msg); err != nil {
+			t.Fatalf("Decode(stream event) error = %v", err)
+		}
+		if msg.Type != "event" || msg.StreamID != streamID {
+			continue
+		}
+		switch msg.Event {
+		case "stream.data":
+			if msg.Channel != "stdout" {
+				continue
+			}
+			data, err := base64.StdEncoding.DecodeString(msg.Payload.Data)
+			if err != nil {
+				t.Fatalf("DecodeString(stdout) error = %v", err)
+			}
+			gotStdout.Write(data)
+		case "stream.exit":
+			if got, want := gotStdout.String(), "b\n"; got != want {
+				t.Fatalf("stdout = %q, want %q", got, want)
+			}
+			cancel()
+			select {
+			case err := <-errCh:
+				if err != nil {
+					t.Fatalf("server exited with error: %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for gbash-extras server shutdown")
+			}
+			if got := stdout.String(); got != "" {
+				t.Fatalf("server stdout = %q, want empty", got)
+			}
+			if got := stderr.String(); got != "" {
+				t.Fatalf("server stderr = %q, want empty", got)
+			}
+			return
+		}
 	}
 }

--- a/internal/shell/mvdan.go
+++ b/internal/shell/mvdan.go
@@ -79,7 +79,8 @@ type resolvedCommand struct {
 }
 
 type MVdan struct {
-	parser *syntax.Parser
+	parser   *syntax.Parser
+	parserMu sync.Mutex
 }
 
 const hostRunnerDir = "/"
@@ -104,6 +105,8 @@ func New() *MVdan {
 }
 
 func (m *MVdan) Parse(name, script string) (*syntax.File, error) {
+	m.parserMu.Lock()
+	defer m.parserMu.Unlock()
 	return m.parser.Parse(strings.NewReader(script), name)
 }
 

--- a/server/doc.go
+++ b/server/doc.go
@@ -1,0 +1,6 @@
+// Package server exposes a shared Unix-socket server mode for gbash runtimes.
+//
+// The package is intentionally small and host-oriented. It lets embedders and
+// shipped CLIs serve persistent gbash sessions over a long-lived connection
+// without committing to a public client SDK.
+package server

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,685 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ewhauser/gbash"
+)
+
+const (
+	protocolVersion = "1"
+	defaultTTL      = 30 * time.Minute
+	defaultReplay   = 1 << 20
+	minReaperTick   = 100 * time.Millisecond
+	maxReaperTick   = time.Second
+)
+
+// Config configures the shared gbash server mode.
+type Config struct {
+	Runtime     *gbash.Runtime
+	Name        string
+	Version     string
+	SessionTTL  time.Duration
+	ReplayBytes int
+}
+
+// ListenAndServeUnix serves the gbash protocol on a Unix domain socket.
+func ListenAndServeUnix(ctx context.Context, socketPath string, cfg Config) error {
+	socketPath = strings.TrimSpace(socketPath)
+	if socketPath == "" {
+		return fmt.Errorf("server: socket path must not be empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o755); err != nil {
+		return fmt.Errorf("server: create socket directory: %w", err)
+	}
+	if err := removeStaleUnixSocket(socketPath); err != nil {
+		return err
+	}
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("server: listen on unix socket: %w", err)
+	}
+	defer func() { _ = os.Remove(socketPath) }()
+	if err := os.Chmod(socketPath, 0o600); err != nil {
+		_ = ln.Close()
+		return fmt.Errorf("server: chmod socket: %w", err)
+	}
+	return Serve(ctx, ln, cfg)
+}
+
+// Serve serves the gbash protocol on an existing listener.
+func Serve(ctx context.Context, ln net.Listener, cfg Config) error {
+	if ln == nil {
+		return fmt.Errorf("server: listener is nil")
+	}
+	cfg = normalizeConfig(cfg)
+	if cfg.Runtime == nil {
+		return fmt.Errorf("server: runtime is nil")
+	}
+
+	srv := &serverState{
+		ctx:      ctx,
+		cfg:      cfg,
+		sessions: make(map[string]*serverSession),
+		conns:    make(map[string]*clientConn),
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = ln.Close()
+			srv.closeConnections()
+		case <-done:
+		}
+	}()
+	go srv.reapLoop(done)
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) || ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("server: accept: %w", err)
+		}
+		srv.addConn(conn)
+	}
+}
+
+type serverState struct {
+	ctx context.Context
+	cfg Config
+
+	nextID atomic.Uint64
+
+	connsMu sync.RWMutex
+	conns   map[string]*clientConn
+
+	sessionsMu sync.Mutex
+	sessions   map[string]*serverSession
+}
+
+type clientConn struct {
+	server *serverState
+	id     string
+	conn   net.Conn
+	enc    *json.Encoder
+	dec    *json.Decoder
+
+	send   chan *protocolMessage
+	closed chan struct{}
+	once   sync.Once
+}
+
+type protocolMessage struct {
+	Version   string          `json:"version,omitempty"`
+	Type      string          `json:"type"`
+	ID        string          `json:"id,omitempty"`
+	Method    string          `json:"method,omitempty"`
+	Event     string          `json:"event,omitempty"`
+	SessionID string          `json:"session_id,omitempty"`
+	StreamID  string          `json:"stream_id,omitempty"`
+	Channel   string          `json:"channel,omitempty"`
+	Seq       uint64          `json:"seq,omitempty"`
+	OK        *bool           `json:"ok,omitempty"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+	Error     *protocolError  `json:"error,omitempty"`
+}
+
+type protocolError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type helloResponse struct {
+	ServerName    string            `json:"server_name"`
+	ServerVersion string            `json:"server_version"`
+	Capabilities  helloCapabilities `json:"capabilities"`
+}
+
+type helloCapabilities struct {
+	Binary           string `json:"binary"`
+	Transport        string `json:"transport"`
+	Reconnect        bool   `json:"reconnect"`
+	FileSystemRPC    bool   `json:"filesystem_rpc"`
+	PTY              bool   `json:"pty"`
+	InteractiveShell bool   `json:"interactive_shell"`
+}
+
+type sessionListResponse struct {
+	Sessions []sessionSummary `json:"sessions"`
+}
+
+type sessionDetailResponse struct {
+	Session sessionSummary  `json:"session"`
+	Streams []streamSummary `json:"streams,omitempty"`
+}
+
+type streamStartResponse struct {
+	SessionID      string `json:"session_id"`
+	StreamID       string `json:"stream_id"`
+	Kind           string `json:"kind"`
+	State          string `json:"state"`
+	WriterAttached bool   `json:"writer_attached"`
+}
+
+type streamAttachResponse struct {
+	SessionID      string `json:"session_id"`
+	StreamID       string `json:"stream_id"`
+	State          string `json:"state"`
+	WriterAttached bool   `json:"writer_attached"`
+}
+
+type sessionCreateRequest struct{}
+
+type execStartRequest struct {
+	Name           string            `json:"name"`
+	Script         string            `json:"script"`
+	Args           []string          `json:"args"`
+	StartupOptions []string          `json:"startup_options"`
+	Env            map[string]string `json:"env"`
+	WorkDir        string            `json:"work_dir"`
+	ReplaceEnv     bool              `json:"replace_env"`
+	TimeoutMs      int64             `json:"timeout_ms"`
+	Stdin          string            `json:"stdin"`
+}
+
+type shellStartRequest struct {
+	Name           string            `json:"name"`
+	Args           []string          `json:"args"`
+	StartupOptions []string          `json:"startup_options"`
+	Env            map[string]string `json:"env"`
+	WorkDir        string            `json:"work_dir"`
+	ReplaceEnv     bool              `json:"replace_env"`
+}
+
+type streamAttachRequest struct {
+	StreamID  string `json:"stream_id"`
+	StdoutSeq uint64 `json:"stdout_seq"`
+	StderrSeq uint64 `json:"stderr_seq"`
+	Write     bool   `json:"write"`
+}
+
+type streamDataRequest struct {
+	Data     string `json:"data"`
+	Encoding string `json:"encoding"`
+}
+
+func normalizeConfig(cfg Config) Config {
+	if cfg.SessionTTL <= 0 {
+		cfg.SessionTTL = defaultTTL
+	}
+	if cfg.ReplayBytes <= 0 {
+		cfg.ReplayBytes = defaultReplay
+	}
+	cfg.Name = strings.TrimSpace(cfg.Name)
+	if cfg.Name == "" {
+		cfg.Name = "gbash"
+	}
+	cfg.Version = strings.TrimSpace(cfg.Version)
+	if cfg.Version == "" {
+		cfg.Version = "dev"
+	}
+	return cfg
+}
+
+func removeStaleUnixSocket(socketPath string) error {
+	info, err := os.Lstat(socketPath)
+	if err == nil {
+		if info.Mode()&os.ModeSocket == 0 {
+			return fmt.Errorf("server: path exists and is not a socket: %s", socketPath)
+		}
+		if removeErr := os.Remove(socketPath); removeErr != nil {
+			return fmt.Errorf("server: remove stale socket: %w", removeErr)
+		}
+		return nil
+	}
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return fmt.Errorf("server: stat socket path: %w", err)
+}
+
+func (s *serverState) reapLoop(done <-chan struct{}) {
+	tick := s.cfg.SessionTTL / 2
+	switch {
+	case tick <= 0:
+		tick = maxReaperTick
+	case tick < minReaperTick:
+		tick = minReaperTick
+	case tick > maxReaperTick:
+		tick = maxReaperTick
+	}
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.reapExpiredSessions(time.Now().UTC())
+		case <-done:
+			return
+		case <-s.ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *serverState) addConn(nc net.Conn) {
+	conn := &clientConn{
+		server: s,
+		id:     s.nextIDValue("conn"),
+		conn:   nc,
+		enc:    json.NewEncoder(nc),
+		dec:    json.NewDecoder(nc),
+		send:   make(chan *protocolMessage, 128),
+		closed: make(chan struct{}),
+	}
+
+	s.connsMu.Lock()
+	s.conns[conn.id] = conn
+	s.connsMu.Unlock()
+
+	go conn.writeLoop()
+	go conn.readLoop()
+}
+
+func (s *serverState) removeConn(id string) {
+	s.connsMu.Lock()
+	delete(s.conns, id)
+	s.connsMu.Unlock()
+}
+
+func (s *serverState) closeConnections() {
+	s.connsMu.RLock()
+	conns := make([]*clientConn, 0, len(s.conns))
+	for _, conn := range s.conns {
+		conns = append(conns, conn)
+	}
+	s.connsMu.RUnlock()
+	for _, conn := range conns {
+		conn.close()
+	}
+}
+
+func (s *serverState) sendToAll(msg *protocolMessage) {
+	s.connsMu.RLock()
+	conns := make([]*clientConn, 0, len(s.conns))
+	for _, conn := range s.conns {
+		conns = append(conns, conn)
+	}
+	s.connsMu.RUnlock()
+	for _, conn := range conns {
+		conn.sendMessage(msg)
+	}
+}
+
+func (s *serverState) nextIDValue(prefix string) string {
+	return fmt.Sprintf("%s-%06d", prefix, s.nextID.Add(1))
+}
+
+func (c *clientConn) writeLoop() {
+	for {
+		select {
+		case <-c.closed:
+			return
+		case msg := <-c.send:
+			if err := c.enc.Encode(msg); err != nil {
+				c.close()
+				return
+			}
+		}
+	}
+}
+
+func (c *clientConn) readLoop() {
+	defer c.close()
+	for {
+		var msg protocolMessage
+		if err := c.dec.Decode(&msg); err != nil {
+			return
+		}
+		if err := c.handleMessage(&msg); err != nil {
+			c.respondError(msg.ID, msg.SessionID, msg.StreamID, "INVALID_REQUEST", err.Error())
+		}
+	}
+}
+
+func (c *clientConn) handleMessage(msg *protocolMessage) error {
+	if msg == nil {
+		return fmt.Errorf("request is nil")
+	}
+	if strings.TrimSpace(msg.Version) != "" && strings.TrimSpace(msg.Version) != protocolVersion {
+		return fmt.Errorf("unsupported protocol version %q", msg.Version)
+	}
+	if strings.TrimSpace(msg.Type) != "request" {
+		return fmt.Errorf("message type must be request")
+	}
+	if strings.TrimSpace(msg.ID) == "" {
+		return fmt.Errorf("request id must not be empty")
+	}
+
+	switch msg.Method {
+	case "hello":
+		c.respondOK(msg.ID, "", "", helloResponse{
+			ServerName:    c.server.cfg.Name,
+			ServerVersion: c.server.cfg.Version,
+			Capabilities: helloCapabilities{
+				Binary:           c.server.cfg.Name,
+				Transport:        "unix",
+				Reconnect:        true,
+				FileSystemRPC:    false,
+				PTY:              false,
+				InteractiveShell: true,
+			},
+		})
+	case "ping":
+		c.respondOK(msg.ID, "", "", map[string]any{"pong": true})
+	case "session.create":
+		return c.handleSessionCreate(msg)
+	case "session.get":
+		return c.handleSessionGet(msg)
+	case "session.list":
+		return c.handleSessionList(msg)
+	case "session.destroy":
+		return c.handleSessionDestroy(msg)
+	case "exec.start":
+		return c.handleExecStart(msg)
+	case "shell.start":
+		return c.handleShellStart(msg)
+	case "stream.attach":
+		return c.handleStreamAttach(msg)
+	case "stream.detach":
+		return c.handleStreamDetach(msg)
+	case "stream.write":
+		return c.handleStreamWrite(msg)
+	case "stream.close":
+		return c.handleStreamClose(msg)
+	case "stream.cancel":
+		return c.handleStreamCancel(msg)
+	default:
+		c.respondError(msg.ID, msg.SessionID, msg.StreamID, "METHOD_NOT_FOUND", fmt.Sprintf("unknown method %q", msg.Method))
+	}
+	return nil
+}
+
+func (c *clientConn) close() {
+	c.once.Do(func() {
+		close(c.closed)
+		_ = c.conn.Close()
+		c.server.removeConn(c.id)
+		c.server.detachConnection(c.id)
+	})
+}
+
+func (c *clientConn) sendMessage(msg *protocolMessage) bool {
+	if msg == nil {
+		return false
+	}
+	select {
+	case <-c.closed:
+		return false
+	case c.send <- msg:
+		return true
+	}
+}
+
+func (c *clientConn) respondOK(id, sessionID, streamID string, payload any) {
+	ok := true
+	c.sendMessage(newProtocolMessage("response", id, sessionID, streamID, "", "", 0, &ok, payload, nil))
+}
+
+func (c *clientConn) respondError(id, sessionID, streamID, code, message string) {
+	ok := false
+	c.sendMessage(newProtocolMessage("response", id, sessionID, streamID, "", "", 0, &ok, nil, &protocolError{
+		Code:    code,
+		Message: message,
+	}))
+}
+
+func newProtocolMessage(msgType, id, sessionID, streamID, event, channel string, seq uint64, ok *bool, payload any, err *protocolError) *protocolMessage {
+	msg := &protocolMessage{
+		Version:   protocolVersion,
+		Type:      msgType,
+		ID:        id,
+		Event:     event,
+		SessionID: sessionID,
+		StreamID:  streamID,
+		Channel:   channel,
+		Seq:       seq,
+		OK:        ok,
+		Error:     err,
+	}
+	if payload != nil {
+		data, marshalErr := json.Marshal(payload)
+		if marshalErr == nil && string(data) != "null" {
+			msg.Payload = data
+		}
+	}
+	return msg
+}
+
+func decodePayload[T any](raw json.RawMessage) (T, error) {
+	var out T
+	if len(raw) == 0 {
+		return out, nil
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+func (c *clientConn) handleSessionCreate(msg *protocolMessage) error {
+	if _, err := decodePayload[sessionCreateRequest](msg.Payload); err != nil {
+		return fmt.Errorf("decode session.create payload: %w", err)
+	}
+	session, err := c.server.createSession()
+	if err != nil {
+		c.respondError(msg.ID, "", "", "INTERNAL", err.Error())
+		return nil
+	}
+	summary := session.summary()
+	c.respondOK(msg.ID, session.id, "", sessionDetailResponse{Session: summary})
+	c.server.sendToAll(session.eventMessage("session.created", summary))
+	return nil
+}
+
+func (c *clientConn) handleSessionGet(msg *protocolMessage) error {
+	session, err := c.server.lookupSession(msg.SessionID)
+	if err != nil {
+		c.respondError(msg.ID, msg.SessionID, "", "SESSION_NOT_FOUND", err.Error())
+		return nil
+	}
+	summary, streams := session.detail()
+	c.respondOK(msg.ID, session.id, "", sessionDetailResponse{Session: summary, Streams: streams})
+	return nil
+}
+
+func (c *clientConn) handleSessionList(msg *protocolMessage) error {
+	c.server.reapExpiredSessions(time.Now().UTC())
+	c.respondOK(msg.ID, "", "", sessionListResponse{Sessions: c.server.listSessions()})
+	return nil
+}
+
+func (c *clientConn) handleSessionDestroy(msg *protocolMessage) error {
+	if strings.TrimSpace(msg.SessionID) == "" {
+		return fmt.Errorf("session_id must not be empty")
+	}
+	session, err := c.server.destroySession(msg.SessionID)
+	if err != nil {
+		code := "INTERNAL"
+		switch {
+		case errors.Is(err, errSessionBusy):
+			code = "SESSION_BUSY"
+		case errors.Is(err, errSessionNotFound):
+			code = "SESSION_NOT_FOUND"
+		}
+		c.respondError(msg.ID, msg.SessionID, "", code, err.Error())
+		return nil
+	}
+	summary := session.summary()
+	c.respondOK(msg.ID, session.id, "", sessionDetailResponse{Session: summary})
+	c.server.sendToAll(newProtocolMessage("event", "", session.id, "", "session.updated", "", 0, nil, summary, nil))
+	return nil
+}
+
+func (c *clientConn) handleExecStart(msg *protocolMessage) error {
+	req, err := decodePayload[execStartRequest](msg.Payload)
+	if err != nil {
+		return fmt.Errorf("decode exec.start payload: %w", err)
+	}
+	session, err := c.server.lookupSession(msg.SessionID)
+	if err != nil {
+		c.respondError(msg.ID, msg.SessionID, "", "SESSION_NOT_FOUND", err.Error())
+		return nil
+	}
+	stream, startErr := session.startExec(c, &req)
+	if startErr != nil {
+		c.respondError(msg.ID, msg.SessionID, "", protocolErrorCode(startErr), startErr.Error())
+		return nil
+	}
+	c.respondOK(msg.ID, session.id, stream.id, streamStartResponse{
+		SessionID:      session.id,
+		StreamID:       stream.id,
+		Kind:           stream.kind,
+		State:          stream.state(),
+		WriterAttached: stream.writerAttached(c.id),
+	})
+	c.server.sendToAll(newProtocolMessage("event", "", session.id, "", "session.updated", "", 0, nil, session.summary(), nil))
+	stream.start()
+	return nil
+}
+
+func (c *clientConn) handleShellStart(msg *protocolMessage) error {
+	req, err := decodePayload[shellStartRequest](msg.Payload)
+	if err != nil {
+		return fmt.Errorf("decode shell.start payload: %w", err)
+	}
+	session, err := c.server.lookupSession(msg.SessionID)
+	if err != nil {
+		c.respondError(msg.ID, msg.SessionID, "", "SESSION_NOT_FOUND", err.Error())
+		return nil
+	}
+	stream, startErr := session.startShell(c, &req)
+	if startErr != nil {
+		c.respondError(msg.ID, msg.SessionID, "", protocolErrorCode(startErr), startErr.Error())
+		return nil
+	}
+	c.respondOK(msg.ID, session.id, stream.id, streamStartResponse{
+		SessionID:      session.id,
+		StreamID:       stream.id,
+		Kind:           stream.kind,
+		State:          stream.state(),
+		WriterAttached: stream.writerAttached(c.id),
+	})
+	c.server.sendToAll(newProtocolMessage("event", "", session.id, "", "session.updated", "", 0, nil, session.summary(), nil))
+	stream.start()
+	return nil
+}
+
+func (c *clientConn) handleStreamAttach(msg *protocolMessage) error {
+	req, err := decodePayload[streamAttachRequest](msg.Payload)
+	if err != nil {
+		return fmt.Errorf("decode stream.attach payload: %w", err)
+	}
+	session, stream, lookupErr := c.server.lookupStream(msg.SessionID, coalesce(req.StreamID, msg.StreamID))
+	if lookupErr != nil {
+		c.respondError(msg.ID, msg.SessionID, coalesce(req.StreamID, msg.StreamID), protocolErrorCode(lookupErr), lookupErr.Error())
+		return nil
+	}
+	resp, messages, attachErr := stream.attach(c, req.StdoutSeq, req.StderrSeq, req.Write)
+	if attachErr != nil {
+		c.respondError(msg.ID, session.id, stream.id, protocolErrorCode(attachErr), attachErr.Error())
+		return nil
+	}
+	c.respondOK(msg.ID, session.id, stream.id, resp)
+	for i := range messages {
+		c.sendMessage(messages[i])
+	}
+	return nil
+}
+
+func (c *clientConn) handleStreamDetach(msg *protocolMessage) error {
+	req, err := decodePayload[streamAttachRequest](msg.Payload)
+	if err != nil {
+		return fmt.Errorf("decode stream.detach payload: %w", err)
+	}
+	session, stream, lookupErr := c.server.lookupStream(msg.SessionID, coalesce(req.StreamID, msg.StreamID))
+	if lookupErr != nil {
+		c.respondError(msg.ID, msg.SessionID, coalesce(req.StreamID, msg.StreamID), protocolErrorCode(lookupErr), lookupErr.Error())
+		return nil
+	}
+	stream.detach(c.id)
+	c.respondOK(msg.ID, session.id, stream.id, streamAttachResponse{
+		SessionID:      session.id,
+		StreamID:       stream.id,
+		State:          stream.state(),
+		WriterAttached: false,
+	})
+	return nil
+}
+
+func (c *clientConn) handleStreamWrite(msg *protocolMessage) error {
+	req, err := decodePayload[streamDataRequest](msg.Payload)
+	if err != nil {
+		return fmt.Errorf("decode stream.write payload: %w", err)
+	}
+	session, stream, lookupErr := c.server.lookupStream(msg.SessionID, msg.StreamID)
+	if lookupErr != nil {
+		c.respondError(msg.ID, msg.SessionID, msg.StreamID, protocolErrorCode(lookupErr), lookupErr.Error())
+		return nil
+	}
+	if err := stream.writeStdin(c.id, req.Encoding, req.Data); err != nil {
+		c.respondError(msg.ID, session.id, stream.id, protocolErrorCode(err), err.Error())
+		return nil
+	}
+	c.respondOK(msg.ID, session.id, stream.id, map[string]any{"written": true})
+	return nil
+}
+
+func (c *clientConn) handleStreamClose(msg *protocolMessage) error {
+	session, stream, lookupErr := c.server.lookupStream(msg.SessionID, msg.StreamID)
+	if lookupErr != nil {
+		c.respondError(msg.ID, msg.SessionID, msg.StreamID, protocolErrorCode(lookupErr), lookupErr.Error())
+		return nil
+	}
+	if err := stream.closeStdin(c.id); err != nil {
+		c.respondError(msg.ID, session.id, stream.id, protocolErrorCode(err), err.Error())
+		return nil
+	}
+	c.respondOK(msg.ID, session.id, stream.id, map[string]any{"closed": true})
+	return nil
+}
+
+func (c *clientConn) handleStreamCancel(msg *protocolMessage) error {
+	session, stream, lookupErr := c.server.lookupStream(msg.SessionID, msg.StreamID)
+	if lookupErr != nil {
+		c.respondError(msg.ID, msg.SessionID, msg.StreamID, protocolErrorCode(lookupErr), lookupErr.Error())
+		return nil
+	}
+	stream.cancelStream()
+	c.respondOK(msg.ID, session.id, stream.id, map[string]any{"canceled": true})
+	return nil
+}
+
+func coalesce(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,563 @@
+package server_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ewhauser/gbash"
+	gbserver "github.com/ewhauser/gbash/server"
+)
+
+const testChunkBytes = 16 << 10
+
+type wireMessage struct {
+	Version   string          `json:"version"`
+	Type      string          `json:"type"`
+	ID        string          `json:"id"`
+	Method    string          `json:"method"`
+	Event     string          `json:"event"`
+	SessionID string          `json:"session_id"`
+	StreamID  string          `json:"stream_id"`
+	Channel   string          `json:"channel"`
+	Seq       uint64          `json:"seq"`
+	OK        *bool           `json:"ok"`
+	Payload   json.RawMessage `json:"payload"`
+	Error     *wireError      `json:"error"`
+}
+
+type wireError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type helloPayload struct {
+	ServerName    string `json:"server_name"`
+	ServerVersion string `json:"server_version"`
+	Capabilities  struct {
+		Binary           string `json:"binary"`
+		Transport        string `json:"transport"`
+		Reconnect        bool   `json:"reconnect"`
+		FileSystemRPC    bool   `json:"filesystem_rpc"`
+		PTY              bool   `json:"pty"`
+		InteractiveShell bool   `json:"interactive_shell"`
+	} `json:"capabilities"`
+}
+
+type sessionSummaryPayload struct {
+	Session struct {
+		SessionID      string `json:"session_id"`
+		State          string `json:"state"`
+		ActiveStreamID string `json:"active_stream_id"`
+	} `json:"session"`
+	Streams []struct {
+		StreamID string `json:"stream_id"`
+		Kind     string `json:"kind"`
+		State    string `json:"state"`
+	} `json:"streams"`
+}
+
+type sessionListPayload struct {
+	Sessions []struct {
+		SessionID string `json:"session_id"`
+		State     string `json:"state"`
+	} `json:"sessions"`
+}
+
+type streamStartPayload struct {
+	SessionID      string `json:"session_id"`
+	StreamID       string `json:"stream_id"`
+	Kind           string `json:"kind"`
+	State          string `json:"state"`
+	WriterAttached bool   `json:"writer_attached"`
+}
+
+type streamExitPayload struct {
+	Kind          string            `json:"kind"`
+	ExitCode      int               `json:"exit_code"`
+	ShellExited   bool              `json:"shell_exited"`
+	FinalEnv      map[string]string `json:"final_env"`
+	ControlStderr string            `json:"control_stderr"`
+}
+
+type streamDataPayload struct {
+	Data     string `json:"data"`
+	Encoding string `json:"encoding"`
+}
+
+type serverHandle struct {
+	socket string
+	cancel context.CancelFunc
+	errCh  chan error
+}
+
+type testClient struct {
+	t      *testing.T
+	conn   net.Conn
+	enc    *json.Encoder
+	dec    *json.Decoder
+	queue  []wireMessage
+	nextID atomic.Uint64
+}
+
+func TestServerSessionLifecycleAndExecStreaming(t *testing.T) {
+	srv := startServer(t, gbserver.Config{
+		Name:        "gbash",
+		Version:     "test",
+		SessionTTL:  time.Second,
+		ReplayBytes: 1 << 20,
+	})
+	client := dialClient(t, srv.socket)
+	defer client.Close()
+
+	hello := client.call("hello", "", "", map[string]any{"client_name": "test"})
+	if hello.OK == nil || !*hello.OK {
+		t.Fatalf("hello response = %#v, want ok", hello)
+	}
+	var helloPayload helloPayload
+	decodePayload(t, &hello, &helloPayload)
+	if helloPayload.Capabilities.Transport != "unix" || !helloPayload.Capabilities.Reconnect || helloPayload.Capabilities.FileSystemRPC || helloPayload.Capabilities.PTY {
+		t.Fatalf("hello capabilities = %+v, want unix reconnect without fs/pty", helloPayload.Capabilities)
+	}
+	if !helloPayload.Capabilities.InteractiveShell || helloPayload.Capabilities.Binary != "gbash" {
+		t.Fatalf("hello capabilities = %+v, want interactive gbash", helloPayload.Capabilities)
+	}
+
+	create := client.call("session.create", "", "", nil)
+	if create.OK == nil || !*create.OK {
+		t.Fatalf("session.create response = %#v, want ok", create)
+	}
+	var created sessionSummaryPayload
+	decodePayload(t, &create, &created)
+	sessionID := created.Session.SessionID
+	if sessionID == "" {
+		t.Fatalf("session.create payload = %+v, want session id", created)
+	}
+	sessionCreated := client.waitFor(2*time.Second, func(msg wireMessage) bool {
+		return msg.Type == "event" && msg.Event == "session.created" && msg.SessionID == sessionID
+	})
+	if sessionCreated.Event != "session.created" {
+		t.Fatalf("session created event = %#v", sessionCreated)
+	}
+
+	getResp := client.call("session.get", sessionID, "", nil)
+	if getResp.OK == nil || !*getResp.OK {
+		t.Fatalf("session.get response = %#v, want ok", getResp)
+	}
+
+	listResp := client.call("session.list", "", "", nil)
+	var listed sessionListPayload
+	decodePayload(t, &listResp, &listed)
+	if len(listed.Sessions) != 1 || listed.Sessions[0].SessionID != sessionID {
+		t.Fatalf("session.list payload = %+v, want only %s", listed, sessionID)
+	}
+
+	largeOutput := strings.Repeat("x", testChunkBytes+4096)
+	script := fmt.Sprintf("printf '%%s' '%s'\nprintf 'warn\\n' >&2\nexport MODE=debug\n", largeOutput)
+	execStart := client.call("exec.start", sessionID, "", map[string]any{
+		"script": script,
+		"stdin":  "closed",
+	})
+	if execStart.OK == nil || !*execStart.OK {
+		t.Fatalf("exec.start response = %#v, want ok", execStart)
+	}
+	var execPayload streamStartPayload
+	decodePayload(t, &execStart, &execPayload)
+	if execPayload.StreamID == "" || execPayload.Kind != "exec" {
+		t.Fatalf("exec.start payload = %+v, want exec stream", execPayload)
+	}
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	stdoutEvents := 0
+	for {
+		msg := client.waitFor(5*time.Second, func(msg wireMessage) bool {
+			if msg.StreamID != execPayload.StreamID {
+				return false
+			}
+			return msg.Event == "stream.data" || msg.Event == "stream.exit"
+		})
+		switch msg.Event {
+		case "stream.data":
+			var payload streamDataPayload
+			decodePayload(t, &msg, &payload)
+			data, err := base64.StdEncoding.DecodeString(payload.Data)
+			if err != nil {
+				t.Fatalf("decode stream data: %v", err)
+			}
+			switch msg.Channel {
+			case "stdout":
+				stdoutEvents++
+				stdout.Write(data)
+			case "stderr":
+				stderr.Write(data)
+			}
+		case "stream.exit":
+			var exit streamExitPayload
+			decodePayload(t, &msg, &exit)
+			if exit.ExitCode != 0 || exit.FinalEnv["MODE"] != "debug" {
+				t.Fatalf("stream.exit payload = %+v, want exit 0 and MODE=debug", exit)
+			}
+			if got, want := stdout.String(), largeOutput; got != want {
+				t.Fatalf("stdout = %q, want %q", got, want)
+			}
+			if got, want := stderr.String(), "warn\n"; got != want {
+				t.Fatalf("stderr = %q, want %q", got, want)
+			}
+			if stdoutEvents < 2 {
+				t.Fatalf("stdout events = %d, want stream split across multiple events", stdoutEvents)
+			}
+			goto destroy
+		}
+	}
+
+destroy:
+	destroyResp := client.call("session.destroy", sessionID, "", nil)
+	if destroyResp.OK == nil || !*destroyResp.OK {
+		t.Fatalf("session.destroy response = %#v, want ok", destroyResp)
+	}
+	listResp = client.call("session.list", "", "", nil)
+	decodePayload(t, &listResp, &listed)
+	if len(listed.Sessions) != 0 {
+		t.Fatalf("session.list payload = %+v, want empty after destroy", listed)
+	}
+}
+
+func TestServerShellConcurrentSessionsAndBusy(t *testing.T) {
+	srv := startServer(t, gbserver.Config{
+		Name:        "gbash",
+		Version:     "test",
+		SessionTTL:  time.Second,
+		ReplayBytes: 1 << 20,
+	})
+	client := dialClient(t, srv.socket)
+	defer client.Close()
+
+	session1 := mustCreateSession(t, client)
+	session2 := mustCreateSession(t, client)
+
+	shell1 := client.call("shell.start", session1, "", nil)
+	shell2 := client.call("shell.start", session2, "", nil)
+	var shell1Payload streamStartPayload
+	var shell2Payload streamStartPayload
+	decodePayload(t, &shell1, &shell1Payload)
+	decodePayload(t, &shell2, &shell2Payload)
+
+	waitForStreamOutput(t, client, shell1Payload.StreamID, "~$ ")
+	waitForStreamOutput(t, client, shell2Payload.StreamID, "~$ ")
+
+	busy := client.call("exec.start", session1, "", map[string]any{"script": "echo no\n"})
+	if busy.OK == nil || *busy.OK {
+		t.Fatalf("busy response = %#v, want error", busy)
+	}
+	if busy.Error == nil || busy.Error.Code != "SESSION_BUSY" {
+		t.Fatalf("busy error = %#v, want SESSION_BUSY", busy.Error)
+	}
+
+	writeResp := client.call("stream.write", session1, shell1Payload.StreamID, map[string]any{
+		"encoding": "base64",
+		"data":     base64.StdEncoding.EncodeToString([]byte("cd /tmp\nexport FOO=bar\npwd\necho $FOO\nexit\n")),
+	})
+	mustOK(t, &writeResp)
+	writeResp = client.call("stream.write", session2, shell2Payload.StreamID, map[string]any{
+		"encoding": "base64",
+		"data":     base64.StdEncoding.EncodeToString([]byte("echo two\nexit\n")),
+	})
+	mustOK(t, &writeResp)
+
+	output1, exit1 := collectStreamUntilExit(t, client, shell1Payload.StreamID)
+	output2, exit2 := collectStreamUntilExit(t, client, shell2Payload.StreamID)
+	if exit1.ExitCode != 0 || exit2.ExitCode != 0 {
+		t.Fatalf("shell exits = %+v %+v, want 0", exit1, exit2)
+	}
+	if !strings.Contains(output1, "/tmp\n") || !strings.Contains(output1, "bar\n") {
+		t.Fatalf("shell1 output = %q, want persisted cwd and env", output1)
+	}
+	if !strings.Contains(output2, "two\n") {
+		t.Fatalf("shell2 output = %q, want echoed data", output2)
+	}
+}
+
+func TestServerAttachReplayGapAndTTL(t *testing.T) {
+	srv := startServer(t, gbserver.Config{
+		Name:        "gbash",
+		Version:     "test",
+		SessionTTL:  250 * time.Millisecond,
+		ReplayBytes: 4000,
+	})
+	client1 := dialClient(t, srv.socket)
+	sessionID := mustCreateSession(t, client1)
+
+	shellStart := client1.call("shell.start", sessionID, "", nil)
+	var shellPayload streamStartPayload
+	decodePayload(t, &shellStart, &shellPayload)
+	waitForStreamOutput(t, client1, shellPayload.StreamID, "~$ ")
+	client1.Close()
+
+	client2 := dialClient(t, srv.socket)
+	defer client2.Close()
+	attach := client2.call("stream.attach", sessionID, "", map[string]any{
+		"stream_id":  shellPayload.StreamID,
+		"stdout_seq": 0,
+		"stderr_seq": 0,
+		"write":      true,
+	})
+	var attachPayload streamStartPayload
+	decodePayload(t, &attach, &attachPayload)
+	if !attachPayload.WriterAttached {
+		t.Fatalf("attach payload = %+v, want writer ownership", attachPayload)
+	}
+	replayed := waitForStreamOutput(t, client2, shellPayload.StreamID, "~$ ")
+	if !strings.Contains(replayed, "~$ ") {
+		t.Fatalf("replayed output = %q, want prompt replay", replayed)
+	}
+	writeResp := client2.call("stream.write", sessionID, shellPayload.StreamID, map[string]any{
+		"encoding": "base64",
+		"data":     base64.StdEncoding.EncodeToString([]byte("cd /tmp\nexport FOO=bar\npwd\necho $FOO\nexit\n")),
+	})
+	mustOK(t, &writeResp)
+	attachedOutput, attachedExit := collectStreamUntilExit(t, client2, shellPayload.StreamID)
+	if attachedExit.ExitCode != 0 || !strings.Contains(attachedOutput, "/tmp\n") || !strings.Contains(attachedOutput, "bar\n") {
+		t.Fatalf("attached output/exit = %q %+v, want replayed shell state", attachedOutput, attachedExit)
+	}
+
+	largeOutput := strings.Repeat("z", 34000)
+	execStart := client2.call("exec.start", sessionID, "", map[string]any{
+		"script": fmt.Sprintf("printf '%%s' '%s'\n", largeOutput),
+	})
+	var execPayload streamStartPayload
+	decodePayload(t, &execStart, &execPayload)
+	_, _ = collectStreamUntilExit(t, client2, execPayload.StreamID)
+
+	gap := client2.call("stream.attach", sessionID, "", map[string]any{
+		"stream_id":  execPayload.StreamID,
+		"stdout_seq": 1,
+	})
+	if gap.OK == nil || *gap.OK {
+		t.Fatalf("gap response = %#v, want error", gap)
+	}
+	if gap.Error == nil || gap.Error.Code != "REPLAY_GAP" {
+		t.Fatalf("gap error = %#v, want REPLAY_GAP", gap.Error)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	listResp := client2.call("session.list", "", "", nil)
+	var listed sessionListPayload
+	decodePayload(t, &listResp, &listed)
+	if len(listed.Sessions) != 0 {
+		t.Fatalf("session.list payload = %+v, want empty after ttl expiry", listed)
+	}
+	getResp := client2.call("session.get", sessionID, "", nil)
+	if getResp.OK == nil || *getResp.OK {
+		t.Fatalf("session.get after ttl = %#v, want error", getResp)
+	}
+	if getResp.Error == nil || getResp.Error.Code != "SESSION_NOT_FOUND" {
+		t.Fatalf("session.get error = %#v, want SESSION_NOT_FOUND", getResp.Error)
+	}
+}
+
+func startServer(t *testing.T, cfg gbserver.Config, opts ...gbash.Option) *serverHandle {
+	t.Helper()
+
+	rt, err := gbash.New(opts...)
+	if err != nil {
+		t.Fatalf("gbash.New() error = %v", err)
+	}
+	cfg.Runtime = rt
+
+	ctx, cancel := context.WithCancel(context.Background())
+	socket := filepath.Join(os.TempDir(), fmt.Sprintf("gbash-server-%d.sock", time.Now().UnixNano()))
+	t.Cleanup(func() { _ = os.Remove(socket) })
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- gbserver.ListenAndServeUnix(ctx, socket, cfg)
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		select {
+		case err := <-errCh:
+			cancel()
+			t.Fatalf("server exited before socket became ready: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("timed out waiting for server socket")
+		}
+		conn, err := net.DialTimeout("unix", socket, 50*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	handle := &serverHandle{socket: socket, cancel: cancel, errCh: errCh}
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("server exited with error: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for server shutdown")
+		}
+	})
+	return handle
+}
+
+func dialClient(t *testing.T, socket string) *testClient {
+	t.Helper()
+
+	conn, err := net.DialTimeout("unix", socket, 5*time.Second)
+	if err != nil {
+		t.Fatalf("DialTimeout(%s) error = %v", socket, err)
+	}
+	return &testClient{
+		t:    t,
+		conn: conn,
+		enc:  json.NewEncoder(conn),
+		dec:  json.NewDecoder(conn),
+	}
+}
+
+func (c *testClient) Close() {
+	_ = c.conn.Close()
+}
+
+func (c *testClient) call(method, sessionID, streamID string, payload any) wireMessage {
+	c.t.Helper()
+
+	id := fmt.Sprintf("req-%d", c.nextID.Add(1))
+	msg := map[string]any{
+		"version":    "1",
+		"type":       "request",
+		"id":         id,
+		"method":     method,
+		"session_id": sessionID,
+		"stream_id":  streamID,
+		"payload":    payload,
+	}
+	if err := c.enc.Encode(msg); err != nil {
+		c.t.Fatalf("Encode(%s) error = %v", method, err)
+	}
+	return c.waitFor(5*time.Second, func(msg wireMessage) bool {
+		return msg.Type == "response" && msg.ID == id
+	})
+}
+
+func (c *testClient) waitFor(timeout time.Duration, match func(wireMessage) bool) wireMessage {
+	c.t.Helper()
+
+	for i := range c.queue {
+		if match(c.queue[i]) {
+			msg := c.queue[i]
+			c.queue = append(c.queue[:i], c.queue[i+1:]...)
+			return msg
+		}
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if time.Now().After(deadline) {
+			c.t.Fatal("timed out waiting for protocol message")
+		}
+		if err := c.conn.SetReadDeadline(deadline); err != nil {
+			c.t.Fatalf("SetReadDeadline() error = %v", err)
+		}
+		var msg wireMessage
+		if err := c.dec.Decode(&msg); err != nil {
+			c.t.Fatalf("Decode() error = %v", err)
+		}
+		if match(msg) {
+			return msg
+		}
+		c.queue = append(c.queue, msg)
+	}
+}
+
+func waitForStreamOutput(t *testing.T, client *testClient, streamID, want string) string {
+	t.Helper()
+
+	var out strings.Builder
+	for {
+		msg := client.waitFor(5*time.Second, func(msg wireMessage) bool {
+			return msg.Type == "event" && msg.StreamID == streamID && msg.Event == "stream.data"
+		})
+		var payload streamDataPayload
+		decodePayload(t, &msg, &payload)
+		data, err := base64.StdEncoding.DecodeString(payload.Data)
+		if err != nil {
+			t.Fatalf("DecodeString() error = %v", err)
+		}
+		out.Write(data)
+		if strings.Contains(out.String(), want) {
+			return out.String()
+		}
+	}
+}
+
+func collectStreamUntilExit(t *testing.T, client *testClient, streamID string) (string, streamExitPayload) {
+	t.Helper()
+
+	var out strings.Builder
+	for {
+		msg := client.waitFor(5*time.Second, func(msg wireMessage) bool {
+			if msg.StreamID != streamID || msg.Type != "event" {
+				return false
+			}
+			return msg.Event == "stream.data" || msg.Event == "stream.exit"
+		})
+		switch msg.Event {
+		case "stream.data":
+			var payload streamDataPayload
+			decodePayload(t, &msg, &payload)
+			data, err := base64.StdEncoding.DecodeString(payload.Data)
+			if err != nil {
+				t.Fatalf("DecodeString() error = %v", err)
+			}
+			out.Write(data)
+		case "stream.exit":
+			var payload streamExitPayload
+			decodePayload(t, &msg, &payload)
+			return out.String(), payload
+		}
+	}
+}
+
+func mustCreateSession(t *testing.T, client *testClient) string {
+	t.Helper()
+
+	resp := client.call("session.create", "", "", nil)
+	mustOK(t, &resp)
+	var payload sessionSummaryPayload
+	decodePayload(t, &resp, &payload)
+	return payload.Session.SessionID
+}
+
+func mustOK(t *testing.T, msg *wireMessage) {
+	t.Helper()
+	if msg == nil || msg.OK == nil || !*msg.OK {
+		t.Fatalf("response = %#v, want ok", msg)
+	}
+}
+
+func decodePayload[T any](t *testing.T, msg *wireMessage, out *T) {
+	t.Helper()
+	if msg == nil || len(msg.Payload) == 0 {
+		return
+	}
+	if err := json.Unmarshal(msg.Payload, out); err != nil {
+		t.Fatalf("Unmarshal(payload) error = %v; raw=%s", err, string(msg.Payload))
+	}
+}

--- a/server/session.go
+++ b/server/session.go
@@ -1,0 +1,907 @@
+package server
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ewhauser/gbash"
+)
+
+const streamChunkBytes = 16 << 10
+
+var (
+	errInvalidArgument    = errors.New("invalid argument")
+	errSessionNotFound    = errors.New("session not found")
+	errSessionBusy        = errors.New("session is busy")
+	errStreamNotFound     = errors.New("stream not found")
+	errStreamClosed       = errors.New("stream is closed")
+	errStreamWriterBusy   = errors.New("stream stdin writer is busy")
+	errStreamWriterNeeded = errors.New("stream stdin owner required")
+	errReplayGap          = errors.New("requested replay is no longer available")
+)
+
+type sessionSummary struct {
+	SessionID      string `json:"session_id"`
+	State          string `json:"state"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
+	ExpiresAt      string `json:"expires_at,omitempty"`
+	ActiveStreamID string `json:"active_stream_id,omitempty"`
+	StreamCount    int    `json:"stream_count"`
+}
+
+type streamSummary struct {
+	StreamID   string `json:"stream_id"`
+	Kind       string `json:"kind"`
+	State      string `json:"state"`
+	CreatedAt  string `json:"created_at"`
+	UpdatedAt  string `json:"updated_at"`
+	StartedAt  string `json:"started_at"`
+	FinishedAt string `json:"finished_at,omitempty"`
+}
+
+type streamExitPayload struct {
+	Kind          string            `json:"kind"`
+	ExitCode      int               `json:"exit_code"`
+	ShellExited   bool              `json:"shell_exited,omitempty"`
+	FinalEnv      map[string]string `json:"final_env,omitempty"`
+	ControlStderr string            `json:"control_stderr,omitempty"`
+}
+
+type streamErrorPayload struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type streamDataPayload struct {
+	Data     string `json:"data"`
+	Encoding string `json:"encoding"`
+}
+
+type streamAttachment struct {
+	conn  *clientConn
+	write bool
+}
+
+type serverSession struct {
+	server *serverState
+	id     string
+	shell  *gbash.Session
+
+	createdAt time.Time
+	updatedAt time.Time
+	idleSince time.Time
+
+	mu             sync.Mutex
+	streams        map[string]*serverStream
+	activeStreamID string
+}
+
+type serverStream struct {
+	session *serverSession
+	id      string
+	kind    string
+
+	createdAt  time.Time
+	startedAt  time.Time
+	updatedAt  time.Time
+	finishedAt time.Time
+
+	mu          sync.Mutex
+	running     bool
+	stdin       io.WriteCloser
+	stdinClosed bool
+	cancel      context.CancelFunc
+
+	attachments map[string]*streamAttachment
+	writerOwner string
+
+	stdout replayBuffer
+	stderr replayBuffer
+
+	exitPayload *streamExitPayload
+
+	startOnce sync.Once
+	startFn   func()
+}
+
+type replayChunk struct {
+	seq  uint64
+	data []byte
+}
+
+type replayBuffer struct {
+	limit  int
+	size   int
+	next   uint64
+	chunks []replayChunk
+}
+
+func protocolErrorCode(err error) string {
+	switch {
+	case errors.Is(err, errInvalidArgument):
+		return "INVALID_ARGUMENT"
+	case errors.Is(err, errSessionNotFound):
+		return "SESSION_NOT_FOUND"
+	case errors.Is(err, errSessionBusy):
+		return "SESSION_BUSY"
+	case errors.Is(err, errStreamNotFound):
+		return "STREAM_NOT_FOUND"
+	case errors.Is(err, errStreamClosed):
+		return "STREAM_CLOSED"
+	case errors.Is(err, errStreamWriterBusy):
+		return "STREAM_STDIN_BUSY"
+	case errors.Is(err, errStreamWriterNeeded):
+		return "STREAM_STDIN_OWNER_REQUIRED"
+	case errors.Is(err, errReplayGap):
+		return "REPLAY_GAP"
+	default:
+		return "INTERNAL"
+	}
+}
+
+func (s *serverState) createSession() (*serverSession, error) {
+	s.reapExpiredSessions(time.Now().UTC())
+
+	sessionShell, err := s.cfg.Runtime.NewSession(s.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create gbash session: %w", err)
+	}
+	now := time.Now().UTC()
+	session := &serverSession{
+		server:    s,
+		id:        s.nextIDValue("sess"),
+		shell:     sessionShell,
+		createdAt: now,
+		updatedAt: now,
+		idleSince: now,
+		streams:   make(map[string]*serverStream),
+	}
+
+	s.sessionsMu.Lock()
+	s.sessions[session.id] = session
+	s.sessionsMu.Unlock()
+	return session, nil
+}
+
+func (s *serverState) lookupSession(id string) (*serverSession, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, fmt.Errorf("%w: session_id must not be empty", errInvalidArgument)
+	}
+	s.reapExpiredSessions(time.Now().UTC())
+	s.sessionsMu.Lock()
+	defer s.sessionsMu.Unlock()
+	session, ok := s.sessions[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", errSessionNotFound, id)
+	}
+	return session, nil
+}
+
+func (s *serverState) listSessions() []sessionSummary {
+	s.sessionsMu.Lock()
+	sessions := make([]*serverSession, 0, len(s.sessions))
+	for _, session := range s.sessions {
+		sessions = append(sessions, session)
+	}
+	s.sessionsMu.Unlock()
+
+	out := make([]sessionSummary, 0, len(sessions))
+	for _, session := range sessions {
+		out = append(out, session.summary())
+	}
+	slices.SortFunc(out, func(a, b sessionSummary) int {
+		return strings.Compare(a.SessionID, b.SessionID)
+	})
+	return out
+}
+
+func (s *serverState) destroySession(id string) (*serverSession, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, fmt.Errorf("%w: session_id must not be empty", errInvalidArgument)
+	}
+
+	s.sessionsMu.Lock()
+	session, ok := s.sessions[id]
+	if !ok {
+		s.sessionsMu.Unlock()
+		return nil, fmt.Errorf("%w: %s", errSessionNotFound, id)
+	}
+	if session.busy() {
+		s.sessionsMu.Unlock()
+		return nil, fmt.Errorf("%w: %s", errSessionBusy, id)
+	}
+	delete(s.sessions, id)
+	s.sessionsMu.Unlock()
+
+	session.destroy()
+	return session, nil
+}
+
+func (s *serverState) lookupStream(sessionID, streamID string) (*serverSession, *serverStream, error) {
+	session, err := s.lookupSession(sessionID)
+	if err != nil {
+		return nil, nil, err
+	}
+	streamID = strings.TrimSpace(streamID)
+	if streamID == "" {
+		return nil, nil, fmt.Errorf("%w: stream_id must not be empty", errInvalidArgument)
+	}
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	stream, ok := session.streams[streamID]
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: %s", errStreamNotFound, streamID)
+	}
+	return session, stream, nil
+}
+
+func (s *serverState) reapExpiredSessions(now time.Time) {
+	s.sessionsMu.Lock()
+	expired := make([]*serverSession, 0)
+	for id, session := range s.sessions {
+		if session.expired(now) {
+			delete(s.sessions, id)
+			expired = append(expired, session)
+		}
+	}
+	s.sessionsMu.Unlock()
+
+	for _, session := range expired {
+		session.destroy()
+	}
+}
+
+func (s *serverState) detachConnection(connID string) {
+	s.sessionsMu.Lock()
+	sessions := make([]*serverSession, 0, len(s.sessions))
+	for _, session := range s.sessions {
+		sessions = append(sessions, session)
+	}
+	s.sessionsMu.Unlock()
+
+	for _, session := range sessions {
+		session.detachConnection(connID)
+	}
+}
+
+func (s *serverSession) summary() sessionSummary {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	summary := sessionSummary{
+		SessionID:      s.id,
+		State:          "idle",
+		CreatedAt:      formatTime(s.createdAt),
+		UpdatedAt:      formatTime(s.updatedAt),
+		ActiveStreamID: s.activeStreamID,
+		StreamCount:    len(s.streams),
+	}
+	if s.activeStreamID != "" {
+		summary.State = "running"
+	}
+	if s.idleSince.IsZero() {
+		return summary
+	}
+	summary.ExpiresAt = formatTime(s.idleSince.Add(s.server.cfg.SessionTTL))
+	return summary
+}
+
+func (s *serverSession) detail() (sessionSummary, []streamSummary) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	streams := make([]streamSummary, 0, len(s.streams))
+	for _, stream := range s.streams {
+		streams = append(streams, stream.summary())
+	}
+	slices.SortFunc(streams, func(a, b streamSummary) int {
+		return strings.Compare(a.StreamID, b.StreamID)
+	})
+	return s.summaryLocked(), streams
+}
+
+func (s *serverSession) summaryLocked() sessionSummary {
+	summary := sessionSummary{
+		SessionID:      s.id,
+		State:          "idle",
+		CreatedAt:      formatTime(s.createdAt),
+		UpdatedAt:      formatTime(s.updatedAt),
+		ActiveStreamID: s.activeStreamID,
+		StreamCount:    len(s.streams),
+	}
+	if s.activeStreamID != "" {
+		summary.State = "running"
+	}
+	if !s.idleSince.IsZero() {
+		summary.ExpiresAt = formatTime(s.idleSince.Add(s.server.cfg.SessionTTL))
+	}
+	return summary
+}
+
+func (s *serverSession) eventMessage(event string, payload any) *protocolMessage {
+	return newProtocolMessage("event", "", s.id, "", event, "", 0, nil, payload, nil)
+}
+
+func (s *serverSession) startExec(conn *clientConn, req *execStartRequest) (*serverStream, error) {
+	if req == nil {
+		req = &execStartRequest{}
+	}
+	stdinMode := strings.TrimSpace(req.Stdin)
+	if stdinMode == "" {
+		stdinMode = "closed"
+	}
+	if stdinMode != "closed" && stdinMode != "stream" {
+		return nil, fmt.Errorf("%w: unsupported exec stdin mode %q", errInvalidArgument, req.Stdin)
+	}
+
+	stream := s.newStream("exec")
+	if stream == nil {
+		return nil, fmt.Errorf("%w: %s", errSessionBusy, s.id)
+	}
+
+	ctx, cancel := context.WithCancel(s.server.ctx)
+	stream.cancel = cancel
+	if stdinMode == "stream" {
+		reader, writer := io.Pipe()
+		stream.stdin = writer
+		stream.attachments[conn.id] = &streamAttachment{conn: conn, write: true}
+		stream.writerOwner = conn.id
+		stream.startFn = func() {
+			go stream.exec(ctx, req, reader)
+		}
+		return stream, nil
+	}
+
+	stream.attachments[conn.id] = &streamAttachment{conn: conn}
+	stream.startFn = func() {
+		go stream.exec(ctx, req, nil)
+	}
+	return stream, nil
+}
+
+func (s *serverSession) startShell(conn *clientConn, req *shellStartRequest) (*serverStream, error) {
+	if req == nil {
+		req = &shellStartRequest{}
+	}
+	stream := s.newStream("shell")
+	if stream == nil {
+		return nil, fmt.Errorf("%w: %s", errSessionBusy, s.id)
+	}
+
+	ctx, cancel := context.WithCancel(s.server.ctx)
+	stream.cancel = cancel
+	reader, writer := io.Pipe()
+	stream.stdin = writer
+	stream.attachments[conn.id] = &streamAttachment{conn: conn, write: true}
+	stream.writerOwner = conn.id
+	stream.startFn = func() {
+		go stream.shellInteract(ctx, req, reader)
+	}
+	return stream, nil
+}
+
+func (s *serverSession) newStream(kind string) *serverStream {
+	now := time.Now().UTC()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.activeStreamID != "" {
+		if active, ok := s.streams[s.activeStreamID]; ok && active.running {
+			return nil
+		}
+	}
+
+	stream := &serverStream{
+		session:     s,
+		id:          s.server.nextIDValue("stream"),
+		kind:        kind,
+		createdAt:   now,
+		startedAt:   now,
+		updatedAt:   now,
+		running:     true,
+		attachments: make(map[string]*streamAttachment),
+		stdout: replayBuffer{
+			limit: s.server.cfg.ReplayBytes,
+			next:  1,
+		},
+		stderr: replayBuffer{
+			limit: s.server.cfg.ReplayBytes,
+			next:  1,
+		},
+	}
+	s.streams[stream.id] = stream
+	s.activeStreamID = stream.id
+	s.updatedAt = now
+	s.idleSince = time.Time{}
+	return stream
+}
+
+func (s *serverSession) busy() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.activeStreamID == "" {
+		return false
+	}
+	stream, ok := s.streams[s.activeStreamID]
+	return ok && stream.running
+}
+
+func (s *serverSession) expired(now time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.activeStreamID != "" {
+		if stream, ok := s.streams[s.activeStreamID]; ok && stream.running {
+			return false
+		}
+	}
+	if s.idleSince.IsZero() || s.server.cfg.SessionTTL <= 0 {
+		return false
+	}
+	return !now.Before(s.idleSince.Add(s.server.cfg.SessionTTL))
+}
+
+func (s *serverSession) destroy() {
+	s.mu.Lock()
+	streams := make([]*serverStream, 0, len(s.streams))
+	for _, stream := range s.streams {
+		streams = append(streams, stream)
+	}
+	s.streams = nil
+	s.activeStreamID = ""
+	s.updatedAt = time.Now().UTC()
+	s.idleSince = s.updatedAt
+	s.mu.Unlock()
+
+	for _, stream := range streams {
+		stream.shutdown()
+	}
+}
+
+func (s *serverSession) detachConnection(connID string) {
+	s.mu.Lock()
+	streams := make([]*serverStream, 0, len(s.streams))
+	for _, stream := range s.streams {
+		streams = append(streams, stream)
+	}
+	s.mu.Unlock()
+
+	for _, stream := range streams {
+		stream.detach(connID)
+	}
+}
+
+func (s *serverSession) markStreamFinished(streamID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.activeStreamID == streamID {
+		s.activeStreamID = ""
+	}
+	now := time.Now().UTC()
+	s.updatedAt = now
+	s.idleSince = now
+}
+
+func (s *serverStream) state() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stateLocked()
+}
+
+func (s *serverStream) stateLocked() string {
+	if s.running {
+		return "running"
+	}
+	return "exited"
+}
+
+func (s *serverStream) writerAttached(connID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.writerOwner == connID
+}
+
+func (s *serverStream) summary() streamSummary {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return streamSummary{
+		StreamID:   s.id,
+		Kind:       s.kind,
+		State:      s.stateLocked(),
+		CreatedAt:  formatTime(s.createdAt),
+		UpdatedAt:  formatTime(s.updatedAt),
+		StartedAt:  formatTime(s.startedAt),
+		FinishedAt: formatTime(s.finishedAt),
+	}
+}
+
+func (s *serverStream) attach(conn *clientConn, stdoutSeq, stderrSeq uint64, write bool) (streamAttachResponse, []*protocolMessage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stdoutReplay, err := s.stdout.replay(stdoutSeq)
+	if err != nil {
+		return streamAttachResponse{}, nil, fmt.Errorf("%w: stdout replay for %s", errReplayGap, s.id)
+	}
+	stderrReplay, err := s.stderr.replay(stderrSeq)
+	if err != nil {
+		return streamAttachResponse{}, nil, fmt.Errorf("%w: stderr replay for %s", errReplayGap, s.id)
+	}
+
+	if write {
+		switch {
+		case !s.running || s.stdin == nil || s.stdinClosed:
+			return streamAttachResponse{}, nil, fmt.Errorf("%w: %s", errStreamClosed, s.id)
+		case s.writerOwner != "" && s.writerOwner != conn.id:
+			return streamAttachResponse{}, nil, fmt.Errorf("%w: %s", errStreamWriterBusy, s.id)
+		default:
+			s.writerOwner = conn.id
+		}
+	}
+	if s.running {
+		attachment := &streamAttachment{conn: conn, write: write}
+		if existing, ok := s.attachments[conn.id]; ok && existing.write {
+			attachment.write = true
+		}
+		s.attachments[conn.id] = attachment
+	}
+
+	messages := make([]*protocolMessage, 0, len(stdoutReplay)+len(stderrReplay)+1)
+	messages = append(messages, replayMessages(s.session.id, s.id, "stdout", stdoutReplay)...)
+	messages = append(messages, replayMessages(s.session.id, s.id, "stderr", stderrReplay)...)
+	if !s.running && s.exitPayload != nil {
+		messages = append(messages, newProtocolMessage("event", "", s.session.id, s.id, "stream.exit", "", 0, nil, s.exitPayload, nil))
+	}
+
+	return streamAttachResponse{
+		SessionID:      s.session.id,
+		StreamID:       s.id,
+		State:          s.stateLocked(),
+		WriterAttached: s.writerOwner == conn.id,
+	}, messages, nil
+}
+
+func (s *serverStream) detach(connID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.attachments, connID)
+	if s.writerOwner == connID {
+		s.writerOwner = ""
+	}
+}
+
+func (s *serverStream) writeStdin(connID, encoding, data string) error {
+	s.mu.Lock()
+	writer := s.stdin
+	closed := s.stdinClosed
+	isOwner := s.writerOwner == connID
+	s.mu.Unlock()
+
+	if !isOwner {
+		return fmt.Errorf("%w: %s", errStreamWriterNeeded, s.id)
+	}
+	if writer == nil || closed {
+		return fmt.Errorf("%w: %s", errStreamClosed, s.id)
+	}
+
+	encoding = strings.TrimSpace(encoding)
+	if encoding == "" {
+		encoding = "base64"
+	}
+	if encoding != "base64" {
+		return fmt.Errorf("%w: unsupported encoding %q", errInvalidArgument, encoding)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return fmt.Errorf("%w: decode base64 stdin: %v", errInvalidArgument, err)
+	}
+	if len(decoded) == 0 {
+		return nil
+	}
+	_, err = writer.Write(decoded)
+	return err
+}
+
+func (s *serverStream) closeStdin(connID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.writerOwner != connID {
+		return fmt.Errorf("%w: %s", errStreamWriterNeeded, s.id)
+	}
+	if s.stdin == nil || s.stdinClosed {
+		return fmt.Errorf("%w: %s", errStreamClosed, s.id)
+	}
+	s.stdinClosed = true
+	s.writerOwner = ""
+	return s.stdin.Close()
+}
+
+func (s *serverStream) cancelStream() {
+	s.mu.Lock()
+	cancel := s.cancel
+	stdin := s.stdin
+	alreadyClosed := s.stdinClosed
+	s.stdinClosed = true
+	s.writerOwner = ""
+	s.mu.Unlock()
+
+	if pipeWriter, ok := stdin.(*io.PipeWriter); ok && !alreadyClosed {
+		_ = pipeWriter.CloseWithError(context.Canceled)
+	} else if stdin != nil && !alreadyClosed {
+		_ = stdin.Close()
+	}
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (s *serverStream) shutdown() {
+	s.cancelStream()
+	s.mu.Lock()
+	s.attachments = nil
+	s.mu.Unlock()
+}
+
+func (s *serverStream) start() {
+	s.startOnce.Do(func() {
+		if s.startFn != nil {
+			s.startFn()
+		}
+	})
+}
+
+func (s *serverStream) exec(ctx context.Context, req *execStartRequest, stdin io.Reader) {
+	if req == nil {
+		req = &execStartRequest{}
+	}
+	stdout := &streamChunkWriter{stream: s, channel: "stdout"}
+	stderr := &streamChunkWriter{stream: s, channel: "stderr"}
+	result, err := s.session.shell.Exec(ctx, &gbash.ExecutionRequest{
+		Name:           req.Name,
+		Script:         req.Script,
+		Args:           append([]string(nil), req.Args...),
+		StartupOptions: append([]string(nil), req.StartupOptions...),
+		Env:            copyStringMap(req.Env),
+		WorkDir:        req.WorkDir,
+		ReplaceEnv:     req.ReplaceEnv,
+		Timeout:        durationFromMillis(req.TimeoutMs),
+		Stdin:          stdin,
+		Stdout:         stdout,
+		Stderr:         stderr,
+	})
+	s.finishExec(result, err)
+}
+
+func (s *serverStream) shellInteract(ctx context.Context, req *shellStartRequest, stdin io.Reader) {
+	if req == nil {
+		req = &shellStartRequest{}
+	}
+	stdout := &streamChunkWriter{stream: s, channel: "stdout"}
+	stderr := &streamChunkWriter{stream: s, channel: "stderr"}
+	result, err := s.session.shell.Interact(ctx, &gbash.InteractiveRequest{
+		Name:           req.Name,
+		Args:           append([]string(nil), req.Args...),
+		StartupOptions: append([]string(nil), req.StartupOptions...),
+		Env:            copyStringMap(req.Env),
+		WorkDir:        req.WorkDir,
+		ReplaceEnv:     req.ReplaceEnv,
+		Stdin:          stdin,
+		Stdout:         stdout,
+		Stderr:         stderr,
+	})
+	s.finishShell(result, err)
+}
+
+func (s *serverStream) finishExec(result *gbash.ExecutionResult, err error) {
+	if err != nil && result == nil {
+		s.emitError(streamErrorPayload{Code: "INTERNAL", Message: err.Error()})
+		s.finish(streamExitPayload{Kind: s.kind, ExitCode: 1}, false)
+		return
+	}
+	if err != nil && !errors.Is(err, context.Canceled) {
+		s.emitError(streamErrorPayload{Code: "INTERNAL", Message: err.Error()})
+	}
+	payload := streamExitPayload{Kind: s.kind}
+	if result != nil {
+		payload.ExitCode = result.ExitCode
+		payload.ShellExited = result.ShellExited
+		payload.FinalEnv = copyStringMap(result.FinalEnv)
+		payload.ControlStderr = strings.TrimSpace(result.ControlStderr)
+	}
+	if errors.Is(err, context.Canceled) {
+		payload.ExitCode = 130
+		payload.ControlStderr = "execution canceled"
+	}
+	s.finish(payload, true)
+}
+
+func (s *serverStream) finishShell(result *gbash.InteractiveResult, err error) {
+	if err != nil && !errors.Is(err, context.Canceled) {
+		s.emitError(streamErrorPayload{Code: "INTERNAL", Message: err.Error()})
+	}
+	payload := streamExitPayload{Kind: s.kind}
+	if result != nil {
+		payload.ExitCode = result.ExitCode
+	}
+	if errors.Is(err, context.Canceled) {
+		payload.ExitCode = 130
+	}
+	s.finish(payload, true)
+}
+
+func (s *serverStream) finish(payload streamExitPayload, broadcastSession bool) {
+	s.mu.Lock()
+	if !s.finishedAt.IsZero() {
+		s.mu.Unlock()
+		return
+	}
+	s.running = false
+	s.updatedAt = time.Now().UTC()
+	s.finishedAt = s.updatedAt
+	s.exitPayload = &payload
+	s.writerOwner = ""
+	stdin := s.stdin
+	s.stdinClosed = true
+	attachments := make([]*clientConn, 0, len(s.attachments))
+	for _, attachment := range s.attachments {
+		attachments = append(attachments, attachment.conn)
+	}
+	s.mu.Unlock()
+
+	if stdin != nil {
+		_ = stdin.Close()
+	}
+	s.session.markStreamFinished(s.id)
+	event := newProtocolMessage("event", "", s.session.id, s.id, "stream.exit", "", 0, nil, payload, nil)
+	for _, conn := range attachments {
+		conn.sendMessage(event)
+	}
+	if broadcastSession {
+		s.session.server.sendToAll(newProtocolMessage("event", "", s.session.id, "", "session.updated", "", 0, nil, s.session.summary(), nil))
+	}
+}
+
+func (s *serverStream) emitData(channel string, p []byte) {
+	if len(p) == 0 {
+		return
+	}
+
+	s.mu.Lock()
+	if channel == "stdout" {
+		_ = s.stdout.append(p)
+	} else {
+		_ = s.stderr.append(p)
+	}
+	var seq uint64
+	if channel == "stdout" {
+		seq = s.stdout.next - 1
+	} else {
+		seq = s.stderr.next - 1
+	}
+	attachments := make([]*clientConn, 0, len(s.attachments))
+	for _, attachment := range s.attachments {
+		attachments = append(attachments, attachment.conn)
+	}
+	s.updatedAt = time.Now().UTC()
+	s.mu.Unlock()
+
+	msg := newProtocolMessage("event", "", s.session.id, s.id, "stream.data", channel, seq, nil, streamDataPayload{
+		Data:     base64.StdEncoding.EncodeToString(append([]byte(nil), p...)),
+		Encoding: "base64",
+	}, nil)
+	for _, conn := range attachments {
+		conn.sendMessage(msg)
+	}
+}
+
+func (s *serverStream) emitError(payload streamErrorPayload) {
+	s.mu.Lock()
+	attachments := make([]*clientConn, 0, len(s.attachments))
+	for _, attachment := range s.attachments {
+		attachments = append(attachments, attachment.conn)
+	}
+	s.mu.Unlock()
+
+	msg := newProtocolMessage("event", "", s.session.id, s.id, "stream.error", "", 0, nil, payload, nil)
+	for _, conn := range attachments {
+		conn.sendMessage(msg)
+	}
+}
+
+func replayMessages(sessionID, streamID, channel string, chunks []replayChunk) []*protocolMessage {
+	messages := make([]*protocolMessage, 0, len(chunks))
+	for _, chunk := range chunks {
+		messages = append(messages, newProtocolMessage("event", "", sessionID, streamID, "stream.data", channel, chunk.seq, nil, streamDataPayload{
+			Data:     base64.StdEncoding.EncodeToString(chunk.data),
+			Encoding: "base64",
+		}, nil))
+	}
+	return messages
+}
+
+func (b *replayBuffer) append(p []byte) uint64 {
+	copied := append([]byte(nil), p...)
+	seq := b.next
+	b.next++
+	b.chunks = append(b.chunks, replayChunk{seq: seq, data: copied})
+	b.size += len(copied)
+	for b.limit > 0 && len(b.chunks) > 0 && b.size > b.limit {
+		b.size -= len(b.chunks[0].data)
+		b.chunks = b.chunks[1:]
+	}
+	return seq
+}
+
+func (b *replayBuffer) replay(lastSeen uint64) ([]replayChunk, error) {
+	if len(b.chunks) == 0 {
+		return nil, nil
+	}
+	first := b.chunks[0].seq
+	if lastSeen != 0 && lastSeen < first-1 {
+		return nil, errReplayGap
+	}
+	out := make([]replayChunk, 0, len(b.chunks))
+	for _, chunk := range b.chunks {
+		if chunk.seq > lastSeen {
+			out = append(out, replayChunk{
+				seq:  chunk.seq,
+				data: append([]byte(nil), chunk.data...),
+			})
+		}
+	}
+	return out, nil
+}
+
+type streamChunkWriter struct {
+	stream  *serverStream
+	channel string
+}
+
+func (w *streamChunkWriter) Write(p []byte) (int, error) {
+	written := len(p)
+	for len(p) > 0 {
+		chunk := p
+		if len(chunk) > streamChunkBytes {
+			chunk = p[:streamChunkBytes]
+		}
+		w.stream.emitData(w.channel, chunk)
+		p = p[len(chunk):]
+	}
+	return written, nil
+}
+
+func durationFromMillis(ms int64) time.Duration {
+	if ms <= 0 {
+		return 0
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+func formatTime(at time.Time) string {
+	if at.IsZero() {
+		return ""
+	}
+	return at.UTC().Format(time.RFC3339Nano)
+}
+
+func copyStringMap(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(src))
+	maps.Copy(out, src)
+	return out
+}

--- a/website/content/api/index.mdx
+++ b/website/content/api/index.mdx
@@ -16,6 +16,7 @@ gbash exposes a Go library for embedding a deterministic bash runtime in your ap
 ```text
 github.com/ewhauser/gbash           Core runtime, sessions, and option helpers
 github.com/ewhauser/gbash/commands   Command interface, registry, and invocation types
+github.com/ewhauser/gbash/server     Shared Unix-socket server mode for persistent sessions
 github.com/ewhauser/gbash/fs         Filesystem abstractions (memory, host overlay, read-write)
 github.com/ewhauser/gbash/network    HTTP client and allowlist configuration for curl
 github.com/ewhauser/gbash/policy     Path access checks and execution limits
@@ -62,6 +63,7 @@ hello world
 ## Next Steps
 
 - [Runtime](/docs/api/runtime) -- creating and configuring runtimes
+- [Server](/docs/api/server) -- hosting persistent sessions over a Unix socket
 - [Tracing and Logging](/docs/api/tracing-and-logging) -- structured traces and lifecycle log callbacks
 - [Sessions](/docs/api/sessions) -- persistent sandbox state across executions
 - [Custom Commands](/docs/api/custom-commands) -- extending the command registry

--- a/website/content/api/server.mdx
+++ b/website/content/api/server.mdx
@@ -1,0 +1,940 @@
+# Server
+
+The `server` package exposes the shared gbash daemon surface used by both `gbash` and `gbash-extras` when they run in `--server` mode.
+
+This page documents the v1 wire protocol as implemented today so external clients can talk to the daemon directly.
+
+## Public API
+
+```go
+type Config struct {
+    Runtime     *gbash.Runtime
+    Name        string
+    Version     string
+    SessionTTL  time.Duration
+    ReplayBytes int
+}
+
+func ListenAndServeUnix(ctx context.Context, socketPath string, cfg Config) error
+func Serve(ctx context.Context, ln net.Listener, cfg Config) error
+```
+
+Use `ListenAndServeUnix` when you want the package to create and manage the Unix domain socket path for you. Use `Serve` when your host already owns the listener.
+
+## Starting the Server
+
+The shipped CLIs expose the same server:
+
+```bash
+gbash --server --socket /tmp/gbash.sock --session-ttl 30m --replay-bytes 1048576
+```
+
+```bash
+gbash-extras --server --socket /tmp/gbash-extras.sock
+```
+
+Filesystem layout is fixed at server startup through the normal runtime or CLI options such as `--root`, `--readwrite-root`, and `--cwd`. The protocol does not provide filesystem RPC in v1.
+
+## Transport and Framing
+
+- v1 transport is a Unix domain socket.
+- The message model is transport-agnostic JSON envelopes.
+- Requests, responses, and events share one long-lived bidirectional connection.
+- Multiple sessions may be active concurrently over one connection.
+- Requests may be in flight concurrently; clients must correlate responses by `id`.
+- Asynchronous events can arrive between any two responses.
+
+On the Unix-socket transport, messages are emitted as a stream of JSON values. The current implementation uses Go's `json.Encoder` and `json.Decoder`, so line-delimited JSON works in practice, but clients should treat the socket as a stream of JSON objects rather than depending on whitespace details.
+
+## Session and Stream Model
+
+The protocol has two identity layers:
+
+- `session_id` identifies one persistent `gbash.Session`.
+- `stream_id` identifies one child operation inside that session.
+
+Child streams are one of:
+
+- `exec.start` for non-interactive `Session.Exec`
+- `shell.start` for interactive `Session.Interact`
+
+Important semantics:
+
+- Filesystem state persists for the life of the session.
+- A session may have many historical streams, but only one active stream at a time.
+- `exec.start` is non-interactive shell execution. If you want environment continuity across separate execs, feed `stream.exit.final_env` into the next `exec.start.env`.
+- `shell.start` creates a live interactive shell stream. Shell-local state such as `cd` and exported variables persists within that live stream.
+- A stream can outlive the connection that created it.
+
+## Envelope
+
+Every message is a JSON object.
+
+Request example:
+
+```json
+{
+  "version": "1",
+  "type": "request",
+  "id": "req-1",
+  "method": "session.create",
+  "payload": {}
+}
+```
+
+Response example:
+
+```json
+{
+  "version": "1",
+  "type": "response",
+  "id": "req-1",
+  "ok": true,
+  "session_id": "sess-000001",
+  "payload": {
+    "session": {
+      "session_id": "sess-000001",
+      "state": "idle",
+      "created_at": "2026-03-15T20:12:34.123456Z",
+      "updated_at": "2026-03-15T20:12:34.123456Z",
+      "expires_at": "2026-03-15T20:42:34.123456Z",
+      "stream_count": 0
+    }
+  }
+}
+```
+
+Event example:
+
+```json
+{
+  "version": "1",
+  "type": "event",
+  "event": "stream.data",
+  "session_id": "sess-000001",
+  "stream_id": "stream-000002",
+  "channel": "stdout",
+  "seq": 3,
+  "payload": {
+    "data": "aGVsbG8K",
+    "encoding": "base64"
+  }
+}
+```
+
+Envelope fields:
+
+| Field | Present on | Meaning |
+|------|------|------|
+| `version` | requests, responses, events | Protocol version. Requests may omit it; if present it must be `"1"`. Server responses and events always send `"1"`. |
+| `type` | all messages | `"request"`, `"response"`, or `"event"`. |
+| `id` | requests, responses | Client-chosen correlation id. Required on requests. Echoed on responses. |
+| `method` | requests | Method name such as `session.create` or `stream.write`. |
+| `event` | events | Event name such as `stream.data`. |
+| `session_id` | session-scoped and stream-scoped messages | Session routing id. |
+| `stream_id` | stream-scoped messages | Stream routing id. |
+| `channel` | `stream.data` events | `"stdout"` or `"stderr"`. |
+| `seq` | `stream.data` events | Per-channel sequence number. Starts at `1` for each channel on each stream. |
+| `ok` | responses | Boolean success flag. |
+| `payload` | all message types | Method-specific or event-specific object. |
+| `error` | error responses | Error object with `code` and `message`. |
+
+General rules:
+
+- Requests with unknown methods get `METHOD_NOT_FOUND`.
+- Malformed envelopes or invalid JSON payloads get `INVALID_REQUEST`.
+- Clients should key logic off `error.code`, not the human-readable `message`.
+- There is no global ordering across stdout and stderr. Only per-channel `seq` is meaningful.
+
+## Common Payload Types
+
+### Session Summary
+
+Used by `session.create`, `session.get`, `session.list`, `session.destroy`, `session.created`, and `session.updated`.
+
+```json
+{
+  "session_id": "sess-000001",
+  "state": "idle",
+  "created_at": "2026-03-15T20:12:34.123456Z",
+  "updated_at": "2026-03-15T20:12:34.123456Z",
+  "expires_at": "2026-03-15T20:42:34.123456Z",
+  "active_stream_id": "",
+  "stream_count": 0
+}
+```
+
+Fields:
+
+- `session_id`: stable id for the persistent sandbox session
+- `state`: `"idle"` or `"running"`
+- `created_at`, `updated_at`, `expires_at`: UTC timestamps in RFC3339Nano format
+- `expires_at`: omitted while the session is running
+- `active_stream_id`: currently running stream, if any
+- `stream_count`: total retained streams in the session, including exited streams still available for replay
+
+### Stream Summary
+
+Returned from `session.get`.
+
+```json
+{
+  "stream_id": "stream-000002",
+  "kind": "exec",
+  "state": "exited",
+  "created_at": "2026-03-15T20:13:00Z",
+  "updated_at": "2026-03-15T20:13:01Z",
+  "started_at": "2026-03-15T20:13:00Z",
+  "finished_at": "2026-03-15T20:13:01Z"
+}
+```
+
+### Stream Start Response
+
+Returned from `exec.start` and `shell.start`.
+
+```json
+{
+  "session_id": "sess-000001",
+  "stream_id": "stream-000002",
+  "kind": "exec",
+  "state": "running",
+  "writer_attached": true
+}
+```
+
+### Stream Attach Response
+
+Returned from `stream.attach` and `stream.detach`.
+
+```json
+{
+  "session_id": "sess-000001",
+  "stream_id": "stream-000002",
+  "state": "running",
+  "writer_attached": false
+}
+```
+
+### Stream Data Payload
+
+Used by `stream.data`.
+
+```json
+{
+  "data": "aGVsbG8K",
+  "encoding": "base64"
+}
+```
+
+`data` is always base64-encoded raw bytes in v1. The server chunks emitted output at 16 KiB raw bytes per event.
+
+### Stream Exit Payload
+
+Used by `stream.exit`.
+
+```json
+{
+  "kind": "exec",
+  "exit_code": 0,
+  "shell_exited": false,
+  "final_env": {
+    "PATH": "/bin",
+    "MODE": "debug"
+  },
+  "control_stderr": ""
+}
+```
+
+Fields:
+
+- `kind`: `"exec"` or `"shell"`
+- `exit_code`: process result code
+- `shell_exited`: only meaningful for `exec.start`
+- `final_env`: only present for `exec.start`
+- `control_stderr`: only present for `exec.start`
+
+Canceled streams report `exit_code: 130`. For canceled exec streams, `control_stderr` is `"execution canceled"`.
+
+### Stream Error Payload
+
+Used by `stream.error`.
+
+```json
+{
+  "code": "INTERNAL",
+  "message": "human readable message"
+}
+```
+
+## Methods
+
+### `hello`
+
+Recommended first request after connecting.
+
+Request:
+
+```json
+{
+  "version": "1",
+  "type": "request",
+  "id": "1",
+  "method": "hello",
+  "payload": {
+    "client_name": "my-client",
+    "client_version": "0.1.0"
+  }
+}
+```
+
+The request payload is optional and currently ignored by the server.
+
+Success response:
+
+```json
+{
+  "version": "1",
+  "type": "response",
+  "id": "1",
+  "ok": true,
+  "payload": {
+    "server_name": "gbash",
+    "server_version": "dev",
+    "capabilities": {
+      "binary": "gbash",
+      "transport": "unix",
+      "reconnect": true,
+      "filesystem_rpc": false,
+      "pty": false,
+      "interactive_shell": true
+    }
+  }
+}
+```
+
+Capability values in v1:
+
+- `binary`: binary identity, for example `gbash` or `gbash-extras`
+- `transport`: always `unix`
+- `reconnect`: always `true`
+- `filesystem_rpc`: always `false`
+- `pty`: always `false`
+- `interactive_shell`: always `true`
+
+### `ping`
+
+Health check request.
+
+Request payload is optional and ignored.
+
+Success response payload:
+
+```json
+{
+  "pong": true
+}
+```
+
+### `session.create`
+
+Creates a new persistent sandbox session.
+
+Request payload is empty or omitted.
+
+Success response payload:
+
+```json
+{
+  "session": {
+    "session_id": "sess-000001",
+    "state": "idle",
+    "created_at": "2026-03-15T20:12:34.123456Z",
+    "updated_at": "2026-03-15T20:12:34.123456Z",
+    "expires_at": "2026-03-15T20:42:34.123456Z",
+    "stream_count": 0
+  }
+}
+```
+
+Side effect:
+
+- Broadcasts `session.created` to every connected client with the same session summary payload.
+
+### `session.get`
+
+Returns one session plus all retained streams.
+
+Required envelope fields:
+
+- `session_id`
+
+Success response payload:
+
+```json
+{
+  "session": {
+    "session_id": "sess-000001",
+    "state": "running",
+    "created_at": "2026-03-15T20:12:34.123456Z",
+    "updated_at": "2026-03-15T20:13:00.000000Z",
+    "active_stream_id": "stream-000002",
+    "stream_count": 1
+  },
+  "streams": [
+    {
+      "stream_id": "stream-000002",
+      "kind": "exec",
+      "state": "running",
+      "created_at": "2026-03-15T20:13:00.000000Z",
+      "updated_at": "2026-03-15T20:13:00.000000Z",
+      "started_at": "2026-03-15T20:13:00.000000Z"
+    }
+  ]
+}
+```
+
+Error codes:
+
+- `SESSION_NOT_FOUND`
+
+### `session.list`
+
+Lists all current sessions.
+
+Success response payload:
+
+```json
+{
+  "sessions": [
+    {
+      "session_id": "sess-000001",
+      "state": "idle",
+      "created_at": "2026-03-15T20:12:34.123456Z",
+      "updated_at": "2026-03-15T20:12:34.123456Z",
+      "expires_at": "2026-03-15T20:42:34.123456Z",
+      "stream_count": 0
+    }
+  ]
+}
+```
+
+### `session.destroy`
+
+Destroys an idle session.
+
+Required envelope fields:
+
+- `session_id`
+
+Success response payload:
+
+```json
+{
+  "session": {
+    "session_id": "sess-000001",
+    "state": "idle",
+    "created_at": "2026-03-15T20:12:34.123456Z",
+    "updated_at": "2026-03-15T20:20:00.000000Z",
+    "expires_at": "2026-03-15T20:50:00.000000Z",
+    "stream_count": 0
+  }
+}
+```
+
+Side effects:
+
+- Broadcasts `session.updated` to every connected client with the final session summary.
+- After success, the session is gone from `session.list` and `session.get`.
+
+Error codes:
+
+- `SESSION_BUSY`
+- `SESSION_NOT_FOUND`
+
+### `exec.start`
+
+Starts a non-interactive child stream inside a session.
+
+Required envelope fields:
+
+- `session_id`
+
+Request payload:
+
+```json
+{
+  "name": "build-step",
+  "script": "printf 'hello\\n'",
+  "args": [],
+  "startup_options": [],
+  "env": {
+    "MODE": "debug"
+  },
+  "work_dir": "/tmp",
+  "replace_env": false,
+  "timeout_ms": 5000,
+  "stdin": "closed"
+}
+```
+
+Payload fields:
+
+- `name`: optional execution name
+- `script`: shell script to execute
+- `args`: optional shell positional arguments
+- `startup_options`: optional shell startup options
+- `env`: optional environment overlay
+- `work_dir`: optional working directory
+- `replace_env`: whether `env` replaces the baseline environment instead of overlaying it
+- `timeout_ms`: optional timeout in milliseconds; omitted or `0` means no timeout
+- `stdin`: `"closed"` or `"stream"`, default `"closed"`
+
+Success response payload:
+
+```json
+{
+  "session_id": "sess-000001",
+  "stream_id": "stream-000002",
+  "kind": "exec",
+  "state": "running",
+  "writer_attached": false
+}
+```
+
+Behavior:
+
+- With `stdin: "closed"`, the creator is attached read-only.
+- With `stdin: "stream"`, the creator becomes the initial stdin writer.
+- The server broadcasts `session.updated` when the stream starts and again when it finishes.
+- Attached clients receive `stream.data`, `stream.error`, and `stream.exit`.
+
+Error codes:
+
+- `SESSION_NOT_FOUND`
+- `SESSION_BUSY`
+- `INVALID_ARGUMENT`
+
+### `shell.start`
+
+Starts an interactive shell stream inside a session.
+
+Required envelope fields:
+
+- `session_id`
+
+Request payload:
+
+```json
+{
+  "name": "debug-shell",
+  "args": [],
+  "startup_options": [],
+  "env": {
+    "TERM": "dumb"
+  },
+  "work_dir": "/tmp",
+  "replace_env": false
+}
+```
+
+Success response payload:
+
+```json
+{
+  "session_id": "sess-000001",
+  "stream_id": "stream-000003",
+  "kind": "shell",
+  "state": "running",
+  "writer_attached": true
+}
+```
+
+Behavior:
+
+- The creator always becomes the initial stdin writer.
+- Shell output is streamed through the same `stream.data` event flow as `exec.start`.
+- The server broadcasts `session.updated` when the stream starts and again when it finishes.
+
+Error codes:
+
+- `SESSION_NOT_FOUND`
+- `SESSION_BUSY`
+
+### `stream.attach`
+
+Attaches the current connection to an existing stream and optionally requests stdin ownership.
+
+Required envelope fields:
+
+- `session_id`
+
+Required stream routing:
+
+- `stream_id` may be supplied either in the envelope or inside the payload as `stream_id`
+
+Request payload:
+
+```json
+{
+  "stream_id": "stream-000002",
+  "stdout_seq": 10,
+  "stderr_seq": 2,
+  "write": false
+}
+```
+
+Payload fields:
+
+- `stream_id`: optional if already present in the envelope
+- `stdout_seq`: last stdout sequence number the client has fully processed
+- `stderr_seq`: last stderr sequence number the client has fully processed
+- `write`: request stdin ownership
+
+Success response payload:
+
+```json
+{
+  "session_id": "sess-000001",
+  "stream_id": "stream-000002",
+  "state": "running",
+  "writer_attached": false
+}
+```
+
+Replay and live delivery behavior:
+
+- After the success response, the server sends buffered `stream.data` events whose `seq` is greater than the provided `stdout_seq` and `stderr_seq`.
+- If the stream has already exited, the replay is followed by one `stream.exit` event.
+- If the stream is still running, future live events continue on the same attachment.
+- Replay and live events may interleave. Clients should use `seq` to deduplicate and order data per channel.
+
+Writer ownership behavior:
+
+- Multiple read-only attachments are allowed.
+- Only one attachment may own stdin writes at a time.
+- Setting `write: true` succeeds only when the stream is still running and stdin is available.
+- If the stream was started without streamable stdin, `write: true` fails with `STREAM_CLOSED`.
+
+Error codes:
+
+- `SESSION_NOT_FOUND`
+- `STREAM_NOT_FOUND`
+- `STREAM_STDIN_BUSY`
+- `STREAM_CLOSED`
+- `REPLAY_GAP`
+
+### `stream.detach`
+
+Detaches the current connection from a stream.
+
+Required envelope fields:
+
+- `session_id`
+
+Required stream routing:
+
+- `stream_id` may be supplied either in the envelope or inside the payload as `stream_id`
+
+Request payload:
+
+```json
+{
+  "stream_id": "stream-000002"
+}
+```
+
+Success response payload:
+
+```json
+{
+  "session_id": "sess-000001",
+  "stream_id": "stream-000002",
+  "state": "running",
+  "writer_attached": false
+}
+```
+
+Behavior:
+
+- Detaching removes this connection from future stream event delivery.
+- If this connection owned stdin, detaching relinquishes ownership.
+- Detaching does not close stdin and does not cancel the stream.
+
+Error codes:
+
+- `SESSION_NOT_FOUND`
+- `STREAM_NOT_FOUND`
+
+### `stream.write`
+
+Writes bytes to the running stream's stdin.
+
+Required envelope fields:
+
+- `session_id`
+- `stream_id`
+
+Request payload:
+
+```json
+{
+  "data": "cHJpbnRmICdoZWxsb1xuJw==",
+  "encoding": "base64"
+}
+```
+
+Rules:
+
+- `encoding` may be omitted; it defaults to `"base64"`.
+- The caller must currently own stdin for that stream.
+
+Success response payload:
+
+```json
+{
+  "written": true
+}
+```
+
+Error codes:
+
+- `SESSION_NOT_FOUND`
+- `STREAM_NOT_FOUND`
+- `STREAM_STDIN_OWNER_REQUIRED`
+- `STREAM_CLOSED`
+- `INVALID_ARGUMENT`
+
+### `stream.close`
+
+Closes the stream's stdin.
+
+Required envelope fields:
+
+- `session_id`
+- `stream_id`
+
+Success response payload:
+
+```json
+{
+  "closed": true
+}
+```
+
+Rules:
+
+- The caller must currently own stdin for that stream.
+- Closing stdin does not itself end the stream; it just sends EOF to the running exec or shell.
+
+Error codes:
+
+- `SESSION_NOT_FOUND`
+- `STREAM_NOT_FOUND`
+- `STREAM_STDIN_OWNER_REQUIRED`
+- `STREAM_CLOSED`
+
+### `stream.cancel`
+
+Cancels the running stream.
+
+Required envelope fields:
+
+- `session_id`
+- `stream_id`
+
+Success response payload:
+
+```json
+{
+  "canceled": true
+}
+```
+
+Behavior:
+
+- Cancels the underlying context.
+- Closes stdin if it is still open.
+- The stream later terminates with `stream.exit`.
+
+Error codes:
+
+- `SESSION_NOT_FOUND`
+- `STREAM_NOT_FOUND`
+
+## Events
+
+### `session.created`
+
+Broadcast to every currently connected client when `session.create` succeeds.
+
+Payload:
+
+```json
+{
+  "session_id": "sess-000001",
+  "state": "idle",
+  "created_at": "2026-03-15T20:12:34.123456Z",
+  "updated_at": "2026-03-15T20:12:34.123456Z",
+  "expires_at": "2026-03-15T20:42:34.123456Z",
+  "stream_count": 0
+}
+```
+
+### `session.updated`
+
+Broadcast to every currently connected client when a session changes high-level state.
+
+Current emit points:
+
+- after `exec.start` succeeds
+- after `shell.start` succeeds
+- when a stream exits
+- after `session.destroy` succeeds
+
+Payload is the same session summary object as `session.created`.
+
+### `stream.data`
+
+Sent only to connections attached to that stream, plus replayed during `stream.attach`.
+
+Payload:
+
+```json
+{
+  "data": "aGVsbG8K",
+  "encoding": "base64"
+}
+```
+
+Envelope fields:
+
+- `channel`: `"stdout"` or `"stderr"`
+- `seq`: per-channel sequence number starting at `1`
+
+### `stream.exit`
+
+Sent only to connections attached to that stream, plus replayed after a successful `stream.attach` to an exited stream.
+
+Payload:
+
+```json
+{
+  "kind": "exec",
+  "exit_code": 0,
+  "shell_exited": false,
+  "final_env": {
+    "MODE": "debug"
+  },
+  "control_stderr": ""
+}
+```
+
+### `stream.error`
+
+Sent only to connections attached to that stream when the server reports an execution-level error.
+
+Payload:
+
+```json
+{
+  "code": "INTERNAL",
+  "message": "human readable message"
+}
+```
+
+## Errors
+
+Error responses use this shape:
+
+```json
+{
+  "version": "1",
+  "type": "response",
+  "id": "req-1",
+  "ok": false,
+  "session_id": "sess-000001",
+  "stream_id": "stream-000002",
+  "error": {
+    "code": "SESSION_BUSY",
+    "message": "session is busy: sess-000001"
+  }
+}
+```
+
+Known error codes in v1:
+
+| Code | Meaning |
+|------|------|
+| `INVALID_REQUEST` | Malformed envelope, unsupported `version`, wrong `type`, missing request `id`, or invalid JSON payload shape. |
+| `METHOD_NOT_FOUND` | Unknown request method. |
+| `INVALID_ARGUMENT` | Unsupported payload value such as bad `stdin` mode or unsupported encoding. |
+| `SESSION_NOT_FOUND` | No such session. |
+| `SESSION_BUSY` | The target session already has a running stream. |
+| `STREAM_NOT_FOUND` | No such stream in that session. |
+| `STREAM_CLOSED` | The stream is exited or does not have writable stdin. |
+| `STREAM_STDIN_BUSY` | Another attachment currently owns stdin. |
+| `STREAM_STDIN_OWNER_REQUIRED` | The caller tried to write or close stdin without owning it. |
+| `REPLAY_GAP` | The requested replay cursor is older than the retained buffer. |
+| `INTERNAL` | Unexpected server-side failure. |
+
+## Reconnect, Replay, and Expiry
+
+Reconnect behavior in v1:
+
+- Closing a connection detaches that connection from every stream.
+- Connection close also relinquishes stdin ownership for any stream the connection owned.
+- Connection close does not cancel the running stream.
+- Another client can later call `stream.attach` and optionally claim stdin ownership.
+
+Replay behavior:
+
+- Each stream keeps separate bounded replay buffers for stdout and stderr.
+- Retention is configured by `ReplayBytes` and applies per channel, per stream.
+- `stdout_seq` and `stderr_seq` are "last seen" cursors.
+- `0` means "replay everything still retained".
+- If the requested cursor is older than the earliest retained chunk, the server returns `REPLAY_GAP`.
+
+Expiry behavior:
+
+- `SessionTTL` is configured at server startup.
+- A session becomes idle when it has no active running stream.
+- Idle sessions expire after `SessionTTL`.
+- New but unused sessions also expire after `SessionTTL`.
+- There is no dedicated `session.expired` event in v1. Expired sessions simply disappear from `session.list`, and later lookups fail with `SESSION_NOT_FOUND`.
+
+## Full Example
+
+Create a session, run one exec stream, and read its output:
+
+Client request:
+
+```json
+{"version":"1","type":"request","id":"1","method":"hello","payload":{"client_name":"demo"}}
+{"version":"1","type":"request","id":"2","method":"session.create","payload":{}}
+{"version":"1","type":"request","id":"3","method":"exec.start","session_id":"sess-000001","payload":{"script":"printf 'hi\\n'","stdin":"closed"}}
+```
+
+Server replies and events:
+
+```json
+{"version":"1","type":"response","id":"1","ok":true,"payload":{"server_name":"gbash","server_version":"dev","capabilities":{"binary":"gbash","transport":"unix","reconnect":true,"filesystem_rpc":false,"pty":false,"interactive_shell":true}}}
+{"version":"1","type":"response","id":"2","ok":true,"session_id":"sess-000001","payload":{"session":{"session_id":"sess-000001","state":"idle","created_at":"2026-03-15T20:12:34.123456Z","updated_at":"2026-03-15T20:12:34.123456Z","expires_at":"2026-03-15T20:42:34.123456Z","stream_count":0}}}
+{"version":"1","type":"event","event":"session.created","session_id":"sess-000001","payload":{"session_id":"sess-000001","state":"idle","created_at":"2026-03-15T20:12:34.123456Z","updated_at":"2026-03-15T20:12:34.123456Z","expires_at":"2026-03-15T20:42:34.123456Z","stream_count":0}}
+{"version":"1","type":"response","id":"3","ok":true,"session_id":"sess-000001","stream_id":"stream-000002","payload":{"session_id":"sess-000001","stream_id":"stream-000002","kind":"exec","state":"running","writer_attached":false}}
+{"version":"1","type":"event","event":"session.updated","session_id":"sess-000001","payload":{"session_id":"sess-000001","state":"running","created_at":"2026-03-15T20:12:34.123456Z","updated_at":"2026-03-15T20:13:00.000000Z","active_stream_id":"stream-000002","stream_count":1}}
+{"version":"1","type":"event","event":"stream.data","session_id":"sess-000001","stream_id":"stream-000002","channel":"stdout","seq":1,"payload":{"data":"aGkK","encoding":"base64"}}
+{"version":"1","type":"event","event":"stream.exit","session_id":"sess-000001","stream_id":"stream-000002","payload":{"kind":"exec","exit_code":0,"shell_exited":false,"final_env":{"PATH":"/bin"}}}
+{"version":"1","type":"event","event":"session.updated","session_id":"sess-000001","payload":{"session_id":"sess-000001","state":"idle","created_at":"2026-03-15T20:12:34.123456Z","updated_at":"2026-03-15T20:13:01.000000Z","expires_at":"2026-03-15T20:43:01.000000Z","stream_count":1}}
+```
+
+## Current Limits
+
+The v1 server intentionally does not provide:
+
+- filesystem RPC
+- PTY resize or host TTY emulation
+- signal forwarding or job control
+- restart-persistent sessions
+
+If you are embedding gbash directly and do not need a wire protocol, use the normal in-process `Runtime` and `Session` APIs instead.


### PR DESCRIPTION
## Summary
- add a new public `server` package for shared Unix-socket server mode used by both `gbash` and `gbash-extras`
- extend the shared `cli` package with `--server`, `--socket`, `--session-ttl`, and `--replay-bytes`, including invalid combination handling
- document the full v1 server protocol in the website docs and sync the package layout / server-mode contract in `SPEC.md`

## Details
- model `session_id` as a persistent `gbash.Session` and `stream_id` as a child `exec.start` or `shell.start` operation
- support multiplexed request/response control messages plus async `session.*` and `stream.*` events over one Unix socket connection
- implement reconnect and replay with per-channel sequence numbers, bounded stdout/stderr buffers, and single-owner stdin semantics
- add integration coverage for lifecycle, concurrent sessions, shell attach/replay, replay gaps, TTL expiry, CLI flag handling, and `gbash-extras --server`
- serialize parser access in `internal/shell/mvdan.go` so concurrent server sessions do not race the shared parser

## Validation
- `go build ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...`
- `go test ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...`
- `make lint`
