### PR TITLE
tests: fix flaky timeout trampoline overhead test

### DIFF
--- a/internal/builtins/timeout_test.go
+++ b/internal/builtins/timeout_test.go
@@ -112,7 +112,7 @@ func TestTimeoutShortNestedCommandAvoidsShellTrampolineOverhead(t *testing.T) {
 	t.Parallel()
 	rt := newRuntime(t, &Config{})
 
-	const script = "if true; then timeout 0.01 sleep 0.001; else sed -n '1,3p' /tmp/text.txt; fi\n"
+	const script = "if true; then timeout 0.05 sleep 0.001; else sed -n '1,3p' /tmp/text.txt; fi\n"
 	for i := range 20 {
 		result, err := rt.Run(context.Background(), &ExecutionRequest{Script: script})
 		if err != nil {


### PR DESCRIPTION
## Summary
- Bumps timeout from 10ms to 50ms in `TestTimeoutShortNestedCommandAvoidsShellTrampolineOverhead` to avoid false failures under CI load.
- The test still validates that the direct exec path avoids shell trampoline overhead — 50ms is plenty of headroom for setup while still being tight enough to catch a regression to the old shell-trampoline path.

## Test plan
- [ ] `go test ./internal/builtins/ -run TestTimeoutShortNested -count=10` passes consistently