### PR TITLE
test: add bats test infrastructure for scripts/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test conformance-test build fuzz fuzz-run fuzz-shard fuzz-smoke fuzz-full bench-smoke bench-full bench-compare bench-fs gnu-test compat-docker-build compat-docker-run website-dev release release-check release-snapshot fix-modules tag-release
+.PHONY: lint test conformance-test build fuzz fuzz-run fuzz-shard fuzz-smoke fuzz-full bench-smoke bench-full bench-compare bench-fs gnu-test compat-docker-build compat-docker-run website-dev release release-check release-snapshot fix-modules tag-release bats-test
 
 GO_PACKAGES := ./... ./contrib/awk/... ./contrib/extras/... ./contrib/htmltomarkdown/... ./contrib/sqlite3/... ./contrib/jq/... ./contrib/yq/... ./examples/...
 BENCH_PACKAGES := ./internal/runtime ./cmd/gbash ./contrib/jq
@@ -265,3 +265,7 @@ fix-modules:
 
 tag-release:
 	PUSH='$(PUSH_TAGS)' REMOTE='$(TAG_REMOTE)' ./scripts/tag_release.sh $(RELEASE_VERSION)
+
+bats-test:
+	@go build -o scripts/tests/.gbash-test-bin ./cmd/gbash/
+	bats scripts/tests/

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,80 @@
+# scripts/
+
+Shell scripts for CI/CD, releases, and compatibility testing.
+
+## Bats tests
+
+Tests live in `scripts/tests/` and use [bats-core](https://github.com/bats-core/bats-core).
+Bats itself runs under the system bash. Each test invokes scripts under gbash
+using `--readwrite-root` pointed at a temporary sandbox directory.
+
+### Running
+
+```
+make bats-test
+```
+
+This builds gbash into `scripts/tests/.gbash-test-bin` and runs all `.bats`
+files in `scripts/tests/`.
+
+Bats must be installed (`brew install bats-core`).
+
+### How the sandbox works
+
+`test_helper.bash` provides two key functions:
+
+- `run_gbash "<command>"` -- runs a command string inside gbash with
+  `--readwrite-root` set to `$SANDBOX`. The sandbox root becomes `/` inside
+  gbash. Scripts, stubs, and state files all go under `$SANDBOX`.
+- `create_stub <name> <body>` -- writes an executable shell script into
+  `$SANDBOX/bin/` so it appears in gbash's PATH at `/bin/`.
+
+The default `setup` creates `$TEST_TEMP_DIR`, `$SANDBOX`, and `$STUB_BIN`.
+Override `setup` in your `.bats` file to add script copies, directory layout,
+and stubs. Always call `rm -rf "${TEST_TEMP_DIR}"` in `teardown`.
+
+### Writing a new test file
+
+1. Create `scripts/tests/<script_name>.bats`.
+2. Start with `load test_helper`.
+3. In `setup`, copy the script into the sandbox and create stubs for any
+   external commands (git, docker, curl, etc.). Use state files under
+   `$SANDBOX/state/` to control stub behavior per test.
+4. Use `run_gbash "scripts/foo.sh arg1 arg2"` to invoke the script.
+5. Assert on `$status` and `$output`.
+
+See `tag_release.bats` for a full example with a multi-case git stub.
+
+### Stub tips
+
+Stubs run as `/bin/sh` inside the gbash sandbox, which is gbash itself. Keep
+stub logic simple -- `case` statements dispatching on `$1` work well.
+
+Use files under `/state/` to make stubs configurable per test. For example, the
+git stub in `tag_release.bats` reads `/state/branch` to return the current
+branch and `/state/tags/<name>` to simulate existing tags.
+
+When a command has positional args you need to extract (like
+`git rev-list -n 1 <tag>`), count positions carefully. There is no `shift`
+happening implicitly -- `$1` is the subcommand, and everything after follows in
+order.
+
+### gbash compatibility
+
+Scripts must parse and run under gbash to be testable. Some bash features are
+not supported. When you hit one, adapt the script to use a compatible
+alternative that still works under regular bash.
+
+Known limitations:
+
+- Process substitution (`< <(cmd)`, `>(cmd)`) is not supported. It fails at
+  parse time with "invalid redirection". Use `for x in $(cmd)` when the loop
+  variable does not need to survive a subshell, or capture into a variable
+  first.
+- `BASH_SOURCE` is not set when gbash runs a script file. Use
+  `${BASH_SOURCE[0]:-$0}` as a fallback.
+- The default PATH inside gbash is `/usr/bin:/bin`. External tools like git,
+  docker, and curl are not available unless stubbed into `/bin/` via the
+  sandbox. This is intentional -- tests should not depend on host tools.
+- `--readwrite-root` must point to a directory inside the system temp directory.
+  You cannot mount arbitrary host paths.

--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
 VERSION="${1:-${RELEASE_VERSION:-}}"
 REMOTE="${REMOTE:-origin}"
 PUSH="${PUSH:-0}"
@@ -35,9 +35,9 @@ fi
 
 HEAD_COMMIT="$(git rev-parse HEAD)"
 tags=("${VERSION}")
-while IFS= read -r module_dir; do
+for module_dir in $(find contrib -mindepth 1 -maxdepth 1 -type d | sort); do
 	tags+=("${module_dir}/${VERSION}")
-done < <(find contrib -mindepth 1 -maxdepth 1 -type d | sort)
+done
 
 created_tags=()
 for tag in "${tags[@]}"; do

--- a/scripts/tests/.gitignore
+++ b/scripts/tests/.gitignore
@@ -1,0 +1,1 @@
+.gbash-test-bin

--- a/scripts/tests/tag_release.bats
+++ b/scripts/tests/tag_release.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# The git stub reads/writes files under /state/ to simulate git behavior.
+# Tags are stored at /state/tags/<tagname> (without refs/tags/ prefix).
+
+setup() {
+	TEST_TEMP_DIR="$(mktemp -d)"
+	SANDBOX="${TEST_TEMP_DIR}/sandbox"
+	STUB_BIN="${SANDBOX}/bin"
+	mkdir -p "${STUB_BIN}" "${SANDBOX}/scripts" "${SANDBOX}/contrib/awk" "${SANDBOX}/contrib/jq" "${SANDBOX}/state"
+
+	cp "${SCRIPTS_DIR}/tag_release.sh" "${SANDBOX}/scripts/tag_release.sh"
+
+	# Default state: on main branch, clean worktree, no existing tags.
+	echo "main" > "${SANDBOX}/state/branch"
+	echo "" > "${SANDBOX}/state/status"
+	echo "abc123def" > "${SANDBOX}/state/head"
+
+	create_stub find 'printf "contrib/awk\ncontrib/jq\n"'
+	create_stub sort 'sort'
+
+	# git stub that reads state files to simulate different scenarios.
+	cat > "${STUB_BIN}/git" << 'GIT_STUB'
+#!/bin/sh
+case "$1" in
+	branch)
+		cat /state/branch
+		;;
+	status)
+		cat /state/status
+		;;
+	rev-parse)
+		shift
+		case "$1" in
+			HEAD)
+				cat /state/head
+				;;
+			-q)
+				# git rev-parse -q --verify refs/tags/<tag>
+				# Strip the refs/tags/ prefix to find our state file.
+				raw_tag="$3"
+				tag="${raw_tag#refs/tags/}"
+				if [ -f "/state/tags/${tag}" ]; then
+					exit 0
+				fi
+				exit 1
+				;;
+		esac
+		;;
+	rev-list)
+		# git rev-list -n 1 <tag>
+		raw_tag="$4"
+		tag="${raw_tag#refs/tags/}"
+		if [ -f "/state/tags/${tag}" ]; then
+			cat "/state/tags/${tag}"
+		fi
+		;;
+	tag)
+		# git tag -a <tag> -m <msg>
+		shift
+		if [ "$1" = "-a" ]; then
+			tag="$2"
+			mkdir -p "/state/tags/$(dirname "${tag}")"
+			cp /state/head "/state/tags/${tag}"
+		fi
+		;;
+	push)
+		shift
+		echo "pushed to $1: $*"
+		;;
+	*)
+		echo "git stub: unhandled: $*" >&2
+		exit 1
+		;;
+esac
+GIT_STUB
+	chmod +x "${STUB_BIN}/git"
+}
+
+teardown() {
+	rm -rf "${TEST_TEMP_DIR}"
+}
+
+@test "requires a version argument" {
+	run_gbash "scripts/tag_release.sh"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"usage: scripts/tag_release.sh vX.Y.Z"* ]]
+}
+
+@test "rejects version without v prefix" {
+	run_gbash "scripts/tag_release.sh 1.2.3"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"version must look like vX.Y.Z"* ]]
+}
+
+@test "rejects non-main branch without override" {
+	echo "feature" > "${SANDBOX}/state/branch"
+	run_gbash "scripts/tag_release.sh v1.0.0"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"release tags must be created from main"* ]]
+}
+
+@test "allows non-main branch with ALLOW_NON_MAIN=1" {
+	echo "feature" > "${SANDBOX}/state/branch"
+	run_gbash "ALLOW_NON_MAIN=1 scripts/tag_release.sh v1.0.0"
+	[ "$status" -eq 0 ]
+}
+
+@test "rejects dirty worktree" {
+	echo "M some/file" > "${SANDBOX}/state/status"
+	run_gbash "scripts/tag_release.sh v1.0.0"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"git worktree must be clean"* ]]
+}
+
+@test "creates root and contrib tags" {
+	run_gbash "scripts/tag_release.sh v1.0.0"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"created tags:"* ]]
+	[[ "$output" == *"v1.0.0"* ]]
+	[[ "$output" == *"contrib/awk/v1.0.0"* ]]
+	[[ "$output" == *"contrib/jq/v1.0.0"* ]]
+}
+
+@test "is idempotent when tags exist on same commit" {
+	head_commit="$(cat "${SANDBOX}/state/head")"
+	mkdir -p "${SANDBOX}/state/tags/contrib/awk" "${SANDBOX}/state/tags/contrib/jq"
+	echo "${head_commit}" > "${SANDBOX}/state/tags/v1.0.0"
+	echo "${head_commit}" > "${SANDBOX}/state/tags/contrib/awk/v1.0.0"
+	echo "${head_commit}" > "${SANDBOX}/state/tags/contrib/jq/v1.0.0"
+
+	run_gbash "scripts/tag_release.sh v1.0.0"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"all release tags already existed"* ]]
+}
+
+@test "fails when tag exists on different commit" {
+	mkdir -p "${SANDBOX}/state/tags"
+	echo "different_commit" > "${SANDBOX}/state/tags/v1.0.0"
+
+	run_gbash "scripts/tag_release.sh v1.0.0"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"tag already exists on a different commit"* ]]
+}
+
+@test "shows push instructions by default" {
+	run_gbash "scripts/tag_release.sh v1.0.0"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"to push them:"* ]]
+	[[ "$output" == *"git push origin"* ]]
+}
+
+@test "pushes tags when PUSH=1" {
+	run_gbash "PUSH=1 scripts/tag_release.sh v1.0.0"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"pushed to origin"* ]]
+}
+
+@test "accepts version from RELEASE_VERSION env var" {
+	run_gbash "RELEASE_VERSION=v2.0.0 scripts/tag_release.sh"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"v2.0.0"* ]]
+}

