### PR TITLE
cli: add loopback listen transport for server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Shell parsing is delegated to [`mvdan/sh`](https://github.com/mvdan/sh), with pr
 - 90+ built-in commands with GNU coreutils compatibility coverage ([compatibility report](https://ewhauser.github.io/gbash/docs/performance/compatibility/))
 - Optional allowlisted network access via `curl`
 - Persistent sessions with shared filesystem state across executions
-- Shared Unix-socket server mode for session-oriented hosts and wrapper binaries
+- Shared JSON-RPC server mode for session-oriented hosts and wrapper binaries
 - Host directory mounting with read-only overlay for real project workspaces
 - Execution budgets — command count, loop iterations, glob expansion, stdout/stderr limits
 - Opt-in structured trace events and lifecycle logs for debugging and agent orchestration
@@ -45,7 +45,7 @@ Shell parsing is delegated to [`mvdan/sh`](https://github.com/mvdan/sh), with pr
 ## Public Packages
 
 - `github.com/ewhauser/gbash`: the core Go runtime and embedding API
-- `github.com/ewhauser/gbash/server`: shared Unix-socket JSON-RPC server mode for hosting persistent gbash sessions
+- `github.com/ewhauser/gbash/server`: shared JSON-RPC server mode for hosting persistent gbash sessions
 - `github.com/ewhauser/gbash/contrib/...`: optional Go command modules
 - `@ewhauser/gbash-wasm/browser`: the explicit browser entrypoint for the `js/wasm` package. It is versioned in-repo today; npm publishing remains disabled in the release workflow for now.
 - `@ewhauser/gbash-wasm/node`: the explicit Node entrypoint for the same `js/wasm` package.
@@ -218,13 +218,17 @@ gbash -c 'echo hello' --json
 
 The JSON payload includes `stdout`, `stderr`, `exitCode`, truncation flags, timing metadata, and trace metadata when the wrapper enables tracing on the underlying runtime.
 
-For long-lived agent or editor integrations, the same shared CLI frontend can serve a Unix domain socket protocol instead of executing one script:
+For long-lived agent or editor integrations, the same shared CLI frontend can serve a JSON-RPC protocol instead of executing one script:
 
 ```bash
 gbash --server --socket /tmp/gbash.sock --session-ttl 30m
 ```
 
-The server speaks JSON-RPC 2.0 over the Unix socket. `session_id` maps 1:1 to a persistent sandbox session, and `session.exec` runs one non-interactive shell execution inside that session and returns the full result in one response. Filesystem shape is still chosen at server startup through the normal CLI/runtime options such as `--root`, `--readwrite-root`, and `--cwd`; it is not configured over the wire.
+```bash
+gbash --server --listen 127.0.0.1:8080 --session-ttl 30m
+```
+
+The server speaks JSON-RPC 2.0 over either a Unix socket or an explicit loopback TCP listener. `session_id` maps 1:1 to a persistent sandbox session, and `session.exec` runs one non-interactive shell execution inside that session and returns the full result in one response. Filesystem shape is still chosen at server startup through the normal CLI/runtime options such as `--root`, `--readwrite-root`, and `--cwd`; it is not configured over the wire. The shared CLI requires exactly one transport flag, `--socket PATH` or `--listen HOST:PORT`, and `--listen` is restricted to loopback hosts because the protocol has no built-in authentication.
 
 Install `gbash-extras` when you want the same CLI surface with the stable official contrib commands (`awk`, `html-to-markdown`, `jq`, `sqlite3`, and `yq`) pre-registered:
 
@@ -232,7 +236,7 @@ Install `gbash-extras` when you want the same CLI surface with the stable offici
 gbash-extras -c 'jq -r .name data.json'
 ```
 
-`gbash-extras --server --socket /tmp/gbash-extras.sock` exposes the same JSON-RPC protocol with the stable extras registry already installed.
+`gbash-extras --server --socket /tmp/gbash-extras.sock` and `gbash-extras --server --listen 127.0.0.1:8081` expose the same JSON-RPC protocol with the stable extras registry already installed.
 
 The shared frontend is also exposed as the public `github.com/ewhauser/gbash/cli` package. Call `cli.Run` with a `cli.Config` to reuse the stock flag parsing, interactive mode, server mode, and runtime setup from your own wrapper binary. For direct embedding without going through the CLI package, use `github.com/ewhauser/gbash/server`.
 ## Configuration

--- a/SPEC.md
+++ b/SPEC.md
@@ -140,7 +140,8 @@ The normal CLI entrypoint also accepts filesystem selection flags before the she
 - `gbash --cwd <dir> ...` sets the initial sandbox working directory
 - `gbash --readwrite-root <dir> ...` mounts `<dir>` as sandbox `/` so writes persist back to the host, but only when `<dir>` is inside the system temp directory
 - `gbash --json ...` emits one JSON object for a non-interactive execution with `stdout`, `stderr`, `exitCode`, truncation flags, timing metadata, and optional trace metadata when tracing is enabled
-- `gbash --server --socket <path>` serves a long-lived Unix domain socket protocol instead of executing a script
+- `gbash --server --socket <path>` serves a long-lived JSON-RPC protocol over a Unix domain socket instead of executing a script
+- `gbash --server --listen <host:port>` serves the same protocol over an explicit loopback TCP listener instead of executing a script
 - `gbash --session-ttl <duration>` controls how long idle server sessions survive without active work
 - when `--cwd` is omitted, `--root` starts at `/home/agent/project` and `--readwrite-root` starts at `/`
 
@@ -150,7 +151,7 @@ That frontend is also exposed as a public `cli` package so shipped binaries can 
 
 - `cmd/gbash` is a thin wrapper over `github.com/ewhauser/gbash/cli`
 - `contrib/extras/cmd/gbash-extras` is a thin wrapper over the same package with `contrib/extras` pre-registered into the runtime
-- `github.com/ewhauser/gbash/server` is the shared public server surface used by both wrapper binaries to host the same session protocol over Unix sockets
+- `github.com/ewhauser/gbash/server` is the shared public server surface used by both wrapper binaries to host the same session protocol over Unix sockets or caller-provided listeners
 
 ### 6.1 Session model
 
@@ -170,8 +171,10 @@ This matches the agent workflow we care about: a sequence of shell calls operati
 
 `gbash` should also expose a local-first server mode for hosts that want a long-lived control endpoint instead of direct in-process method calls.
 
-- the server transport is a Unix domain socket in v1
+- the server protocol is JSON-RPC 2.0 over either a Unix domain socket or a caller-provided listener such as loopback TCP
 - the protocol is JSON-RPC 2.0 request/response, not a custom streaming transport
+- the shared CLI requires exactly one transport flag: `--socket` or `--listen`
+- the shared CLI restricts `--listen` to loopback hosts because v1 has no authentication layer
 - `session_id` maps 1:1 to a persistent `Session`
 - filesystem shape is configured once at server startup through the normal runtime options and is not part of the wire protocol
 - the primary remote operation is `session.exec`, which runs one non-interactive `Session.Exec` call and returns the full execution result in one response
@@ -227,7 +230,7 @@ Because `mvdan/sh` currently validates `interp.Dir(...)` against the host filesy
 ```text
 cli/                   reusable CLI frontend shared by shipped binaries
 cmd/gbash/             CLI entrypoint for local execution
-server/                public Unix-socket server surface shared by wrapper binaries
+server/                public JSON-RPC server surface shared by wrapper binaries
 internal/runtime/      internal runtime implementation and execution orchestration
 shell/                mvdan/sh integration and handler wiring
 fs/                   project-owned filesystem interfaces and virtual backends
@@ -244,7 +247,7 @@ tests/                integration fixtures and compatibility-style harnesses
 Package responsibilities:
 
 - `cli/`: reusable CLI frontend that parses shell flags, renders help/version output, handles interactive mode, and provisions runtimes for thin wrapper binaries
-- `server/`: public shared server implementation that owns Unix-socket listeners, JSON-RPC framing, and session registries for both shipped CLIs and external hosts
+- `server/`: public shared server implementation that owns JSON-RPC framing and session registries for both shipped CLIs and external hosts, plus Unix-socket listener helpers
 - `internal/runtime/`: internal runtime/session creation, run configuration, result collection, output capture
 - `shell/`: parser and runner adapter; no product policy lives here
 - `fs/`: POSIX-like path normalization, memory filesystem, host-backed lower layers, overlay, and snapshot backends

--- a/cli/run.go
+++ b/cli/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"strings"
 
@@ -68,8 +69,17 @@ func run(ctx context.Context, cfg Config, argv0 string, args []string, stdin io.
 		if parsed.Source != builtins.BashSourceStdin || parsed.Interactive {
 			return 2, fmt.Errorf("--server cannot be combined with script execution or interactive shell flags")
 		}
-		if strings.TrimSpace(runtimeOpts.socket) == "" {
-			return 2, fmt.Errorf("--socket is required when --server is set")
+		socketPath := strings.TrimSpace(runtimeOpts.socket)
+		listenAddr := strings.TrimSpace(runtimeOpts.listen)
+		switch {
+		case socketPath == "" && listenAddr == "":
+			return 2, fmt.Errorf("either --socket or --listen is required when --server is set")
+		case socketPath != "" && listenAddr != "":
+			return 2, fmt.Errorf("--socket and --listen are mutually exclusive")
+		case listenAddr != "":
+			if err := validateLoopbackListenAddress(listenAddr); err != nil {
+				return 2, err
+			}
 		}
 	}
 	if runtimeOpts.json && parsed.Source == builtins.BashSourceStdin && (parsed.Interactive || stdinTTY) {
@@ -91,12 +101,7 @@ func run(ctx context.Context, cfg Config, argv0 string, args []string, stdin io.
 	}
 	if runtimeOpts.server {
 		meta := currentBuildInfo(cfg.Build)
-		err = gbserver.ListenAndServeUnix(ctx, runtimeOpts.socket, gbserver.Config{
-			Runtime:    rt,
-			Name:       cfg.Name,
-			Version:    meta.Version,
-			SessionTTL: runtimeOpts.sessionTTL,
-		})
+		err = serveServer(ctx, rt, cfg.Name, meta.Version, &runtimeOpts)
 		if err != nil {
 			return 1, fmt.Errorf("server error: %w", err)
 		}
@@ -110,6 +115,44 @@ func run(ctx context.Context, cfg Config, argv0 string, args []string, stdin io.
 		return runBashInvocationJSON(ctx, cfg.Name, rt, parsed, stdin, stdout)
 	}
 	return runBashInvocation(ctx, rt, parsed, stdin, stdout, stderr)
+}
+
+func serveServer(ctx context.Context, rt *gbash.Runtime, name, version string, runtimeOpts *runtimeOptions) error {
+	cfg := gbserver.Config{
+		Runtime: rt,
+		Name:    name,
+		Version: version,
+	}
+	var socketPath string
+	var listenAddr string
+	if runtimeOpts != nil {
+		cfg.SessionTTL = runtimeOpts.sessionTTL
+		socketPath = strings.TrimSpace(runtimeOpts.socket)
+		listenAddr = strings.TrimSpace(runtimeOpts.listen)
+	}
+	if socketPath != "" {
+		return gbserver.ListenAndServeUnix(ctx, socketPath, cfg)
+	}
+	ln, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return fmt.Errorf("listen on tcp address: %w", err)
+	}
+	defer func() { _ = ln.Close() }()
+	return gbserver.Serve(ctx, ln, cfg)
+}
+
+func validateLoopbackListenAddress(addr string) error {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(addr))
+	if err != nil {
+		return fmt.Errorf("parse --listen: %w", err)
+	}
+	if strings.EqualFold(host, "localhost") {
+		return nil
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return nil
+	}
+	return fmt.Errorf("--listen must use a loopback host such as 127.0.0.1, [::1], or localhost")
 }
 
 func runBashInvocation(ctx context.Context, rt *gbash.Runtime, parsed *builtins.BashInvocation, stdin io.Reader, stdout, stderr io.Writer) (int, error) {

--- a/cli/runtime_options.go
+++ b/cli/runtime_options.go
@@ -20,6 +20,7 @@ type runtimeOptions struct {
 	json          bool
 	server        bool
 	socket        string
+	listen        string
 	sessionTTL    time.Duration
 }
 
@@ -72,6 +73,14 @@ func parseRuntimeOptions(args []string) (runtimeOptions, []string, error) {
 			opts.socket = args[i]
 		case strings.HasPrefix(arg, "--socket="):
 			opts.socket = strings.TrimPrefix(arg, "--socket=")
+		case arg == "--listen":
+			if i+1 >= len(args) {
+				return opts, nil, fmt.Errorf("--listen requires a host:port")
+			}
+			i++
+			opts.listen = args[i]
+		case strings.HasPrefix(arg, "--listen="):
+			opts.listen = strings.TrimPrefix(arg, "--listen=")
 		case arg == "--session-ttl":
 			if i+1 >= len(args) {
 				return opts, nil, fmt.Errorf("--session-ttl requires a duration")
@@ -262,6 +271,7 @@ func renderHelp(w io.Writer, name string) error {
 		"\nCLI server options:\n"+
 		"  --server                run the shared gbash JSON-RPC server instead of executing a script\n"+
 		"  --socket PATH           listen on PATH for Unix domain socket clients\n"+
+		"  --listen HOST:PORT      listen on loopback HOST:PORT for TCP clients\n"+
 		"  --session-ttl DURATION  keep idle sessions alive for DURATION before expiry\n")
 	return err
 }

--- a/cmd/gbash/cli_test.go
+++ b/cmd/gbash/cli_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -122,7 +123,7 @@ func TestRunCLIHelpRendersServerFlags(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("exitCode = %d, want 0", exitCode)
 	}
-	for _, want := range []string{"CLI server options:", "--server", "--socket PATH", "--session-ttl DURATION"} {
+	for _, want := range []string{"CLI server options:", "--server", "--socket PATH", "--listen HOST:PORT", "--session-ttl DURATION"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want help to contain %q", stdout.String(), want)
 		}
@@ -216,19 +217,55 @@ func TestRunCLIJSONOutputRejectsInteractiveShell(t *testing.T) {
 	}
 }
 
-func TestRunCLIServerRequiresSocket(t *testing.T) {
+func TestRunCLIServerRequiresTransport(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
 	exitCode, err := runCLI(context.Background(), "gbash", []string{"--server"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err == nil {
-		t.Fatal("runCLI() error = nil, want socket requirement")
+		t.Fatal("runCLI() error = nil, want transport requirement")
 	}
 	if exitCode != 2 {
 		t.Fatalf("exitCode = %d, want 2", exitCode)
 	}
-	if !strings.Contains(err.Error(), "--socket is required") {
-		t.Fatalf("error = %v, want socket requirement", err)
+	if !strings.Contains(err.Error(), "--socket or --listen") {
+		t.Fatalf("error = %v, want transport requirement", err)
+	}
+}
+
+func TestRunCLIServerRejectsMultipleTransportFlags(t *testing.T) {
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), "gbash", []string{
+		"--server",
+		"--socket", filepath.Join(t.TempDir(), "gbash.sock"),
+		"--listen", "127.0.0.1:9000",
+	}, strings.NewReader(""), &stdout, &stderr, false)
+	if err == nil {
+		t.Fatal("runCLI() error = nil, want transport conflict")
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d, want 2", exitCode)
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error = %v, want transport conflict", err)
+	}
+}
+
+func TestRunCLIServerRejectsNonLoopbackListen(t *testing.T) {
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), "gbash", []string{"--server", "--listen", "0.0.0.0:9000"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err == nil {
+		t.Fatal("runCLI() error = nil, want loopback requirement")
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d, want 2", exitCode)
+	}
+	if !strings.Contains(err.Error(), "loopback host") {
+		t.Fatalf("error = %v, want loopback requirement", err)
 	}
 }
 
@@ -265,6 +302,87 @@ func TestRunCLIServerRejectsJSONMode(t *testing.T) {
 	}
 	if got := stderr.String(); got != "" {
 		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
+func TestRunCLIServerListensOnTCP(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	addr := reserveLoopbackTCPAddress(t)
+	var stdout strings.Builder
+	var stderr strings.Builder
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := runCLI(ctx, "gbash", []string{"--server", "--listen", addr}, strings.NewReader(""), &stdout, &stderr, false)
+		errCh <- err
+	}()
+
+	var conn net.Conn
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-errCh:
+			t.Fatalf("server exited before tcp listener became ready: %v", err)
+		default:
+		}
+		dialed, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err == nil {
+			conn = dialed
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if conn == nil {
+		t.Fatalf("timed out waiting for gbash server tcp listener at %s", addr)
+	}
+	defer func() { _ = conn.Close() }()
+
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+	if err := enc.Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "1",
+		"method":  "system.hello",
+		"params":  map[string]any{"client_name": "test"},
+	}); err != nil {
+		t.Fatalf("Encode(system.hello) error = %v", err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline() error = %v", err)
+	}
+	var resp struct {
+		Result struct {
+			Capabilities struct {
+				Transport string `json:"transport"`
+			} `json:"capabilities"`
+		} `json:"result"`
+		Error any `json:"error"`
+	}
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatalf("Decode(system.hello) error = %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("system.hello error = %#v, want success", resp.Error)
+	}
+	if got, want := resp.Result.Capabilities.Transport, "tcp"; got != want {
+		t.Fatalf("transport = %q, want %q", got, want)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("server exited with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for gbash server shutdown")
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("server stdout = %q, want empty", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("server stderr = %q, want empty", got)
 	}
 }
 
@@ -339,6 +457,20 @@ func mustParseCLIJSONResult(t *testing.T, raw string) cliJSONResult {
 		t.Fatalf("Unmarshal(JSON output) error = %v; raw=%q", err, raw)
 	}
 	return out
+}
+
+func reserveLoopbackTCPAddress(t *testing.T) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen(tcp) error = %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("Close(tcp listener) error = %v", err)
+	}
+	return addr
 }
 
 func TestRunCLIRootMountReadsHostFilesWithoutPersistingWrites(t *testing.T) {

--- a/contrib/extras/cmd/gbash-extras/main_test.go
+++ b/contrib/extras/cmd/gbash-extras/main_test.go
@@ -222,3 +222,141 @@ func TestCLIServerServesStableExtrasRegistry(t *testing.T) {
 		t.Fatalf("server stderr = %q, want empty", got)
 	}
 }
+
+func TestCLIServerListensOnTCPWithStableExtrasRegistry(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	addr := reserveLoopbackTCPAddress(t)
+	var stdout strings.Builder
+	var stderr strings.Builder
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := runCLI(ctx, "gbash-extras", []string{"--server", "--listen", addr}, strings.NewReader(""), &stdout, &stderr, false)
+		errCh <- err
+	}()
+
+	var conn net.Conn
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-errCh:
+			t.Fatalf("server exited before tcp listener became ready: %v", err)
+		default:
+		}
+		dialed, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err == nil {
+			conn = dialed
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if conn == nil {
+		t.Fatalf("timed out waiting for gbash-extras tcp listener at %s", addr)
+	}
+	defer func() { _ = conn.Close() }()
+
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+	send := func(id, method string, params any) {
+		t.Helper()
+		if err := enc.Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      id,
+			"method":  method,
+			"params":  params,
+		}); err != nil {
+			t.Fatalf("Encode(%s) error = %v", method, err)
+		}
+	}
+	readUntilResponse := func(id string) map[string]any {
+		t.Helper()
+		for {
+			if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				t.Fatalf("SetReadDeadline() error = %v", err)
+			}
+			var msg map[string]any
+			if err := dec.Decode(&msg); err != nil {
+				t.Fatalf("Decode() error = %v", err)
+			}
+			if msg["id"] == id {
+				return msg
+			}
+		}
+	}
+
+	send("1", "system.hello", map[string]any{"client_name": "test"})
+	helloResp := readUntilResponse("1")
+	result, ok := helloResp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("system.hello response = %#v, want result object", helloResp)
+	}
+	capabilities, ok := result["capabilities"].(map[string]any)
+	if !ok {
+		t.Fatalf("system.hello response = %#v, want capabilities", helloResp)
+	}
+	if got, want := capabilities["transport"], "tcp"; got != want {
+		t.Fatalf("transport = %v, want %q", got, want)
+	}
+
+	send("2", "session.create", nil)
+	createResp := readUntilResponse("2")
+	result, ok = createResp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("session.create response = %#v, want result object", createResp)
+	}
+	session, ok := result["session"].(map[string]any)
+	if !ok {
+		t.Fatalf("session.create response = %#v, want session object", createResp)
+	}
+	sessionID, ok := session["session_id"].(string)
+	if !ok || sessionID == "" {
+		t.Fatalf("session.create response = %#v, want session_id", createResp)
+	}
+
+	send("3", "session.exec", map[string]any{
+		"session_id": sessionID,
+		"script":     "printf 'a,b\\n' | awk -F, '{print $2}'\n",
+	})
+	execResp := readUntilResponse("3")
+	result, ok = execResp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("session.exec response = %#v, want result object", execResp)
+	}
+	if got, want := result["stdout"], "b\n"; got != want {
+		t.Fatalf("stdout = %v, want %q", got, want)
+	}
+	if got, want := result["exit_code"], float64(0); got != want {
+		t.Fatalf("exit_code = %v, want %v", got, want)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("server exited with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for gbash-extras tcp server shutdown")
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("server stdout = %q, want empty", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("server stderr = %q, want empty", got)
+	}
+}
+
+func reserveLoopbackTCPAddress(t *testing.T) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen(tcp) error = %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("Close(tcp listener) error = %v", err)
+	}
+	return addr
+}

