### PR TITLE
network: tighten allowlist path matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,8 @@ gb, err := gbash.New(
 )
 ```
 
+Allowed URL prefixes are origin- and path-boundary aware. For example, `https://api.example.com/v1` matches `/v1` and `/v1/...`, but not `/v10`.
+
 For full transport control in tests or embedding, inject your own `Config.NetworkClient`.
 See [`examples/oauth-network-extension`](./examples/oauth-network-extension) for a demo that injects OAuth headers from a host-side vault so the sandbox never sees the bearer token.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -251,7 +251,7 @@ Package responsibilities:
 - `internal/runtime/`: internal runtime/session creation, run configuration, result collection, output capture
 - `shell/`: parser and runner adapter; no product policy lives here
 - `fs/`: POSIX-like path normalization, memory filesystem, host-backed lower layers, overlay, and snapshot backends
-- `network/`: runtime-owned HTTP sandbox with URL-prefix allowlists, method controls, redirect revalidation, and response-size limits
+- `network/`: runtime-owned HTTP sandbox with origin- and path-boundary-aware allowlists, method controls, redirect revalidation, and response-size limits
 - `commands/`: registry and Go-native command implementations such as `clear`, `complete`, `compopt`, `echo`, `egrep`, `fgrep`, `grep`, `history`, `ls`, `pwd`, `strings`, and `xan`
 - `contrib/`: opt-in command modules that stay outside the root module dependency graph so heavyweight helpers do not inflate the core runtime. The repository may also expose umbrella contrib helpers such as `contrib/extras` to register the stable official contrib command set without changing the default runtime surface, and may ship official opt-in binaries such as `contrib/extras/cmd/gbash-extras` from the corresponding contrib module. Current examples include `awk`, `html-to-markdown`, `jq`, `nodejs`, `sqlite3`, and `yq`.
 - `packages/`: publishable JavaScript and TypeScript packages. `packages/gbash-wasm` owns the `js/wasm` assets plus explicit host entrypoints such as `@ewhauser/gbash-wasm/browser` and `@ewhauser/gbash-wasm/node`.

--- a/internal/builtins/curl_test.go
+++ b/internal/builtins/curl_test.go
@@ -77,6 +77,34 @@ func TestCurlBlocksDisallowedOrigin(t *testing.T) {
 	}
 }
 
