### PR TITLE
runtime: add direct nested command exec path

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -306,6 +306,7 @@ type Session struct {
 type ExecutionRequest struct {
     Name    string
     Script  string
+    Command []string
     Args    []string
     Env     map[string]string
     WorkDir string
@@ -487,6 +488,8 @@ Key design decisions:
 - command implementations receive project context through `Invocation`, not through globals
 - commands that need sub-execution should use the injected `Invocation.Exec` callback rather than reaching around the runtime
 - `Invocation.Exec` inherits the current command environment and virtual working directory by default while staying inside the same session and policy boundary
+- `Invocation.Exec` supports two non-interactive modes: `Script` for nested shell execution and `Command` for already-tokenized argv execution without shell parsing
+- `Script` and `Command` are mutually exclusive; `Args` applies to script mode positional parameters
 - direct filesystem and text-processing commands should prefer `Invocation.FS` over nested shell execution
 - commands that need whole-input reads should use `commands.ReadAll`, `commands.ReadAllStdin`, or `Invocation.FS.ReadFile` so `MaxFileBytes` and diagnostic behavior stay consistent
 - orchestration-style commands such as `xargs`, `find -exec`, and shell-wrapper helpers should use `Invocation.Exec`

--- a/commands/execution.go
+++ b/commands/execution.go
@@ -14,16 +14,19 @@ type ExecutionRequest struct {
 	Interpreter     string
 	PassthroughArgs []string
 	Script          string
-	Args            []string
-	StartupOptions  []string
-	Env             map[string]string
-	WorkDir         string
-	Timeout         time.Duration
-	ReplaceEnv      bool
-	Interactive     bool
-	Stdin           io.Reader
-	Stdout          io.Writer
-	Stderr          io.Writer
+	// Command runs an already-tokenized command argv without shell parsing.
+	// Script and Command are mutually exclusive.
+	Command        []string
+	Args           []string
+	StartupOptions []string
+	Env            map[string]string
+	WorkDir        string
+	Timeout        time.Duration
+	ReplaceEnv     bool
+	Interactive    bool
+	Stdin          io.Reader
+	Stdout         io.Writer
+	Stderr         io.Writer
 }
 
 // ExecutionResult reports the outcome of an [ExecutionRequest].

--- a/internal/builtins/subexec_helpers.go
+++ b/internal/builtins/subexec_helpers.go
@@ -51,8 +51,7 @@ func executeCommand(ctx context.Context, inv *Invocation, opts *executeCommandOp
 
 	argv := append([]string{resolved.Path}, opts.Argv[1:]...)
 	return inv.Exec(ctx, &ExecutionRequest{
-		Script:     "\"$@\"\n",
-		Args:       argv,
+		Command:    argv,
 		Env:        env,
 		WorkDir:    workDir,
 		ReplaceEnv: opts.ReplaceEnv,

--- a/internal/builtins/timeout_test.go
+++ b/internal/builtins/timeout_test.go
@@ -102,3 +102,18 @@ func TestTimeoutStopsOptionParsingAtDuration(t *testing.T) {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }
+
+func TestTimeoutShortNestedCommandAvoidsShellTrampolineOverhead(t *testing.T) {
+	rt := newRuntime(t, &Config{})
+
+	const script = "if true; then timeout 0.01 sleep 0.001; else sed -n '1,3p' /tmp/text.txt; fi\n"
+	for i := range 20 {
+		result, err := rt.Run(context.Background(), &ExecutionRequest{Script: script})
+		if err != nil {
+			t.Fatalf("Run(attempt %d) error = %v", i+1, err)
+		}
+		if result.ExitCode != 0 {
+			t.Fatalf("attempt %d ExitCode = %d, want 0; stderr=%q", i+1, result.ExitCode, result.Stderr)
+		}
+	}
+}

--- a/internal/builtins/xargs_test.go
+++ b/internal/builtins/xargs_test.go
@@ -259,3 +259,21 @@ func TestXArgsAcceptsMaxProcsFlag(t *testing.T) {
 		t.Fatalf("Stderr = %q, want %q", got, want)
 	}
 }
+
+func TestXArgsRunsShebangScriptViaDirectExec(t *testing.T) {
+	session := newSession(t, &Config{})
+	writeSessionFile(t, session, "/tmp/xargs-script.sh", []byte("#!/bin/sh\nprintf '%s:%s\\n' \"$1\" \"$2\"\n"))
+
+	result, err := session.Exec(context.Background(), &ExecutionRequest{
+		Script: "chmod 755 /tmp/xargs-script.sh\nprintf 'left\\nright\\n' | xargs -n1 /tmp/xargs-script.sh fixed\n",
+	})
+	if err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "fixed:left\nfixed:right\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/runtime/direct_command_test.go
+++ b/internal/runtime/direct_command_test.go
@@ -1,0 +1,81 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ewhauser/gbash/policy"
+)
+
+func TestDirectCommandRequestRespectsPATHAndWorkDir(t *testing.T) {
+	session := newSession(t, &Config{})
+	if err := session.FileSystem().MkdirAll(context.Background(), "/tmp/work", 0o755); err != nil {
+		t.Fatalf("MkdirAll(/tmp/work) error = %v", err)
+	}
+
+	result, err := session.Exec(context.Background(), &ExecutionRequest{
+		Command: []string{"pwd"},
+		Env:     map[string]string{"PATH": "/bin"},
+		WorkDir: "/tmp/work",
+	})
+	if err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "/tmp/work\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestDirectCommandRequestReturns127ForMissingCommand(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	result, err := session.Exec(context.Background(), &ExecutionRequest{
+		Command: []string{"definitely-missing-command"},
+	})
+	if err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+	if result.ExitCode != 127 {
+		t.Fatalf("ExitCode = %d, want 127; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if !strings.Contains(result.Stderr, "definitely-missing-command: command not found") {
+		t.Fatalf("Stderr = %q, want command-not-found message", result.Stderr)
+	}
+}
+
+func TestDirectCommandRequestCancellationReturns130(t *testing.T) {
+	rt := newRuntimeWithLimits(t, policy.Limits{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	time.AfterFunc(20*time.Millisecond, cancel)
+
+	result, err := rt.Run(ctx, &ExecutionRequest{
+		Command: []string{"sleep", "1"},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 130 {
+		t.Fatalf("ExitCode = %d, want 130", result.ExitCode)
+	}
+	if !strings.Contains(result.Stderr, "execution canceled") {
+		t.Fatalf("Stderr = %q, want cancellation message", result.Stderr)
+	}
+}
+
+func TestDirectCommandRequestRejectsScriptAndCommand(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	if _, err := session.Exec(context.Background(), &ExecutionRequest{
+		Script:  "echo hi\n",
+		Command: []string{"echo", "hi"},
+	}); err == nil {
+		t.Fatal("Exec() error = nil, want validation failure")
+	}
+}

--- a/internal/runtime/execution_control_test.go
+++ b/internal/runtime/execution_control_test.go
@@ -24,7 +24,7 @@ func (c *timeoutProbe) Run(ctx context.Context, inv *commands.Invocation) error 
 	}
 
 	result, err := inv.Exec(ctx, &commands.ExecutionRequest{
-		Script:  "while true; do :; done\n",
+		Command: []string{"sleep", "1"},
 		Timeout: 20 * time.Millisecond,
 	})
 	if err != nil {
@@ -85,7 +85,7 @@ func TestInvocationExecTimeoutIsScopedToSubexecution(t *testing.T) {
 	rt := newRuntime(t, &Config{
 		Registry: registryWithCommands(t, &timeoutProbe{}),
 		Policy: policy.NewStatic(&policy.Config{
-			AllowedCommands: []string{"echo", "timeoutprobe"},
+			AllowedCommands: []string{"echo", "sleep", "timeoutprobe"},
 			ReadRoots:       []string{"/"},
 			WriteRoots:      []string{"/"},
 		}),

--- a/internal/runtime/execution_types.go
+++ b/internal/runtime/execution_types.go
@@ -14,6 +14,7 @@ type ExecutionRequest struct {
 	Interpreter     string
 	PassthroughArgs []string
 	Script          string
+	Command         []string
 	Args            []string
 	StartupOptions  []string
 	Env             map[string]string
@@ -66,6 +67,7 @@ func executionRequestFromCommand(req *commands.ExecutionRequest) *ExecutionReque
 		Interpreter:     req.Interpreter,
 		PassthroughArgs: cloneStrings(req.PassthroughArgs),
 		Script:          req.Script,
+		Command:         cloneStrings(req.Command),
 		Args:            cloneStrings(req.Args),
 		StartupOptions:  cloneStrings(req.StartupOptions),
 		Env:             copyStringMap(req.Env),

--- a/internal/runtime/observability_test.go
+++ b/internal/runtime/observability_test.go
@@ -302,6 +302,10 @@ func (f failingEngine) Run(context.Context, *shell.Execution) (*shell.RunResult,
 	return nil, f.err
 }
 
+func (f failingEngine) RunCommand(context.Context, *shell.Execution) (*shell.RunResult, error) {
+	return nil, f.err
+}
+
 func collectExecutionIDs(ids []string, events []trace.Event) []string {
 	seen := make(map[string]struct{}, len(ids)+len(events))
 	out := make([]string, 0, len(ids)+len(events))

--- a/internal/runtime/session.go
+++ b/internal/runtime/session.go
@@ -42,6 +42,9 @@ func (s *Session) exec(ctx context.Context, req *ExecutionRequest) (*ExecutionRe
 	if req == nil {
 		req = &ExecutionRequest{}
 	}
+	if err := validateExecutionRequest(req); err != nil {
+		return nil, err
+	}
 	ctx, cancel := executionContext(ctx, req.Timeout)
 	defer cancel()
 
@@ -49,6 +52,9 @@ func (s *Session) exec(ctx context.Context, req *ExecutionRequest) (*ExecutionRe
 	execEnv := executionEnv(s.cfg.BaseEnv, req)
 	visiblePWD, hasVisiblePWD := execEnv["PWD"]
 	execEnv["PWD"] = workDir
+	if len(req.Command) > 0 {
+		execEnv["__JB_PWD"] = workDir
+	}
 	if !s.bootAt.IsZero() {
 		execEnv["GBASH_SESSION_BOOT_AT"] = s.bootAt.Format(time.RFC3339)
 	}
@@ -94,9 +100,10 @@ func (s *Session) exec(ctx context.Context, req *ExecutionRequest) (*ExecutionRe
 		Name:        baseLogEvent.Name,
 		WorkDir:     baseLogEvent.WorkDir,
 	})
-	runResult, runErr := s.cfg.Engine.Run(ctx, &shell.Execution{
+	execReq := &shell.Execution{
 		Name:           baseLogEvent.Name,
 		Script:         req.Script,
+		Command:        cloneStrings(req.Command),
 		Args:           req.Args,
 		StartupOptions: req.StartupOptions,
 		Interactive:    req.Interactive,
@@ -114,7 +121,16 @@ func (s *Session) exec(ctx context.Context, req *ExecutionRequest) (*ExecutionRe
 		Trace:          recorder,
 		Exec:           s.subexecCallback,
 		Interact:       s.interactCallback,
-	})
+	}
+	var (
+		runResult *shell.RunResult
+		runErr    error
+	)
+	if len(req.Command) > 0 {
+		runResult, runErr = s.cfg.Engine.RunCommand(ctx, execReq)
+	} else {
+		runResult, runErr = s.cfg.Engine.Run(ctx, execReq)
+	}
 	finished := time.Now().UTC()
 
 	var events []trace.Event
@@ -267,6 +283,16 @@ func executionContext(ctx context.Context, timeout time.Duration) (context.Conte
 		return ctx, func() {}
 	}
 	return context.WithTimeout(ctx, timeout)
+}
+
+func validateExecutionRequest(req *ExecutionRequest) error {
+	if req == nil {
+		return nil
+	}
+	if req.Script != "" && len(req.Command) > 0 {
+		return errors.New("execution request cannot set both Script and Command")
+	}
+	return nil
 }
 
 func runtimeVisiblePWDMatchesCurrentDir(ctx context.Context, fsys gbfs.FileSystem, candidate string) bool {

--- a/internal/runtime/subexec_test.go
+++ b/internal/runtime/subexec_test.go
@@ -34,15 +34,35 @@ func (c *subexecProbe) Run(ctx context.Context, inv *commands.Invocation) error 
 	switch inv.Args[0] {
 	case "inherit":
 		result, err = inv.Exec(ctx, &commands.ExecutionRequest{
-			Script: "echo \"$FOO\"\npwd\ncat note.txt\n",
+			Command: []string{"printenv", "FOO"},
 		})
+		if err == nil {
+			if _, writeErr := io.WriteString(inv.Stdout, result.Stdout); writeErr != nil {
+				return writeErr
+			}
+			result, err = inv.Exec(ctx, &commands.ExecutionRequest{Command: []string{"pwd"}})
+		}
+		if err == nil {
+			if _, writeErr := io.WriteString(inv.Stdout, result.Stdout); writeErr != nil {
+				return writeErr
+			}
+			result, err = inv.Exec(ctx, &commands.ExecutionRequest{Command: []string{"cat", "note.txt"}})
+		}
 	case "write":
 		result, err = inv.Exec(ctx, &commands.ExecutionRequest{
-			Script: "echo nested > nested.txt\n",
+			Command: []string{"cp", "note.txt", "nested.txt"},
 		})
 	case "deny":
 		result, err = inv.Exec(ctx, &commands.ExecutionRequest{
-			Script: "cat /denied.txt\n",
+			Command: []string{"cat", "/denied.txt"},
+		})
+	case "missing":
+		result, err = inv.Exec(ctx, &commands.ExecutionRequest{
+			Command: []string{"definitely-missing-command"},
+		})
+	case "shebang":
+		result, err = inv.Exec(ctx, &commands.ExecutionRequest{
+			Command: []string{"/tmp/subexec-script.sh", "value"},
 		})
 	default:
 		return fmt.Errorf("unknown mode %q", inv.Args[0])
@@ -61,7 +81,7 @@ func (c *subexecProbe) Run(ctx context.Context, inv *commands.Invocation) error 
 			return err
 		}
 	}
-	if inv.Args[0] == "deny" {
+	if inv.Args[0] == "deny" || inv.Args[0] == "missing" {
 		if _, err := fmt.Fprintf(inv.Stdout, "exit=%d\n", result.ExitCode); err != nil {
 			return err
 		}
@@ -99,7 +119,7 @@ func TestInvocationExecInheritsEnvDirAndSessionState(t *testing.T) {
 func TestInvocationExecUsesSameSessionFilesystem(t *testing.T) {
 	session := newSession(t, &Config{Registry: registryWithSubexecProbe(t)})
 
-	result := mustExecSession(t, session, "subexecprobe write\ncat nested.txt\n")
+	result := mustExecSession(t, session, "echo nested > note.txt\nsubexecprobe write\ncat nested.txt\n")
 	if result.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
 	}
@@ -138,6 +158,36 @@ func TestInvocationExecStaysWithinSessionPolicyBoundary(t *testing.T) {
 	}
 	if !strings.Contains(result.Stderr, `command "cat" denied`) {
 		t.Fatalf("Stderr = %q, want nested policy denial message", result.Stderr)
+	}
+}
+
+func TestInvocationExecReturns127ForMissingDirectCommand(t *testing.T) {
+	rt := newRuntime(t, &Config{Registry: registryWithSubexecProbe(t)})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "subexecprobe missing\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if !strings.Contains(result.Stdout, "exit=127") {
+		t.Fatalf("Stdout = %q, want nested command-not-found exit code", result.Stdout)
+	}
+}
+
+func TestInvocationExecRunsShebangBackedCommand(t *testing.T) {
+	session := newSession(t, &Config{Registry: registryWithSubexecProbe(t)})
+	writeSessionFile(t, session, "/tmp/subexec-script.sh", []byte("#!/bin/sh\nprintf 'script:%s\\n' \"$1\"\n"))
+
+	result := mustExecSession(t, session, "chmod 755 /tmp/subexec-script.sh\nsubexecprobe shebang\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "script:value\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 }
 

--- a/internal/shell/mvdan.go
+++ b/internal/shell/mvdan.go
@@ -30,6 +30,7 @@ import (
 type Engine interface {
 	Parse(name, script string) (*syntax.File, error)
 	Run(ctx context.Context, exec *Execution) (*RunResult, error)
+	RunCommand(ctx context.Context, exec *Execution) (*RunResult, error)
 }
 
 type InteractiveEngine interface {
@@ -39,6 +40,7 @@ type InteractiveEngine interface {
 type Execution struct {
 	Name              string
 	Script            string
+	Command           []string
 	Program           *syntax.File
 	Args              []string
 	StartupOptions    []string
@@ -203,6 +205,94 @@ func (m *MVdan) Run(ctx context.Context, exec *Execution) (result *RunResult, ru
 		FinalEnv:    envMapFromVars(runner.Vars),
 		ShellExited: runner.Exited(),
 	}, runErr
+}
+
+func (m *MVdan) RunCommand(ctx context.Context, exec *Execution) (*RunResult, error) {
+	if exec == nil {
+		exec = &Execution{}
+	}
+	if exec.Dir == "" {
+		exec.Dir = "/"
+	}
+	if exec.Stdin == nil {
+		exec.Stdin = strings.NewReader("")
+	}
+	if exec.Stdout == nil {
+		exec.Stdout = io.Discard
+	}
+	if exec.Stderr == nil {
+		exec.Stderr = io.Discard
+	}
+	if exec.Trace == nil {
+		exec.Trace = trace.NopRecorder{}
+	}
+
+	finalEnv := mergeEnv(nil, exec.Env)
+	if len(exec.Command) == 0 {
+		return &RunResult{FinalEnv: finalEnv}, nil
+	}
+
+	env := expand.ListEnviron(envPairs(finalEnv)...)
+	virtualWD := virtualDir(env, exec.Dir)
+	resolved, ok, err := lookupCommand(ctx, exec, virtualWD, env, exec.Command[0])
+	if err != nil {
+		if policy.IsDenied(err) {
+			recordPolicyDenied(exec.Trace, err, string(policy.FileActionStat), "", exec.Command[0], 126, "")
+			return &RunResult{FinalEnv: finalEnv}, shellFailureToWriter(ctx, exec.Stderr, 126, "%v", err)
+		}
+		return &RunResult{FinalEnv: finalEnv}, err
+	}
+	start := time.Now().UTC()
+	if !ok {
+		return &RunResult{FinalEnv: finalEnv}, shellFailureToWriter(ctx, exec.Stderr, 127, "%s: command not found", exec.Command[0])
+	}
+	if err := allowCommand(ctx, exec.Policy, resolved.name, exec.Command); err != nil {
+		recordPolicyDenied(exec.Trace, err, "", resolved.path, resolved.name, 126, resolved.source)
+		return &RunResult{FinalEnv: finalEnv}, shellFailureToWriter(ctx, exec.Stderr, 126, "%v", err)
+	}
+	recordCommand(exec.Trace, trace.EventCommandStart, traceCommandInfo(exec.Command, false, &commandTraceResolution{
+		Dir:              virtualWD,
+		ResolvedName:     resolved.name,
+		ResolvedPath:     resolved.path,
+		ResolutionSource: resolved.source,
+	}))
+
+	finalEnv, err = invokeResolvedCommand(ctx, exec, resolved, exec.Command, finalEnv, virtualWD, exec.Stdin, exec.Stdout, exec.Stderr)
+	result := &RunResult{FinalEnv: finalEnv}
+	if err == nil {
+		recordCommand(exec.Trace, trace.EventCommandExit, traceCommandInfo(exec.Command, false, &commandTraceResolution{
+			Dir:              virtualWD,
+			ExitCode:         0,
+			Duration:         time.Since(start),
+			ResolvedName:     resolved.name,
+			ResolvedPath:     resolved.path,
+			ResolutionSource: resolved.source,
+		}))
+		return result, nil
+	}
+	if code, ok := commands.ExitCode(err); ok {
+		if message, ok := commands.DiagnosticMessage(err); ok && exec.Stderr != nil {
+			_, _ = fmt.Fprintln(exec.Stderr, message)
+		}
+		recordCommand(exec.Trace, trace.EventCommandExit, traceCommandInfo(exec.Command, false, &commandTraceResolution{
+			Dir:              virtualWD,
+			ExitCode:         code,
+			Duration:         time.Since(start),
+			ResolvedName:     resolved.name,
+			ResolvedPath:     resolved.path,
+			ResolutionSource: resolved.source,
+		}))
+		return result, interp.ExitStatus(code)
+	}
+	recordCommand(exec.Trace, trace.EventCommandExit, traceCommandInfo(exec.Command, false, &commandTraceResolution{
+		Dir:              virtualWD,
+		ExitCode:         1,
+		Duration:         time.Since(start),
+		ResolvedName:     resolved.name,
+		ResolvedPath:     resolved.path,
+		ResolutionSource: resolved.source,
+	}))
+	return result, err
 }
 
 func (m *MVdan) runnerOptions(exec *Execution, budget *executionBudget) []interp.RunnerOption {
@@ -430,34 +520,11 @@ func (m *MVdan) execHandler(exec *Execution, budget *executionBudget) interp.Exe
 			}))
 		}
 
-		invocationArgs := append([]string(nil), resolved.args...)
-		invocationArgs = append(invocationArgs, args[1:]...)
-		invocation := commands.NewInvocation(&commands.InvocationOptions{
-			Args:       invocationArgs,
-			Env:        currentEnv,
-			Cwd:        virtualWD,
-			Stdin:      hc.Stdin,
-			Stdout:     hc.Stdout,
-			Stderr:     hc.Stderr,
-			FileSystem: exec.FS,
-			Network:    exec.Network,
-			Policy:     exec.Policy,
-			Trace:      exec.Trace,
-			Exec:       subexecInvoker(exec.Exec, currentEnv, virtualWD),
-			Interact:   interactiveInvoker(exec.Interact, currentEnv, virtualWD),
-			GetRegisteredCommands: func() []string {
-				if exec.Registry == nil {
-					return nil
-				}
-				return exec.Registry.Names()
-			},
-		})
-		commandCtx := shellstate.WithCompletionState(ctx, completionStateForExecution(exec))
-		err = commands.RunCommand(commandCtx, resolved.command, invocation)
-		if syncErr := syncCommandHistory(ctx, &hc, currentEnv, invocation.Env); syncErr != nil {
+		finalEnv, err := invokeResolvedCommand(ctx, exec, resolved, args, currentEnv, virtualWD, hc.Stdin, hc.Stdout, hc.Stderr)
+		if syncErr := syncCommandHistory(ctx, &hc, currentEnv, finalEnv); syncErr != nil {
 			return syncErr
 		}
-		if syncErr := syncUmaskEnv(ctx, &hc, currentEnv, invocation.Env); syncErr != nil {
+		if syncErr := syncUmaskEnv(ctx, &hc, currentEnv, finalEnv); syncErr != nil {
 			return syncErr
 		}
 
@@ -509,6 +576,45 @@ func (m *MVdan) execHandler(exec *Execution, budget *executionBudget) interp.Exe
 	}
 }
 
+func invokeResolvedCommand(
+	ctx context.Context,
+	exec *Execution,
+	resolved *resolvedCommand,
+	argv []string,
+	currentEnv map[string]string,
+	virtualWD string,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+) (map[string]string, error) {
+	invocationArgs := append([]string(nil), resolved.args...)
+	if len(argv) > 1 {
+		invocationArgs = append(invocationArgs, argv[1:]...)
+	}
+	invocation := commands.NewInvocation(&commands.InvocationOptions{
+		Args:       invocationArgs,
+		Env:        currentEnv,
+		Cwd:        virtualWD,
+		Stdin:      stdin,
+		Stdout:     stdout,
+		Stderr:     stderr,
+		FileSystem: exec.FS,
+		Network:    exec.Network,
+		Policy:     exec.Policy,
+		Trace:      exec.Trace,
+		Exec:       subexecInvoker(exec.Exec, currentEnv, virtualWD),
+		Interact:   interactiveInvoker(exec.Interact, currentEnv, virtualWD),
+		GetRegisteredCommands: func() []string {
+			if exec.Registry == nil {
+				return nil
+			}
+			return exec.Registry.Names()
+		},
+	})
+	commandCtx := shellstate.WithCompletionState(ctx, completionStateForExecution(exec))
+	return invocation.Env, commands.RunCommand(commandCtx, resolved.command, invocation)
+}
+
 func subexecInvoker(execFn func(context.Context, *commands.ExecutionRequest) (*commands.ExecutionResult, error), currentEnv map[string]string, currentDir string) func(context.Context, *commands.ExecutionRequest) (*commands.ExecutionResult, error) {
 	if execFn == nil {
 		return nil
@@ -549,6 +655,7 @@ func normalizeSubexecRequest(req *commands.ExecutionRequest, currentEnv map[stri
 		Interpreter:     req.Interpreter,
 		PassthroughArgs: append([]string(nil), req.PassthroughArgs...),
 		Script:          req.Script,
+		Command:         append([]string(nil), req.Command...),
 		Args:            append([]string(nil), req.Args...),
 		StartupOptions:  append([]string(nil), req.StartupOptions...),
 		Env:             mergeEnv(currentEnv, req.Env),


### PR DESCRIPTION
## Summary
- add an explicit `ExecutionRequest.Command` path for argv-style nested execution and document it in `SPEC.md`
- route direct nested command execution through the existing command resolution, policy, PATH, tracing, and shebang machinery without reparsing a synthetic shell script
- switch shared subexec helpers to the direct-command path and add regressions for the short nested timeout case, direct nested exec behavior, and xargs shebang execution

## Testing
- `go test ./internal/runtime ./internal/builtins -count=1`
- `go test ./internal/runtime -run 'FuzzGeneratedPrograms/8da3948462fc6094' -count=10`
- `go test ./internal/runtime -run=^$ -fuzz=FuzzGeneratedPrograms -fuzztime=10s`
- `make lint`