--- a/server/doc.go
+++ b/server/doc.go
@@ -1,6 +1,6 @@
-// Package server exposes a shared Unix-socket server mode for gbash runtimes.
+// Package server exposes a shared JSON-RPC server mode for gbash runtimes.
 //
 // The package is intentionally small and host-oriented. It lets embedders and
-// shipped CLIs serve persistent gbash sessions over a Unix-socket JSON-RPC
-// endpoint without committing to a public client SDK.
+// shipped CLIs serve persistent gbash sessions over JSON-RPC endpoints without
+// committing to a public client SDK.
 package server

--- a/server/server.go
+++ b/server/server.go
@@ -78,10 +78,11 @@ func Serve(ctx context.Context, ln net.Listener, cfg Config) error {
 	}
 
 	srv := &serverState{
-		ctx:      ctx,
-		cfg:      cfg,
-		sessions: make(map[string]*serverSession),
-		conns:    make(map[string]*clientConn),
+		ctx:       ctx,
+		cfg:       cfg,
+		transport: listenerTransport(ln),
+		sessions:  make(map[string]*serverSession),
+		conns:     make(map[string]*clientConn),
 	}
 
 	done := make(chan struct{})
@@ -109,8 +110,9 @@ func Serve(ctx context.Context, ln net.Listener, cfg Config) error {
 }
 
 type serverState struct {
-	ctx context.Context
-	cfg Config
+	ctx       context.Context
+	cfg       Config
+	transport string
 
 	nextID atomic.Uint64
 
@@ -176,6 +178,18 @@ func normalizeConfig(cfg Config) Config {
 		cfg.Version = "dev"
 	}
 	return cfg
+}
+
+func listenerTransport(ln net.Listener) string {
+	if ln == nil || ln.Addr() == nil {
+		return ""
+	}
+	switch strings.TrimSpace(ln.Addr().Network()) {
+	case "tcp4", "tcp6":
+		return "tcp"
+	default:
+		return strings.TrimSpace(ln.Addr().Network())
+	}
 }
 
 func removeStaleUnixSocket(socketPath string) error {
@@ -364,7 +378,7 @@ func (c *clientConn) handleRequest(req *rpcRequest) *rpcResponse {
 			Protocol:      jsonRPCVersion,
 			Capabilities: helloCapabilities{
 				Binary:             c.server.cfg.Name,
-				Transport:          "unix",
+				Transport:          c.server.transport,
 				PersistentSessions: true,
 				SessionExec:        true,
 				FileSystemRPC:      false,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -251,6 +251,57 @@ func TestServerSessionTTLExpiry(t *testing.T) {
 	}
 }
 
+func TestServeTCPListenerReportsTCPTransport(t *testing.T) {
+	rt, err := gbash.New()
+	if err != nil {
+		t.Fatalf("gbash.New() error = %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen(tcp) error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- gbserver.Serve(ctx, ln, gbserver.Config{
+			Runtime:    rt,
+			Name:       "gbash",
+			Version:    "test",
+			SessionTTL: time.Second,
+		})
+	}()
+
+	client := &testClient{
+		t:    t,
+		conn: mustDialTCP(t, ln.Addr().String()),
+	}
+	client.enc = json.NewEncoder(client.conn)
+	client.dec = json.NewDecoder(client.conn)
+	defer client.Close()
+
+	resp := client.call("system.hello", map[string]any{"client_name": "test"})
+	mustOK(t, &resp)
+
+	var payload helloResult
+	decodeResult(t, &resp, &payload)
+	if got, want := payload.Capabilities.Transport, "tcp"; got != want {
+		t.Fatalf("transport = %q, want %q", got, want)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Serve(tcp) error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for tcp server shutdown")
+	}
+}
+
 func startServer(t *testing.T, cfg gbserver.Config, opts ...gbash.Option) *serverHandle {
 	t.Helper()
 
@@ -310,6 +361,16 @@ func dialClient(t *testing.T, socket string) *testClient {
 		enc:  json.NewEncoder(conn),
 		dec:  json.NewDecoder(conn),
 	}
+}
+
+func mustDialTCP(t *testing.T, addr string) net.Conn {
+	t.Helper()
+
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("DialTimeout(%q) error = %v", addr, err)
+	}
+	return conn
 }
 
 func (c *testClient) Close() {

--- a/website/content/api/server.mdx
+++ b/website/content/api/server.mdx
@@ -18,7 +18,7 @@ func ListenAndServeUnix(ctx context.Context, socketPath string, cfg Config) erro
 func Serve(ctx context.Context, ln net.Listener, cfg Config) error
 ```
 
-Use `ListenAndServeUnix` when you want the package to create and manage the Unix domain socket path for you. Use `Serve` when your host already owns the listener.
+Use `ListenAndServeUnix` when you want the package to create and manage the Unix domain socket path for you. Use `Serve` when your host already owns the listener, including a loopback TCP listener.
 
 ## Starting the Server
 
@@ -29,19 +29,34 @@ gbash --server --socket /tmp/gbash.sock --session-ttl 30m
 ```
 
 ```bash
+gbash --server --listen 127.0.0.1:8080 --session-ttl 30m
+```
+
+```bash
 gbash-extras --server --socket /tmp/gbash-extras.sock
+```
+
+```bash
+gbash-extras --server --listen 127.0.0.1:8081
 ```
 
 Filesystem layout is fixed at server startup through the normal runtime or CLI options such as `--root`, `--readwrite-root`, and `--cwd`. The protocol does not provide filesystem RPC in v1.
 
+The shared CLI requires exactly one transport flag:
+
+- `--socket PATH` for a Unix domain socket
+- `--listen HOST:PORT` for a loopback TCP listener
+
+`--listen` only accepts loopback hosts such as `127.0.0.1`, `[::1]`, and `localhost` because v1 has no built-in authentication or authorization layer.
+
 ## Transport
 
-- v1 transport is a Unix domain socket
+- v1 transport is listener-based: Unix domain sockets or loopback TCP
 - protocol is JSON-RPC 2.0
 - messages are a stream of JSON values on the socket
 - requests and responses share the same connection
 - there are no async server-pushed events in v1
-- clients can open more than one socket if they want concurrent outstanding requests
+- clients can open more than one connection if they want concurrent outstanding requests
 
 The current implementation uses Go's `json.Encoder` and `json.Decoder`, so newline-delimited JSON works in practice, but clients should treat the socket as a stream of JSON objects rather than depending on whitespace details.
 
@@ -220,7 +235,7 @@ Success result:
 Current capability values:
 
 - `binary`: binary identity, for example `gbash` or `gbash-extras`
-- `transport`: always `unix`
+- `transport`: `unix` for Unix domain sockets and `tcp` for TCP listeners
 - `persistent_sessions`: always `true`
 - `session_exec`: always `true`
 - `filesystem_rpc`: always `false`


### PR DESCRIPTION
## Summary
- add `--listen HOST:PORT` as an alternative to `--socket PATH` for server mode
- restrict CLI-managed TCP listeners to loopback addresses and report the actual transport in `system.hello`
- add TCP transport coverage for the shared CLI, server package, extras CLI, and update the docs/spec

## Testing
- go test ./server ./cmd/gbash ./contrib/extras/cmd/gbash-extras
- go test ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...
- module-by-module golangci-lint run --allow-parallel-runners ./... across all go.work main modules