--- a/scripts/tests/test_helper.bash
+++ b/scripts/tests/test_helper.bash
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Bats runs under system bash. Tests invoke scripts under gbash using
+# --readwrite-root pointed at a temp directory with stubbed binaries.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPTS_DIR="${REPO_ROOT}/scripts"
+
+# Build gbash if not already built or if source is newer than the binary.
+GBASH_BIN="${REPO_ROOT}/scripts/tests/.gbash-test-bin"
+if [[ ! -x "${GBASH_BIN}" ]] || [[ "${REPO_ROOT}/cmd/gbash/main.go" -nt "${GBASH_BIN}" ]]; then
+	(cd "${REPO_ROOT}" && go build -o "${GBASH_BIN}" ./cmd/gbash/) || {
+		echo "failed to build gbash" >&2
+		return 1
+	}
+fi
+
+export GBASH_BIN
+export REPO_ROOT
+export SCRIPTS_DIR
+
+# Create a fresh temporary directory for each test.
+setup() {
+	TEST_TEMP_DIR="$(mktemp -d)"
+	SANDBOX="${TEST_TEMP_DIR}/sandbox"
+	STUB_BIN="${SANDBOX}/bin"
+	mkdir -p "${STUB_BIN}"
+}
+
+teardown() {
+	rm -rf "${TEST_TEMP_DIR}"
+}
+
+# Run a script under gbash with --readwrite-root pointed at the sandbox.
+# Usage: run_gbash <script-path-relative-to-sandbox> [args...]
+run_gbash() {
+	run "${GBASH_BIN}" --readwrite-root "${SANDBOX}" -c "
+		export PATH=/bin:/usr/bin
+		cd /
+		$*
+	"
+}
+
+# Create a stub executable in the sandbox's bin directory.
+# Usage: create_stub <name> <body>
+create_stub() {
+	local name="$1"
+	local body="$2"
+	cat > "${STUB_BIN}/${name}" <<-STUB
+	#!/bin/sh
+	${body}
+	STUB
+	chmod +x "${STUB_BIN}/${name}"
+}


### PR DESCRIPTION
## Summary

- Adds bats-core test infrastructure that runs scripts under gbash using `--readwrite-root` with stubbed external commands (git, find, etc.)
- Includes `tag_release.bats` with 11 tests covering argument validation, branch checks, dirty worktree detection, tag creation, idempotency, conflict detection, and push behavior
- Fixes two gbash compatibility issues in `tag_release.sh`: `BASH_SOURCE` fallback (#292) and process substitution replacement (#291)
- Adds `make bats-test` target and `scripts/AGENTS.md` documenting how to write and run tests

## Test plan

- [x] `make bats-test` passes (11/11)
- [ ] `bash -n scripts/tag_release.sh` still parses under regular bash
- [ ] `make tag-release RELEASE_VERSION=...` still works for real releases