### PR TITLE
builtins: support Bash printf character constants

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -75,6 +75,8 @@ The shell adapter may pre-validate parsed AST forms that are known to trigger `m
 
 The shell adapter may also apply small AST normalizations before execution when `mvdan/sh` behavior diverges from the Bash semantics we intend to preserve. One example is wrapping the right-hand side of pipelines in explicit subshells so parent-shell state matches Bash's default `lastpipe=off` behavior.
 
+Registry-backed replacements for Bash builtins should preserve shell-visible Bash coercions when practical. One compatibility requirement is that numeric `printf` conversions accept quoted character constants such as `"'A"` and `"\"B"`.
+
 ### 5.3 Project-owned boundaries
 
 The runtime owns:

--- a/internal/builtins/printf.go
+++ b/internal/builtins/printf.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 type Printf struct{}
@@ -150,20 +151,66 @@ func applyPrintfSpec(spec string, verb byte, arg string) (formatted string, stop
 	case 's', 'q':
 		return fmt.Sprintf(spec, arg), false, nil
 	case 'c':
-		value, _ := strconv.ParseInt(arg, 0, 64)
-		return fmt.Sprintf(spec, rune(value)), false, nil
+		return fmt.Sprintf(spec, printfCharArg(arg)), false, nil
 	case 'd', 'i', 'o', 'u', 'x', 'X':
-		value, _ := strconv.ParseInt(arg, 0, 64)
+		value := parsePrintfIntArg(arg)
+		if verb == 'i' {
+			return fmt.Sprintf(spec[:len(spec)-1]+"d", value), false, nil
+		}
 		if verb == 'u' {
 			return fmt.Sprintf(spec[:len(spec)-1]+"d", uint64(value)), false, nil
 		}
 		return fmt.Sprintf(spec, value), false, nil
 	case 'e', 'E', 'f', 'F', 'g', 'G':
-		value, _ := strconv.ParseFloat(arg, 64)
+		value := parsePrintfFloatArg(arg)
 		return fmt.Sprintf(spec, value), false, nil
 	default:
 		return "", false, fmt.Errorf("unsupported format verb %%%c", verb)
 	}
+}
+
+func printfCharArg(arg string) rune {
+	if arg == "" {
+		return 0
+	}
+	r, size := utf8.DecodeRuneInString(arg)
+	if r == utf8.RuneError && size == 1 {
+		return rune(arg[0])
+	}
+	return r
+}
+
+func parsePrintfIntArg(arg string) int64 {
+	if value, ok := parsePrintfQuotedCharArg(arg); ok {
+		return value
+	}
+	value, _ := strconv.ParseInt(arg, 0, 64)
+	return value
+}
+
+func parsePrintfFloatArg(arg string) float64 {
+	if value, ok := parsePrintfQuotedCharArg(arg); ok {
+		return float64(value)
+	}
+	value, _ := strconv.ParseFloat(arg, 64)
+	return value
+}
+
+func parsePrintfQuotedCharArg(arg string) (int64, bool) {
+	if len(arg) < 2 {
+		return 0, false
+	}
+	if arg[0] != '\'' && arg[0] != '"' {
+		return 0, false
+	}
+	r, size := utf8.DecodeRuneInString(arg[1:])
+	if r == utf8.RuneError && size == 1 {
+		return int64(arg[1]), true
+	}
+	if size == 0 {
+		return 0, false
+	}
+	return int64(r), true
 }
 
 func isPrintfVerb(ch byte) bool {

--- a/internal/builtins/printf_test.go
+++ b/internal/builtins/printf_test.go
@@ -1,0 +1,34 @@
+package builtins_test
+
+import "testing"
+
+func TestPrintfSupportsBashNumericCharConstants(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	result := mustExecSession(t, session,
+		"single=\"'A\"\n"+
+			"double='\"B'\n"+
+			"printf '%d|%i|%o|%u|%x|%X|%.1f|%g\\n' \"$single\" \"$single\" \"$single\" \"$single\" \"$single\" \"$single\" \"$single\" \"$double\"\n",
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "65|65|101|65|41|41|65.0|66\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}
+
+func TestPrintfCharacterFormatUsesFirstCharacter(t *testing.T) {
+	session := newSession(t, &Config{})
+
+	result := mustExecSession(t, session,
+		"quoted=\"'B\"\n"+
+			"printf '%c%c%c%c' A 65 \"$quoted\" '' | od -An -tx1 -v\n",
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, " 41 36 27 00\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- support Bash-style quoted character constants for numeric and float `printf` conversions
- make `%c` consume the first character of its argument and map `%i` to integer formatting
- add regression coverage and document the builtin compatibility rule in `SPEC.md`

## Testing
- `go test ./internal/builtins`
- `go test ./... ./contrib/extras/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...`
- `make lint`