### PR TITLE
ci: preserve fuzz repro inputs on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,19 +127,29 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - run: make fuzz-shard
+      - id: fuzz
+        continue-on-error: true
+        run: make fuzz-shard
         env:
           FUZZ_SHARD: ${{ matrix.make_var }}
           FUZZTIME: ${{ matrix.fuzztime }}
 
+      - id: collect_fuzz_artifacts
+        if: steps.fuzz.outcome == 'failure'
+        shell: bash
+        run: ./scripts/collect_fuzz_failure_artifacts.sh "$RUNNER_TEMP/fuzz-pr-deep-${{ matrix.shard }}-corpus"
+
       - name: Upload fuzz corpus artifacts
-        if: failure()
+        if: steps.collect_fuzz_artifacts.outputs.has_files == 'true'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: fuzz-pr-deep-${{ matrix.shard }}-corpus
-          if-no-files-found: ignore
-          path: |
-            **/testdata/fuzz/Fuzz*/*
+          if-no-files-found: error
+          path: ${{ steps.collect_fuzz_artifacts.outputs.artifact_dir }}
+
+      - name: Fail if fuzzing found a reproducer
+        if: steps.fuzz.outcome == 'failure'
+        run: exit 1
 
   fuzz-pr-jq-deep:
     if: github.event_name == 'pull_request' && needs.detect-fuzz-changes.outputs.run_jq_deep == 'true'
@@ -153,19 +163,29 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - run: make fuzz-run
+      - id: fuzz
+        continue-on-error: true
+        run: make fuzz-run
         env:
           FUZZ_TARGETS: ./contrib/jq:FuzzJQCompatibilityFlags ./contrib/jq:FuzzJQCommands
           FUZZTIME: 15s
 
+      - id: collect_fuzz_artifacts
+        if: steps.fuzz.outcome == 'failure'
+        shell: bash
+        run: ./scripts/collect_fuzz_failure_artifacts.sh "$RUNNER_TEMP/fuzz-pr-jq-corpus"
+
       - name: Upload fuzz corpus artifacts
-        if: failure()
+        if: steps.collect_fuzz_artifacts.outputs.has_files == 'true'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: fuzz-pr-jq-corpus
-          if-no-files-found: ignore
-          path: |
-            **/testdata/fuzz/Fuzz*/*
+          if-no-files-found: error
+          path: ${{ steps.collect_fuzz_artifacts.outputs.artifact_dir }}
+
+      - name: Fail if fuzzing found a reproducer
+        if: steps.fuzz.outcome == 'failure'
+        run: exit 1
 
   fuzz-pr-yq-deep:
     if: github.event_name == 'pull_request' && needs.detect-fuzz-changes.outputs.run_yq_deep == 'true'
@@ -179,19 +199,29 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - run: make fuzz-run
+      - id: fuzz
+        continue-on-error: true
+        run: make fuzz-run
         env:
           FUZZ_TARGETS: ./contrib/yq:FuzzYQCommands
           FUZZTIME: 15s
 
+      - id: collect_fuzz_artifacts
+        if: steps.fuzz.outcome == 'failure'
+        shell: bash
+        run: ./scripts/collect_fuzz_failure_artifacts.sh "$RUNNER_TEMP/fuzz-pr-yq-corpus"
+
       - name: Upload fuzz corpus artifacts
-        if: failure()
+        if: steps.collect_fuzz_artifacts.outputs.has_files == 'true'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: fuzz-pr-yq-corpus
-          if-no-files-found: ignore
-          path: |
-            **/testdata/fuzz/Fuzz*/*
+          if-no-files-found: error
+          path: ${{ steps.collect_fuzz_artifacts.outputs.artifact_dir }}
+
+      - name: Fail if fuzzing found a reproducer
+        if: steps.fuzz.outcome == 'failure'
+        run: exit 1
 
   fuzz-pr-sqlite3-deep:
     if: github.event_name == 'pull_request' && needs.detect-fuzz-changes.outputs.run_sqlite3_deep == 'true'
@@ -205,16 +235,26 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - run: make fuzz-run
+      - id: fuzz
+        continue-on-error: true
+        run: make fuzz-run
         env:
           FUZZ_TARGETS: ./contrib/sqlite3:FuzzSQLiteCommands ./contrib/sqlite3:FuzzSQLiteFileCommands
           FUZZTIME: 15s
 
+      - id: collect_fuzz_artifacts
+        if: steps.fuzz.outcome == 'failure'
+        shell: bash
+        run: ./scripts/collect_fuzz_failure_artifacts.sh "$RUNNER_TEMP/fuzz-pr-sqlite3-corpus"
+
       - name: Upload fuzz corpus artifacts
-        if: failure()
+        if: steps.collect_fuzz_artifacts.outputs.has_files == 'true'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: fuzz-pr-sqlite3-corpus
-          if-no-files-found: ignore
-          path: |
-            **/testdata/fuzz/Fuzz*/*
+          if-no-files-found: error
+          path: ${{ steps.collect_fuzz_artifacts.outputs.artifact_dir }}
+
+      - name: Fail if fuzzing found a reproducer
+        if: steps.fuzz.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/fuzz-full.yml
+++ b/.github/workflows/fuzz-full.yml
@@ -33,16 +33,26 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - run: make fuzz-shard
+      - id: fuzz
+        continue-on-error: true
+        run: make fuzz-shard
         env:
           FUZZ_SHARD: ${{ matrix.make_var }}
           FUZZTIME: 10s
 
+      - id: collect_fuzz_artifacts
+        if: steps.fuzz.outcome == 'failure'
+        shell: bash
+        run: ./scripts/collect_fuzz_failure_artifacts.sh "$RUNNER_TEMP/fuzz-full-${{ matrix.shard }}-corpus"
+
       - name: Upload fuzz corpus artifacts
-        if: failure()
+        if: steps.collect_fuzz_artifacts.outputs.has_files == 'true'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: fuzz-full-${{ matrix.shard }}-corpus
-          if-no-files-found: ignore
-          path: |
-            **/testdata/fuzz/Fuzz*/*
+          if-no-files-found: error
+          path: ${{ steps.collect_fuzz_artifacts.outputs.artifact_dir }}
+
+      - name: Fail if fuzzing found a reproducer
+        if: steps.fuzz.outcome == 'failure'
+        run: exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Typical local workflow:
 3. Keep the minimized input under `testdata/fuzz/...` if it still adds regression value after the fix.
 4. Re-run the owning fuzz target plus the relevant shard.
 
-CI uploads any generated fuzz corpus artifacts from failing fuzz jobs so minimized inputs can be downloaded directly from the workflow run.
+CI uploads any new or modified fuzz corpus files from failing fuzz jobs, along with a manifest of re-run commands and base64 copies so minimized inputs can be recovered directly from the workflow run.
 
 ## Module Versioning
 

--- a/scripts/collect_fuzz_failure_artifacts.sh
+++ b/scripts/collect_fuzz_failure_artifacts.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+artifact_dir="${1:-${RUNNER_TEMP:-}/fuzz-failure-artifacts}"
+if [ -z "${artifact_dir}" ]; then
+  echo "artifact directory is required" >&2
+  exit 1
+fi
+
+output_file="${GITHUB_OUTPUT:-}"
+summary_file="${GITHUB_STEP_SUMMARY:-}"
+
+rm -rf "${artifact_dir}"
+mkdir -p "${artifact_dir}/files" "${artifact_dir}/base64"
+
+manifest_file="${artifact_dir}/manifest.md"
+{
+  echo "# Fuzz Failure Inputs"
+  echo
+} > "${manifest_file}"
+
+if [ -n "${summary_file}" ]; then
+  {
+    echo "## Fuzz Failure Inputs"
+    echo
+  } >> "${summary_file}"
+fi
+
+files=()
+while IFS= read -r path; do
+  [ -n "${path}" ] || continue
+
+  rel_path="${path#./}"
+  if git ls-files --error-unmatch -- "${rel_path}" >/dev/null 2>&1; then
+    if [ -z "$(git status --short -- "${rel_path}")" ]; then
+      continue
+    fi
+  fi
+
+  files+=("${path}")
+done < <(find . -type f -path '*/testdata/fuzz/Fuzz*/*' | LC_ALL=C sort)
+
+if [ "${#files[@]}" -eq 0 ]; then
+  {
+    echo "No new or modified fuzz corpus files were detected after the failing run."
+    echo
+  } >> "${manifest_file}"
+  if [ -n "${summary_file}" ]; then
+    {
+      echo "No new or modified fuzz corpus files were detected after the failing run."
+      echo
+    } >> "${summary_file}"
+  fi
+  if [ -n "${output_file}" ]; then
+    {
+      echo "has_files=false"
+      echo "artifact_dir=${artifact_dir}"
+    } >> "${output_file}"
+  fi
+  exit 0
+fi
+
+count=0
+for path in "${files[@]}"; do
+  [ -f "${path}" ] || continue
+
+  rel_path="${path#./}"
+  dest_path="${artifact_dir}/files/${rel_path}"
+  mkdir -p "$(dirname "${dest_path}")"
+  cp "${path}" "${dest_path}"
+
+  encoded_path="${artifact_dir}/base64/${rel_path}.b64"
+  mkdir -p "$(dirname "${encoded_path}")"
+  base64 < "${path}" > "${encoded_path}"
+
+  pkg_path="${rel_path%%/testdata/fuzz/*}"
+  fuzz_suffix="${rel_path#${pkg_path}/testdata/fuzz/}"
+  fuzz_target="${fuzz_suffix%%/*}"
+  corpus_name="${fuzz_suffix#${fuzz_target}/}"
+  rerun_cmd="go test ./${pkg_path} -run='${fuzz_target}/${corpus_name}'"
+  size_bytes="$(wc -c < "${path}" | tr -d '[:space:]')"
+  sha256="$(shasum -a 256 "${path}" | awk '{print $1}')"
+
+  {
+    echo "Path: \`${rel_path}\`"
+    echo "Re-run: \`${rerun_cmd}\`"
+    echo "Bytes: ${size_bytes}"
+    echo "SHA256: \`${sha256}\`"
+    echo "Base64 Copy: \`base64/${rel_path}.b64\`"
+    echo
+  } >> "${manifest_file}"
+
+  if [ -n "${summary_file}" ]; then
+    {
+      echo "Path: \`${rel_path}\`"
+      echo "Re-run: \`${rerun_cmd}\`"
+      echo "Bytes: ${size_bytes}"
+      echo "SHA256: \`${sha256}\`"
+      echo
+    } >> "${summary_file}"
+  fi
+
+  count=$((count + 1))
+done
+
+if [ -n "${output_file}" ]; then
+  {
+    echo "has_files=true"
+    echo "artifact_dir=${artifact_dir}"
+    echo "count=${count}"
+  } >> "${output_file}"
+fi


### PR DESCRIPTION
## Summary
- keep fuzz jobs running long enough to collect and upload generated repro inputs before the job is marked failed
- add a helper that finds new or modified fuzz corpus files, copies them into an artifact bundle, and writes rerun details plus checksums
- document that CI uploads the generated fuzz repro bundle for failing jobs

## Testing
- make lint