### PR TITLE
include WASM build in pretest step

### DIFF
--- a/packages/gbash-wasm/package.json
+++ b/packages/gbash-wasm/package.json
@@ -21,7 +21,7 @@
     "build": "rm -rf dist && tsc -p tsconfig.build.json && bash scripts/build-wasm.sh",
     "build:ts": "tsc -p tsconfig.build.json",
     "build:wasm": "bash scripts/build-wasm.sh",
-    "pretest": "tsc -p tsconfig.build.json",
+    "pretest": "tsc -p tsconfig.build.json && bash scripts/build-wasm.sh",
     "test": "node --test test/*.test.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
The Node tests load gbash.wasm and wasm_exec.js at runtime, so the
TypeScript-only pretest was insufficient. Run build-wasm.sh as well.
