### PR TITLE
security: add observability regressions

### DIFF
--- a/internal/runtime/observability_test.go
+++ b/internal/runtime/observability_test.go
@@ -136,6 +136,72 @@ func TestTraceRawPreservesSensitiveArgv(t *testing.T) {
 	}
 }
 
+func TestTraceRedactedLeavesResultsFinalEnvAndLoggerOutputsRaw(t *testing.T) {
+	t.Parallel()
+	var (
+		callbackEvents []trace.Event
+		logEvents      []LogEvent
+	)
+	rt := newRuntime(t, &Config{
+		Tracing: TraceConfig{
+			Mode: TraceRedacted,
+			OnEvent: func(_ context.Context, event trace.Event) {
+				callbackEvents = append(callbackEvents, event)
+			},
+		},
+		Logger: func(_ context.Context, event LogEvent) {
+			logEvents = append(logEvents, event)
+		},
+	})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "" +
+			"export API_TOKEN=env-secret\n" +
+			"printf 'stdout:%s\\n' \"$API_TOKEN\"\n" +
+			"printf 'stderr:%s\\n' \"$API_TOKEN\" >&2\n" +
+			"echo -H 'Authorization: Bearer argv-secret' >/dev/null\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got, want := result.Stdout, "stdout:env-secret\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+	if got, want := result.Stderr, "stderr:env-secret\n"; got != want {
+		t.Fatalf("Stderr = %q, want %q", got, want)
+	}
+	if got, want := result.FinalEnv["API_TOKEN"], "env-secret"; got != want {
+		t.Fatalf("FinalEnv[API_TOKEN] = %q, want %q", got, want)
+	}
+
+	event := findCommandEvent(callbackEvents, trace.EventCallExpanded, "echo")
+	if event == nil || event.Command == nil {
+		t.Fatalf("missing callback echo event: %#v", callbackEvents)
+	}
+	if !event.Redacted {
+		t.Fatalf("event.Redacted = %t, want true", event.Redacted)
+	}
+	if got, want := event.Command.Argv, []string{"echo", "-H", "Authorization: [REDACTED]"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("redacted argv = %#v, want %#v", got, want)
+	}
+
+	stdoutEvent := findLogEvent(logEvents, LogStdout)
+	if stdoutEvent == nil {
+		t.Fatalf("missing stdout log event: %#v", logEvents)
+	}
+	if got, want := stdoutEvent.Output, "stdout:env-secret\n"; got != want {
+		t.Fatalf("stdout log output = %q, want %q", got, want)
+	}
+
+	stderrEvent := findLogEvent(logEvents, LogStderr)
+	if stderrEvent == nil {
+		t.Fatalf("missing stderr log event: %#v", logEvents)
+	}
+	if got, want := stderrEvent.Output, "stderr:env-secret\n"; got != want {
+		t.Fatalf("stderr log output = %q, want %q", got, want)
+	}
+}
+
 func TestNestedExecTracingInvokesInheritedCallbacks(t *testing.T) {
 	t.Parallel()
 	var executionIDs []string
@@ -343,4 +409,13 @@ func logKinds(events []LogEvent) []LogKind {
 		out = append(out, events[i].Kind)
 	}
 	return out
+}
+
+func findLogEvent(events []LogEvent, kind LogKind) *LogEvent {
+	for i := range events {
+		if events[i].Kind == kind {
+			return &events[i]
+		}
+	}
+	return nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -227,6 +227,40 @@ func TestServerConcurrentSessionsAndBusy(t *testing.T) {
 	}
 }
 
+func TestServerExecReturnsRawOutputsAndFinalEnvWithTraceRedacted(t *testing.T) {
+	t.Parallel()
+	srv := startServer(t, gbserver.Config{
+		Name:       "gbash",
+		Version:    "test",
+		SessionTTL: time.Second,
+	}, gbash.WithTracing(gbash.TraceConfig{Mode: gbash.TraceRedacted}))
+	client := dialClient(t, srv.socket)
+	defer client.Close()
+
+	sessionID := mustCreateSession(t, client)
+	exec := client.call("session.exec", map[string]any{
+		"session_id": sessionID,
+		"script": "" +
+			"export API_TOKEN=env-secret\n" +
+			"printf 'stdout:%s\\n' \"$API_TOKEN\"\n" +
+			"printf 'stderr:%s\\n' \"$API_TOKEN\" >&2\n" +
+			"echo -H 'Authorization: Bearer argv-secret' >/dev/null\n",
+	})
+	mustOK(t, &exec)
+
+	var payload execResult
+	decodeResult(t, &exec, &payload)
+	if got, want := payload.Stdout, "stdout:env-secret\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if got, want := payload.Stderr, "stderr:env-secret\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+	if got, want := payload.FinalEnv["API_TOKEN"], "env-secret"; got != want {
+		t.Fatalf("FinalEnv[API_TOKEN] = %q, want %q", got, want)
+	}
+}
+
 func TestServerSessionTTLExpiry(t *testing.T) {
 	t.Parallel()
 	srv := startServer(t, gbserver.Config{


### PR DESCRIPTION
## Summary
- add TM-005 runtime coverage showing TraceRedacted still returns raw stdout, stderr, and FinalEnv
- add TM-005 server coverage showing session.exec returns the same raw outputs under TraceRedacted
- document the current leak boundary in tests so future changes are explicit

## Testing
- go test ./internal/runtime ./server
- make lint