### PR TITLE
fix forbidigo violations in contrib modules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -274,6 +274,9 @@ linters:
         text: "use of `unix\\.Uname` forbidden"
         linters:
           - forbidigo
+      - path: contrib/extras/cmd/gbash-extras/main\.go$
+        linters:
+          - forbidigo
       - path: internal/fuzztest/
         linters:
           - forbidigo

--- a/contrib/awk/awk.go
+++ b/contrib/awk/awk.go
@@ -3,7 +3,6 @@ package awk
 import (
 	"bytes"
 	"context"
-	"io"
 	"strings"
 
 	"github.com/benhoyt/goawk/interp"
@@ -201,9 +200,9 @@ func readNamedInputs(ctx context.Context, inv *commands.Invocation, names []stri
 		if !defaultStdin {
 			return nil, nil
 		}
-		data, err := io.ReadAll(inv.Stdin)
+		data, err := commands.ReadAllStdin(ctx, inv)
 		if err != nil {
-			return nil, &commands.ExitError{Code: 1, Err: err}
+			return nil, err
 		}
 		return []namedInput{{Data: data}}, nil
 	}
@@ -216,9 +215,9 @@ func readNamedInputs(ctx context.Context, inv *commands.Invocation, names []stri
 	for _, name := range names {
 		if name == "-" {
 			if !stdinRead {
-				data, err := io.ReadAll(inv.Stdin)
+				data, err := commands.ReadAllStdin(ctx, inv)
 				if err != nil {
-					return nil, &commands.ExitError{Code: 1, Err: err}
+					return nil, err
 				}
 				stdinData = data
 				stdinRead = true
@@ -243,9 +242,9 @@ func readAllFile(ctx context.Context, inv *commands.Invocation, name string) ([]
 	}
 	defer func() { _ = file.Close() }()
 
-	data, err := io.ReadAll(file)
+	data, err := commands.ReadAll(ctx, inv, file)
 	if err != nil {
-		return nil, &commands.ExitError{Code: 1, Err: err}
+		return nil, err
 	}
 	return data, nil
 }

--- a/contrib/jq/jq.go
+++ b/contrib/jq/jq.go
@@ -469,7 +469,7 @@ func collectJQInputs(ctx context.Context, inv *commands.Invocation, opts *jqOpti
 
 func readJQInputSources(ctx context.Context, inv *commands.Invocation, inputs []string) (*jqSources, error) {
 	if len(inputs) == 0 {
-		data, err := readAllStdin(inv)
+		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return nil, err
 		}
@@ -495,7 +495,7 @@ func readJQInputSources(ctx context.Context, inv *commands.Invocation, inputs []
 			if stdinUsed {
 				data = nil
 			} else {
-				data, err = readAllStdin(inv)
+				data, err = readAllStdin(ctx, inv)
 				stdinUsed = true
 			}
 		} else {
@@ -872,10 +872,10 @@ func exitf(inv *commands.Invocation, code int, format string, args ...any) error
 	return commands.Exitf(inv, code, format, args...)
 }
 
-func readAllStdin(inv *commands.Invocation) ([]byte, error) {
-	data, err := io.ReadAll(inv.Stdin)
+func readAllStdin(ctx context.Context, inv *commands.Invocation) ([]byte, error) {
+	data, err := commands.ReadAllStdin(ctx, inv)
 	if err != nil {
-		return nil, &commands.ExitError{Code: 1, Err: err}
+		return nil, err
 	}
 	return data, nil
 }
@@ -899,9 +899,9 @@ func readAllFile(ctx context.Context, inv *commands.Invocation, name string) (da
 	}
 	defer func() { _ = file.Close() }()
 
-	data, err = io.ReadAll(file)
+	data, err = commands.ReadAll(ctx, inv, file)
 	if err != nil {
-		return nil, "", &commands.ExitError{Code: 1, Err: err}
+		return nil, "", err
 	}
 	return data, abs, nil
 }

--- a/contrib/sqlite3/sqlite3.go
+++ b/contrib/sqlite3/sqlite3.go
@@ -122,9 +122,9 @@ func (c *SQLite3) Run(ctx context.Context, inv *commands.Invocation) error {
 	}
 
 	if parsed.sqlText == "" {
-		data, err := io.ReadAll(inv.Stdin)
+		data, err := commands.ReadAllStdin(ctx, inv)
 		if err != nil {
-			return &commands.ExitError{Code: 1, Err: err}
+			return err
 		}
 		parsed.sqlText = string(data)
 	}
@@ -326,9 +326,9 @@ func readSQLiteDatabase(ctx context.Context, inv *commands.Invocation, name stri
 	}
 	defer func() { _ = file.Close() }()
 
-	data, err := io.ReadAll(file)
+	data, err := commands.ReadAll(ctx, inv, file)
 	if err != nil {
-		return nil, &commands.ExitError{Code: 1, Err: err}
+		return nil, err
 	}
 	return data, nil
 }

--- a/contrib/yq/yq.go
+++ b/contrib/yq/yq.go
@@ -678,17 +678,17 @@ func readAllFile(ctx context.Context, inv *commands.Invocation, name string) (da
 	}
 	defer func() { _ = file.Close() }()
 
-	data, err = io.ReadAll(file)
+	data, err = commands.ReadAll(ctx, inv, file)
 	if err != nil {
-		return nil, "", &commands.ExitError{Code: 1, Err: err}
+		return nil, "", err
 	}
 	return data, abs, nil
 }
 
-func readAllStdin(inv *commands.Invocation) ([]byte, error) {
-	data, err := io.ReadAll(inv.Stdin)
+func readAllStdin(ctx context.Context, inv *commands.Invocation) ([]byte, error) {
+	data, err := commands.ReadAllStdin(ctx, inv)
 	if err != nil {
-		return nil, &commands.ExitError{Code: 1, Err: err}
+		return nil, err
 	}
 	return data, nil
 }
@@ -698,7 +698,7 @@ func readNamedInputs(ctx context.Context, inv *commands.Invocation, names []stri
 		if !defaultStdin {
 			return nil, nil
 		}
-		data, err := readAllStdin(inv)
+		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return nil, err
 		}
@@ -718,7 +718,7 @@ func readNamedInputs(ctx context.Context, inv *commands.Invocation, names []stri
 	for _, name := range names {
 		if name == "-" {
 			if !stdinLoaded {
-				data, err := readAllStdin(inv)
+				data, err := readAllStdin(ctx, inv)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
## Summary
- Replace `io.ReadAll` with `commands.ReadAll` / `commands.ReadAllStdin` in awk, jq, sqlite3, and yq contrib modules so `MaxFileBytes` limits are enforced consistently.
- Add lint exclusion for `contrib/extras/cmd/gbash-extras/main.go` which legitimately needs `os.Args`, `os.Exit`, and `os.Stderr` as a program entry point.

## Test plan
- [x] All four affected contrib modules compile
- [x] `go test ./contrib/awk/...` passes
- [x] `go test ./contrib/jq/...` passes
- [x] `go test ./contrib/sqlite3/...` passes
- [x] `go test ./contrib/yq/...` passes
- [ ] CI golangci-lint runs clean across all modules