### PR TITLE
compat: make GNU temp cleanup best-effort

### DIFF
--- a/scripts/gnu-test.sh
+++ b/scripts/gnu-test.sh
@@ -320,7 +320,9 @@ remove_tmp_ ()
     echo "Not removing temporary directory $test_dir_"
   else
     cd "$initial_cwd_" || cd / || cd /tmp
-    "$jbgo_host_chmod_" -R u+rwx "$test_dir_"
+    if test -e "$test_dir_"; then
+      "$jbgo_host_chmod_" -R u+rwx "$test_dir_" 2>/dev/null || :
+    fi
     "$jbgo_host_rm_" -rf "$test_dir_" 2>/dev/null \
       || { "$jbgo_host_sleep_" 1 && "$jbgo_host_rm_" -rf "$test_dir_"; } \
       || { test $__st = 0 && __st=1; }


### PR DESCRIPTION
## Summary
- make the GNU harness temp-dir permission fixup best-effort during cleanup
- continue to host-side `rm -rf` even when host `chmod -R` fails
- prevent leaked per-test temp trees from accumulating and exhausting Compat runner disk

## Context
Compat started failing after March 15, 2026 with runner disk exhaustion. The first failing run was:
- https://github.com/ewhauser/gbash/actions/runs/23128387677

That run reported `Free space left: 0 MB` and then `No space left on device` while still inside `make gnu-test`.

The regression appears to come from the GNU harness cleanup override added in `scripts/gnu-test.sh`, where cleanup redefined `remove_tmp_` to run a bare host `chmod -R` before `rm -rf`. Under `set -e`, a failing `chmod` aborts cleanup and leaves the whole test temp tree behind.

This change makes the chmod step best-effort so cleanup still attempts removal.

## Verification
- `make lint`
- `bash -n scripts/gnu-test.sh`
- targeted `sh -ec` cleanup probe that forces the chmod step to fail and verifies the temp directory is still removed

## Notes
- I did not run the full Compat harness locally because Docker was not reachable from this environment.
