### PR TITLE
fix writeFile error swallowing and loadRuntime singleton poisoning

### DIFF
--- a/packages/gbash-wasm/src/browser.ts
+++ b/packages/gbash-wasm/src/browser.ts
@@ -53,10 +53,9 @@ export class Bash {
     this.shellPromise = this.init(options);
   }
 
-  writeFile(path: string, content: string): void {
-    void this.shellPromise.then((shell) => {
-      shell.writeFile(path, content);
-    });
+  async writeFile(path: string, content: string): Promise<void> {
+    const shell = await this.shellPromise;
+    shell.writeFile(path, content);
   }
 
   async exec(command: string): Promise<CommandResult> {
@@ -102,7 +101,10 @@ async function loadRuntime(options: BashOptions): Promise<GBashRuntime> {
       const result = await instantiateWasm(wasmUrl, go.importObject);
       go.run(result.instance);
       return waitForRuntime();
-    })();
+    })().catch((err) => {
+      runtimePromise = null;
+      throw err;
+    });
   }
   return runtimePromise;
 }

--- a/packages/gbash-wasm/src/node.ts
+++ b/packages/gbash-wasm/src/node.ts
@@ -68,10 +68,9 @@ export class Bash {
     this.shellPromise = this.init(options);
   }
 
-  writeFile(path: string, content: string): void {
-    void this.shellPromise.then((shell) => {
-      shell.writeFile(path, content);
-    });
+  async writeFile(path: string, content: string): Promise<void> {
+    const shell = await this.shellPromise;
+    shell.writeFile(path, content);
   }
 
   async exec(command: string): Promise<CommandResult> {
@@ -118,7 +117,10 @@ async function loadRuntime(options: BashOptions): Promise<GBashRuntime> {
       const result = await instantiateWasm(wasmUrl, go.importObject);
       void go.run(result.instance);
       return waitForRuntime();
-    })();
+    })().catch((err) => {
+      runtimePromise = null;
+      throw err;
+    });
   }
   return runtimePromise;
 }

--- a/packages/gbash-wasm/test/node.test.mjs
+++ b/packages/gbash-wasm/test/node.test.mjs
@@ -80,11 +80,10 @@ test("working directory persists across execs", async () => {
 // writeFile / readFile round-trip
 // ---------------------------------------------------------------------------
 
-test("writeFile then cat reads back the content", async () => {
+test("writeFile completes before subsequent exec sees the file", async () => {
   const bash = new Bash();
 
-  // writeFile is fire-and-forget, so exec after to ensure ordering.
-  bash.writeFile("/home/agent/injected.txt", "injected content\n");
+  await bash.writeFile("/home/agent/injected.txt", "injected content\n");
   const result = await bash.exec("cat /home/agent/injected.txt");
   assert.equal(result.exitCode, 0);
   assert.equal(result.stdout, "injected content\n");


### PR DESCRIPTION
## Summary

- **writeFile**: Changed from fire-and-forget (`void` return with `void this.shellPromise.then(...)`) to `async` returning `Promise<void>`. Errors from failed shell initialization now propagate to callers instead of being silently swallowed.
- **loadRuntime**: Added `.catch()` handler that clears `runtimePromise` on failure. Previously, a failed WASM load (bad URL, network error, timeout) would cache the rejected promise permanently, causing all subsequent `new Bash()` instances to fail with the same stale error.
- Updated the existing `writeFile` test to `await` the call, matching the new contract.

Both fixes applied to `browser.ts` and `node.ts`.

## Test plan

- [x] Existing `writeFile` test updated and passing
- [x] Full node test suite passes (21/21)
- [x] TypeScript build succeeds