+func TestCurlBlocksPathPrefixConfusion(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer server.Close()
+
+	rt := newRuntime(t, &Config{
+		Network: &NetworkConfig{
+			AllowedURLPrefixes: []string{server.URL + "/private"},
+			DenyPrivateRanges:  false,
+		},
+	})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "curl " + server.URL + "/private-token\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 7 {
+		t.Fatalf("ExitCode = %d, want 7", result.ExitCode)
+	}
+	if !strings.Contains(result.Stderr, "allowlist") {
+		t.Fatalf("Stderr = %q, want allowlist denial", result.Stderr)
+	}
+}
+
 func TestCurlBlocksDisallowedMethodByDefault(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/network/network.go
+++ b/network/network.go
@@ -454,14 +454,24 @@ func urlAllowed(target *url.URL, entries []allowListEntry) bool {
 		if origin != entry.origin {
 			continue
 		}
-		if entry.pathPrefix == "/" || entry.pathPrefix == "" {
-			return true
-		}
-		if strings.HasPrefix(pathname, entry.pathPrefix) {
+		if allowListPathMatches(pathname, entry.pathPrefix) {
 			return true
 		}
 	}
 	return false
+}
+
+func allowListPathMatches(pathname, prefix string) bool {
+	if prefix == "" || prefix == "/" {
+		return true
+	}
+	if pathname == prefix {
+		return true
+	}
+	if strings.HasSuffix(prefix, "/") {
+		return strings.HasPrefix(pathname, prefix)
+	}
+	return strings.HasPrefix(pathname, prefix+"/")
 }
 
 func resolveRedirectURL(currentURL, location string) (string, error) {

--- a/network/network_fuzz_test.go
+++ b/network/network_fuzz_test.go
@@ -20,12 +20,14 @@ func FuzzHTTPClientPolicy(f *testing.F) {
 
 		allowlist := []string{
 			"https://api.example.com/",
+			"https://api.example.com/private",
 			"https://api.example.com/private/",
 			"https://cdn.example.com/files/",
 		}
 		requests := []string{
 			"https://api.example.com/data",
 			"https://api.example.com/private/token",
+			"https://api.example.com/private-token",
 			"https://cdn.example.com/files/item.txt",
 			"https://evil.example.net/data",
 			"http://localhost/admin",
@@ -34,6 +36,7 @@ func FuzzHTTPClientPolicy(f *testing.F) {
 			"",
 			"/data",
 			"https://api.example.com/data",
+			"https://api.example.com/private-token",
 			"https://evil.example.net/data",
 			"http://localhost/admin",
 		}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,17 @@ type resolverFunc func(context.Context, string) ([]net.IPAddr, error)
 
 func (fn resolverFunc) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
 	return fn(ctx, host)
+}
+
+type staticHTTPDoer struct{}
+
+func (staticHTTPDoer) Do(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader("ok")),
+	}, nil
 }
 
 func TestNewRejectsInvalidAllowList(t *testing.T) {
@@ -69,6 +81,33 @@ func TestClientBlocksPathOutsideAllowListPrefix(t *testing.T) {
 	}
 }
 
+func TestClientTreatsAllowListPathsAsSegmentBoundaries(t *testing.T) {
+	t.Parallel()
+	client, err := New(&Config{
+		AllowedURLPrefixes: []string{"https://api.example.com/private"},
+	}, WithDoer(staticHTTPDoer{}))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	for _, target := range []string{
+		"https://api.example.com/private",
+		"https://api.example.com/private/token",
+	} {
+		_, err := client.Do(context.Background(), &Request{URL: target})
+		if err != nil {
+			t.Fatalf("Do(%q) error = %v, want allowed request", target, err)
+		}
+	}
+
+	_, err = client.Do(context.Background(), &Request{
+		URL: "https://api.example.com/private-token",
+	})
+	if !IsDenied(err) {
+		t.Fatalf("Do() error = %v, want denied sibling-path request", err)
+	}
+}
+
 func TestClientBlocksDisallowedMethod(t *testing.T) {
 	t.Parallel()
 	client, err := New(&Config{
@@ -106,6 +145,32 @@ func TestClientRevalidatesRedirectTargets(t *testing.T) {
 
 	_, err = client.Do(context.Background(), &Request{
 		URL:             server.URL,
+		FollowRedirects: true,
+	})
+	var redirectErr *RedirectNotAllowedError
+	if !errors.As(err, &redirectErr) {
+		t.Fatalf("Do() error = %v, want redirect denied error", err)
+	}
+}
+
+func TestClientRevalidatesRedirectTargetsAcrossPathBoundary(t *testing.T) {
+	t.Parallel()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, server.URL+"/private-token", http.StatusFound)
+	}))
+	defer server.Close()
+
+	client, err := New(&Config{
+		AllowedURLPrefixes: []string{server.URL + "/private"},
+		DenyPrivateRanges:  false,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	_, err = client.Do(context.Background(), &Request{
+		URL:             server.URL + "/private",
 		FollowRedirects: true,
 	})
 	var redirectErr *RedirectNotAllowedError


### PR DESCRIPTION
## Summary
- harden URL allowlist matching so path prefixes respect segment boundaries instead of raw lexical prefixes
- add TM-003 regressions for sibling-path denial, redirect revalidation across the same-origin boundary, and end-to-end curl coverage
- seed the network fuzz corpus with the new path-confusion cases and document the boundary-aware behavior

## Testing
- go test ./network ./internal/builtins
- make lint