### PR TITLE
website: fix favicon not showing on GitHub Pages

### DIFF
--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -9,6 +9,8 @@ const ibmPlexMono = IBM_Plex_Mono({
   display: "swap",
 });
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
 const metadataBase = new URL(
   process.env.NEXT_PUBLIC_SITE_URL ??
     (process.env.VERCEL_PROJECT_PRODUCTION_URL
@@ -20,6 +22,13 @@ const metadataBase = new URL(
 
 export const metadata: Metadata = {
   metadataBase,
+  icons: {
+    icon: {
+      url: `${basePath}/icon`,
+      type: "image/png",
+      sizes: "32x32",
+    },
+  },
   title: {
     default: "gbash — A deterministic bash runtime for AI agents",
     template: "%s | gbash",


### PR DESCRIPTION
## Summary
- Next.js does not prepend `basePath` to the auto-generated `<link rel="icon">` from `icon.tsx` during static exports
- The favicon link was pointing to `/icon` instead of `/gbash/icon`, causing a 404 on GitHub Pages
- Explicitly set `icons` in the layout metadata using the `NEXT_PUBLIC_BASE_PATH` env var

## Test plan
- [x] Verified locally: `GBASH_WEBSITE_EXPORT=1 GBASH_WEBSITE_BASE_PATH=/gbash pnpm build` produces `<link rel="icon" href="/gbash/icon" ...>` in the output HTML