### PR TITLE
ci: enable unparam linter and remove unused params/returns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - paralleltest
     - testifylint
     - unconvert
+    - unparam
 
   settings:
     revive:

--- a/cli/run.go
+++ b/cli/run.go
@@ -21,10 +21,10 @@ func Run(ctx context.Context, cfg Config, argv0 string, args []string, stdin io.
 	if ttyDetector == nil {
 		ttyDetector = stdinIsTTY
 	}
-	return run(ctx, cfg, argv0, args, stdin, stdout, stderr, ttyDetector(stdin))
+	return run(ctx, cfg, args, stdin, stdout, stderr, ttyDetector(stdin))
 }
 
-func run(ctx context.Context, cfg Config, argv0 string, args []string, stdin io.Reader, stdout, stderr io.Writer, stdinTTY bool) (int, error) {
+func run(ctx context.Context, cfg Config, args []string, stdin io.Reader, stdout, stderr io.Writer, stdinTTY bool) (int, error) {
 	cfg = normalizeConfig(cfg)
 
 	runtimeOpts, args, err := parseRuntimeOptions(args)

--- a/cmd/gbash/cli_test.go
+++ b/cmd/gbash/cli_test.go
@@ -58,7 +58,7 @@ func TestRunCLIPrintsVersion(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIWithConfig(context.Background(), cfg, "gbash", []string{"--version"}, strings.NewReader("echo ignored"), &stdout, &stderr, false)
+	exitCode, err := runCLIWithConfig(context.Background(), cfg, []string{"--version"}, strings.NewReader("echo ignored"), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -80,7 +80,7 @@ func TestRunCLIHelpRendersBashInvocationFlags(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"--help"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"--help"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -104,7 +104,7 @@ func TestRunCLIHelpRendersFilesystemFlags(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"--help"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"--help"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -126,7 +126,7 @@ func TestRunCLIHelpRendersServerFlags(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"--help"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"--help"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -148,7 +148,7 @@ func TestRunCLIJSONOutputEncodesExecutionResult(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-c", "printf 'hello\\n'; printf 'warn\\n' >&2", "--json"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-c", "printf 'hello\\n'; printf 'warn\\n' >&2", "--json"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -185,7 +185,7 @@ func TestRunCLIJSONOutputEncodesCLIError(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-c", "pwd", "--json", "--root", "/", "--readwrite-root", "/"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-c", "pwd", "--json", "--root", "/", "--readwrite-root", "/"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -213,7 +213,7 @@ func TestRunCLIJSONOutputRejectsInteractiveShell(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"--json"}, strings.NewReader(""), &stdout, &stderr, true)
+	exitCode, err := runCLI(context.Background(), []string{"--json"}, strings.NewReader(""), &stdout, &stderr, true)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -235,7 +235,7 @@ func TestRunCLIServerRequiresTransport(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"--server"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"--server"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err == nil {
 		t.Fatal("runCLI() error = nil, want transport requirement")
 	}
@@ -252,7 +252,7 @@ func TestRunCLIServerRejectsMultipleTransportFlags(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{
+	exitCode, err := runCLI(context.Background(), []string{
 		"--server",
 		"--socket", filepath.Join(t.TempDir(), "gbash.sock"),
 		"--listen", "127.0.0.1:9000",
@@ -273,7 +273,7 @@ func TestRunCLIServerRejectsNonLoopbackListen(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"--server", "--listen", "0.0.0.0:9000"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"--server", "--listen", "0.0.0.0:9000"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err == nil {
 		t.Fatal("runCLI() error = nil, want loopback requirement")
 	}
@@ -290,7 +290,7 @@ func TestRunCLIServerRejectsScriptExecutionFlags(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"--server", "--socket", filepath.Join(t.TempDir(), "gbash.sock"), "-c", "echo hi"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"--server", "--socket", filepath.Join(t.TempDir(), "gbash.sock"), "-c", "echo hi"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err == nil {
 		t.Fatal("runCLI() error = nil, want server/script rejection")
 	}
@@ -307,7 +307,7 @@ func TestRunCLIServerRejectsJSONMode(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"--server", "--socket", filepath.Join(t.TempDir(), "gbash.sock"), "--json"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"--server", "--socket", filepath.Join(t.TempDir(), "gbash.sock"), "--json"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -333,7 +333,7 @@ func TestRunCLIServerListensOnTCP(t *testing.T) {
 	var stderr strings.Builder
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := runCLI(ctx, "gbash", []string{"--server", "--listen", addr}, strings.NewReader(""), &stdout, &stderr, false)
+		_, err := runCLI(ctx, []string{"--server", "--listen", addr}, strings.NewReader(""), &stdout, &stderr, false)
 		errCh <- err
 	}()
 
@@ -410,7 +410,7 @@ func TestRunCLISharedFlagsStopAfterFirstScriptPositional(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-c", `printf '%s\n' "$1"`, "_", "--json"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-c", `printf '%s\n' "$1"`, "_", "--json"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -432,7 +432,7 @@ func TestRunCLIReadWriteRootPersistsHostWritesAcrossExecutions(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"--readwrite-root", tmp, "--cwd", "/", "-c", "printf host-data > shared.txt"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"--readwrite-root", tmp, "--cwd", "/", "-c", "printf host-data > shared.txt"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI(write) error = %v", err)
 	}
@@ -455,7 +455,7 @@ func TestRunCLIReadWriteRootPersistsHostWritesAcrossExecutions(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	exitCode, err = runCLI(context.Background(), "gbash", []string{"--readwrite-root=" + tmp, "--cwd=/", "-c", "pwd; cat shared.txt"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err = runCLI(context.Background(), []string{"--readwrite-root=" + tmp, "--cwd=/", "-c", "pwd; cat shared.txt"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI(read) error = %v", err)
 	}
@@ -508,7 +508,7 @@ func TestRunCLIRootMountReadsHostFilesWithoutPersistingWrites(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"--root", root, "--cwd", gbash.DefaultWorkspaceMountPoint + "/subdir", "-c", "pwd; cat host.txt; printf overlay > overlay.txt"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"--root", root, "--cwd", gbash.DefaultWorkspaceMountPoint + "/subdir", "-c", "pwd; cat host.txt; printf overlay > overlay.txt"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -531,7 +531,7 @@ func TestRunCLIFilesystemFlagsRejectConflictingModes(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"--root", "/", "--readwrite-root", "/", "-c", "pwd"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"--root", "/", "--readwrite-root", "/", "-c", "pwd"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err == nil {
 		t.Fatalf("runCLI() error = nil, want conflict error")
 	}
@@ -549,7 +549,7 @@ func TestRunCLIReadWriteRootRejectsNonTempDirectories(t *testing.T) {
 	var stderr strings.Builder
 
 	nonTempRoot := filepath.Dir(filepath.Clean(os.TempDir()))
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"--readwrite-root", nonTempRoot, "--cwd", "/", "-c", "pwd"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"--readwrite-root", nonTempRoot, "--cwd", "/", "-c", "pwd"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err == nil {
 		t.Fatalf("runCLI() error = nil, want temp-directory restriction")
 	}
@@ -566,7 +566,7 @@ func TestRunCLICommandStringSupportsGroupedShortFlags(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-ceu", `echo "$MISSING"`}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-ceu", `echo "$MISSING"`}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -609,7 +609,7 @@ func TestRunCLICommandStringUsesBashArg0Semantics(t *testing.T) {
 			var stdout strings.Builder
 			var stderr strings.Builder
 
-			exitCode, err := runCLI(context.Background(), "gbash", tc.args, strings.NewReader(""), &stdout, &stderr, false)
+			exitCode, err := runCLI(context.Background(), tc.args, strings.NewReader(""), &stdout, &stderr, false)
 			if err != nil {
 				t.Fatalf("runCLI() error = %v", err)
 			}
@@ -637,7 +637,7 @@ func TestRunCLISupportsScriptFileArgs(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{scriptPath, "left", "right"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{scriptPath, "left", "right"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -657,7 +657,7 @@ func TestRunCLIDashSReadsScriptFromStdinAndUsesArgs(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-s", "value"}, strings.NewReader("printf '%s|%s\\n' \"$0\" \"$1\"\n"), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-s", "value"}, strings.NewReader("printf '%s|%s\\n' \"$0\" \"$1\"\n"), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -677,7 +677,7 @@ func TestRunCLIImplicitStdinUsesInvocationNameAsArg0(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", nil, strings.NewReader("printf '%s\\n' \"$0\"\n"), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), nil, strings.NewReader("printf '%s\\n' \"$0\"\n"), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -697,7 +697,7 @@ func TestRunCLISupportsDashOPipefail(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-e", "-o", "pipefail", "-c", "false | true\necho after"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-e", "-o", "pipefail", "-c", "false | true\necho after"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -747,7 +747,7 @@ func TestRunCLIStartupOptionsAffectExecution(t *testing.T) {
 			var stdout strings.Builder
 			var stderr strings.Builder
 
-			exitCode, err := runCLI(context.Background(), "gbash", tc.args, strings.NewReader(""), &stdout, &stderr, false)
+			exitCode, err := runCLI(context.Background(), tc.args, strings.NewReader(""), &stdout, &stderr, false)
 			if err != nil {
 				t.Fatalf("runCLI() error = %v", err)
 			}
@@ -769,7 +769,7 @@ func TestRunCLIInteractiveCommandStringUsesInteractiveShellSemantics(t *testing.
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-ic", "alias hi='echo alias-ok'\nhi"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-ic", "alias hi='echo alias-ok'\nhi"}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -795,7 +795,7 @@ func TestRunCLIInteractiveScriptUsesInteractiveShellSemantics(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-i", scriptPath}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-i", scriptPath}, strings.NewReader(""), &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -817,7 +817,7 @@ func TestRunCLIHostUtilityPassesStdin(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "cat", nil, strings.NewReader("stdin-data"), &stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "cat", nil, strings.NewReader("stdin-data"), &stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -846,7 +846,7 @@ func TestRunCLIHostUtilityCatRejectsAppendToSelf(t *testing.T) {
 	defer func() { _ = stdout.Close() }()
 
 	var stderr strings.Builder
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "cat", []string{"out"}, strings.NewReader(""), stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "cat", []string{"out"}, strings.NewReader(""), stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -889,7 +889,7 @@ func TestRunCLIHostUtilityCatCanCopyThroughSharedReadWriteTarget(t *testing.T) {
 	defer func() { _ = stdout.Close() }()
 
 	var stderr strings.Builder
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "cat", []string{"-", "fy"}, stdin, stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "cat", []string{"-", "fy"}, stdin, stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -919,7 +919,7 @@ func TestRunCLIHostUtilityPassesGBASHUmaskToRuntime(t *testing.T) {
 
 	var stdout strings.Builder
 	var stderr strings.Builder
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "chmod", []string{"a=r,=x", "file.txt"}, strings.NewReader(""), &stdout, &stderr, false, &hostUtilityOpts{gbashUmask: "0005"})
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "chmod", []string{"a=r,=x", "file.txt"}, strings.NewReader(""), &stdout, &stderr, &hostUtilityOpts{gbashUmask: "0005"})
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -954,7 +954,7 @@ func TestRunCLIHostUtilityChownNoOpOnExistingOwnership(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "chown", []string{"-R", spec, "keep"}, strings.NewReader(""), &stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "chown", []string{"-R", spec, "keep"}, strings.NewReader(""), &stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -981,7 +981,7 @@ func TestRunCLIHostUtilityChownAcceptsCurrentUsername(t *testing.T) {
 
 	var stdout strings.Builder
 	var stderr strings.Builder
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "chown", []string{current.Username, "owned.txt"}, strings.NewReader(""), &stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "chown", []string{current.Username, "owned.txt"}, strings.NewReader(""), &stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -999,7 +999,7 @@ func TestRunCLIHostUtilityUnknownCommandReturns127(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "missing-command", nil, strings.NewReader(""), &stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "missing-command", nil, strings.NewReader(""), &stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -1027,7 +1027,7 @@ func TestRunCLIHostUtilityYesReportsSingleWriteErrorOnDevFull(t *testing.T) {
 	defer func() { _ = full.Close() }()
 
 	var stderr strings.Builder
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "yes", []string{"x"}, strings.NewReader(""), full, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "yes", []string{"x"}, strings.NewReader(""), full, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -1046,7 +1046,7 @@ func TestRunCLIHostUtilityEnvSupportsDoubleDashCommandSeparator(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "env", []string{"--", "pwd", "-P"}, strings.NewReader(""), &stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "env", []string{"--", "pwd", "-P"}, strings.NewReader(""), &stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -1076,7 +1076,7 @@ func TestRunCLIHostUtilityEnvSupportsAssignmentsAfterDoubleDash(t *testing.T) {
 
 	var stdout strings.Builder
 	var stderr strings.Builder
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "env", []string{"--", "POSIXLY_CORRECT=1", "pwd"}, strings.NewReader(""), &stdout, &stderr, false, &hostUtilityOpts{cwd: logicalDir})
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "env", []string{"--", "POSIXLY_CORRECT=1", "pwd"}, strings.NewReader(""), &stdout, &stderr, &hostUtilityOpts{cwd: logicalDir})
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -1106,7 +1106,7 @@ func TestRunCLIHostUtilityStreamsOutputBeforeExit(t *testing.T) {
 	}, 1)
 
 	go func() {
-		exitCode, err := runCLIHostUtility(t, ctx, tmp, "seq", []string{"999999", "inf"}, strings.NewReader(""), stdout, &stderr, false, nil)
+		exitCode, err := runCLIHostUtility(t, ctx, tmp, "seq", []string{"999999", "inf"}, strings.NewReader(""), stdout, &stderr, nil)
 		done <- struct {
 			exitCode int
 			err      error
@@ -1144,7 +1144,7 @@ func TestRunCLIHostUtilityTailFollowMissingFileByName(t *testing.T) {
 	}, 1)
 
 	go func() {
-		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"-F", "-s0.05", "--max-unchanged-stats=1", "missing/file"}, strings.NewReader(""), stdout, stderr, false, nil)
+		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"-F", "-s0.05", "--max-unchanged-stats=1", "missing/file"}, strings.NewReader(""), stdout, stderr, nil)
 		done <- struct {
 			exitCode int
 			err      error
@@ -1194,7 +1194,7 @@ func TestRunCLIHostUtilityTailFollowMissingFlatFileByName(t *testing.T) {
 	}, 1)
 
 	go func() {
-		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"--follow=name", "--retry", "-s0.05", "--max-unchanged-stats=1", "missing"}, strings.NewReader(""), stdout, stderr, false, nil)
+		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"--follow=name", "--retry", "-s0.05", "--max-unchanged-stats=1", "missing"}, strings.NewReader(""), stdout, stderr, nil)
 		done <- struct {
 			exitCode int
 			err      error
@@ -1245,7 +1245,7 @@ func TestRunCLIHostUtilityTailFollowUntailableByNameUntilFileAppears(t *testing.
 	}, 1)
 
 	go func() {
-		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"-F", "-s0.05", "--max-unchanged-stats=1", "untailable"}, strings.NewReader(""), stdout, stderr, false, nil)
+		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"-F", "-s0.05", "--max-unchanged-stats=1", "untailable"}, strings.NewReader(""), stdout, stderr, nil)
 		done <- struct {
 			exitCode int
 			err      error
@@ -1306,7 +1306,7 @@ func TestRunCLIHostUtilityTailFollowDescriptorSurvivesRename(t *testing.T) {
 	}, 1)
 
 	go func() {
-		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"-f", "-s0.05", "a"}, strings.NewReader(""), stdout, stderr, false, nil)
+		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"-f", "-s0.05", "a"}, strings.NewReader(""), stdout, stderr, nil)
 		done <- struct {
 			exitCode int
 			err      error
@@ -1370,7 +1370,7 @@ func TestRunCLIHostUtilityTailFollowByNameHandlesRenameAndReplacement(t *testing
 	}, 1)
 
 	go func() {
-		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"-F", "-s0.05", "--max-unchanged-stats=1", "a", "b"}, strings.NewReader(""), stdout, stderr, false, nil)
+		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"-F", "-s0.05", "--max-unchanged-stats=1", "a", "b"}, strings.NewReader(""), stdout, stderr, nil)
 		done <- struct {
 			exitCode int
 			err      error
@@ -1476,7 +1476,7 @@ func TestRunCLIHostUtilityTailGroupedQuietFollowFlags(t *testing.T) {
 	}, 1)
 
 	go func() {
-		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"-qF", "-s0.05", "--max-unchanged-stats=1", "1", "2"}, strings.NewReader(""), stdout, stderr, false, nil)
+		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"-qF", "-s0.05", "--max-unchanged-stats=1", "1", "2"}, strings.NewReader(""), stdout, stderr, nil)
 		done <- struct {
 			exitCode int
 			err      error
@@ -1515,7 +1515,7 @@ func TestRunCLIHostUtilityTailFollowByNameWithoutRetryFailsWhenMissingInitially(
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"--follow=name", "no-such"}, strings.NewReader(""), &stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"--follow=name", "no-such"}, strings.NewReader(""), &stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -1552,7 +1552,7 @@ func TestRunCLIHostUtilityTailFollowByNameWithoutRetryStopsWhenFileDisappears(t 
 	}, 1)
 
 	go func() {
-		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"--follow=name", "-s0.05", "--max-unchanged-stats=1", "file"}, strings.NewReader(""), stdout, stderr, false, nil)
+		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"--follow=name", "-s0.05", "--max-unchanged-stats=1", "file"}, strings.NewReader(""), stdout, stderr, nil)
 		done <- struct {
 			exitCode int
 			err      error
@@ -1607,7 +1607,7 @@ func TestRunCLIHostUtilityTailFollowByNameWithoutRetryTracksReappearingFileWhile
 	}, 1)
 
 	go func() {
-		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"--follow=name", "-s0.05", "--max-unchanged-stats=1", "a", "foo"}, strings.NewReader(""), stdout, stderr, false, nil)
+		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"--follow=name", "-s0.05", "--max-unchanged-stats=1", "a", "foo"}, strings.NewReader(""), stdout, stderr, nil)
 		done <- struct {
 			exitCode int
 			err      error
@@ -1665,7 +1665,7 @@ func TestRunCLIHostUtilityTailFollowPidIsUnsupported(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"-f", "-s0.05", "--pid=2147483647", "--pid=" + strconv.Itoa(os.Getpid()), "here"}, strings.NewReader(""), &stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"-f", "-s0.05", "--pid=2147483647", "--pid=" + strconv.Itoa(os.Getpid()), "here"}, strings.NewReader(""), &stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -1691,7 +1691,7 @@ func TestRunCLIHostUtilityTailFollowPidIsUnsupportedForDeadPidToo(t *testing.T) 
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"-f", "-s10", "--pid=2147483647", "empty"}, strings.NewReader(""), &stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"-f", "-s10", "--pid=2147483647", "empty"}, strings.NewReader(""), &stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -1717,7 +1717,7 @@ func TestRunCLIHostUtilityTailRetryWarnsWithoutFollow(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"--retry", "file"}, strings.NewReader(""), &stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"--retry", "file"}, strings.NewReader(""), &stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -1747,7 +1747,7 @@ func TestRunCLIHostUtilityTailRetryDescriptorReportsAppearanceAndTruncation(t *t
 	}, 1)
 
 	go func() {
-		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"--follow=descriptor", "--retry", "-s0.05", "missing"}, strings.NewReader(""), stdout, stderr, false, nil)
+		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"--follow=descriptor", "--retry", "-s0.05", "missing"}, strings.NewReader(""), stdout, stderr, nil)
 		done <- struct {
 			exitCode int
 			err      error
@@ -1803,7 +1803,7 @@ func TestRunCLIHostUtilityTailRetryDescriptorGivesUpOnUntailableReplacement(t *t
 	}, 1)
 
 	go func() {
-		exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"--follow=descriptor", "--retry", "-s0.05", "missing"}, strings.NewReader(""), &stdout, stderr, false, nil)
+		exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"--follow=descriptor", "--retry", "-s0.05", "missing"}, strings.NewReader(""), &stdout, stderr, nil)
 		done <- struct {
 			exitCode int
 			err      error
@@ -1842,7 +1842,7 @@ func TestRunCLIHostUtilityTailFollowDashReadsStandardInput(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"-f", "-"}, strings.NewReader("line\n"), &stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"-f", "-"}, strings.NewReader("line\n"), &stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -1876,7 +1876,7 @@ func TestRunCLIHostUtilityTailFollowDashReportsClosedStdin(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"-f", "-"}, stdin, &stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"-f", "-"}, stdin, &stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -1901,7 +1901,7 @@ func TestRunCLIHostUtilityTailFollowNameRejectsDash(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"--follow=name", "-"}, strings.NewReader("line\n"), &stdout, &stderr, false, nil)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "tail", []string{"--follow=name", "-"}, strings.NewReader("line\n"), &stdout, &stderr, nil)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -1935,7 +1935,7 @@ func TestRunCLIHostUtilityTailDebugReportsPollingMode(t *testing.T) {
 	}, 1)
 
 	go func() {
-		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"--debug", "-n0", "-F", "-s0.05", "a"}, strings.NewReader(""), &stdout, stderr, false, nil)
+		exitCode, err := runCLIHostUtility(t, ctx, tmp, "tail", []string{"--debug", "-n0", "-F", "-s0.05", "a"}, strings.NewReader(""), &stdout, stderr, nil)
 		done <- struct {
 			exitCode int
 			err      error
@@ -1976,7 +1976,7 @@ func TestRunCLIHostUtilityPwdHonorsLogicalAndPhysicalModes(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "pwd", []string{"-L"}, strings.NewReader("ignored"), &stdout, &stderr, false, cwdOpts)
+	exitCode, err := runCLIHostUtility(t, context.Background(), tmp, "pwd", []string{"-L"}, strings.NewReader("ignored"), &stdout, &stderr, cwdOpts)
 	if err != nil {
 		t.Fatalf("runCLI(-L) error = %v", err)
 	}
@@ -1992,7 +1992,7 @@ func TestRunCLIHostUtilityPwdHonorsLogicalAndPhysicalModes(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	exitCode, err = runCLIHostUtility(t, context.Background(), tmp, "pwd", []string{"--physical"}, strings.NewReader("ignored"), &stdout, &stderr, false, cwdOpts)
+	exitCode, err = runCLIHostUtility(t, context.Background(), tmp, "pwd", []string{"--physical"}, strings.NewReader("ignored"), &stdout, &stderr, cwdOpts)
 	if err != nil {
 		t.Fatalf("runCLI(--physical) error = %v", err)
 	}
@@ -2008,7 +2008,7 @@ func TestRunCLIHostUtilityPwdHonorsLogicalAndPhysicalModes(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	exitCode, err = runCLIHostUtility(t, context.Background(), tmp, "pwd", nil, strings.NewReader("ignored"), &stdout, &stderr, false, &hostUtilityOpts{cwd: logicalDir, posixlyCorrect: "1"})
+	exitCode, err = runCLIHostUtility(t, context.Background(), tmp, "pwd", nil, strings.NewReader("ignored"), &stdout, &stderr, &hostUtilityOpts{cwd: logicalDir, posixlyCorrect: "1"})
 	if err != nil {
 		t.Fatalf("runCLI(POSIXLY_CORRECT) error = %v", err)
 	}
@@ -2029,7 +2029,7 @@ type hostUtilityOpts struct {
 	posixlyCorrect string
 }
 
-func runCLIHostUtility(t *testing.T, ctx context.Context, root, utility string, utilityArgs []string, stdin io.Reader, stdout, stderr io.Writer, stdinTTY bool, opts *hostUtilityOpts) (int, error) {
+func runCLIHostUtility(t *testing.T, ctx context.Context, root, utility string, utilityArgs []string, stdin io.Reader, stdout, stderr io.Writer, opts *hostUtilityOpts) (int, error) {
 	t.Helper()
 
 	cwd := root
@@ -2057,7 +2057,7 @@ func runCLIHostUtility(t *testing.T, ctx context.Context, root, utility string, 
 		utility,
 	}
 	args = append(args, utilityArgs...)
-	return runCLI(ctx, "gbash", args, stdin, stdout, stderr, stdinTTY)
+	return runCLI(ctx, args, stdin, stdout, stderr, false)
 }
 
 func currentSandboxCwd(root, cwd string) (string, error) {

--- a/cmd/gbash/cli_test_helpers_test.go
+++ b/cmd/gbash/cli_test_helpers_test.go
@@ -9,11 +9,11 @@ import (
 
 const continuationPrompt = "> "
 
-func runCLI(ctx context.Context, argv0 string, args []string, stdin io.Reader, stdout, stderr io.Writer, stdinTTY bool) (int, error) {
-	return runCLIWithConfig(ctx, newCLIConfig(), argv0, args, stdin, stdout, stderr, stdinTTY)
+func runCLI(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer, stdinTTY bool) (int, error) {
+	return runCLIWithConfig(ctx, newCLIConfig(), args, stdin, stdout, stderr, stdinTTY)
 }
 
-func runCLIWithConfig(ctx context.Context, cfg rootcli.Config, argv0 string, args []string, stdin io.Reader, stdout, stderr io.Writer, stdinTTY bool) (int, error) {
+func runCLIWithConfig(ctx context.Context, cfg rootcli.Config, args []string, stdin io.Reader, stdout, stderr io.Writer, stdinTTY bool) (int, error) {
 	cfg.TTYDetector = func(io.Reader) bool { return stdinTTY }
-	return rootcli.Run(ctx, cfg, argv0, args, stdin, stdout, stderr)
+	return rootcli.Run(ctx, cfg, "gbash", args, stdin, stdout, stderr)
 }

--- a/cmd/gbash/repl_test.go
+++ b/cmd/gbash/repl_test.go
@@ -14,7 +14,7 @@ func TestRunCLIInteractivePersistsCWDAndEnvAcrossEntries(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-i"}, input, &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-i"}, input, &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -51,7 +51,7 @@ func TestRunCLIInteractiveSupportsMultilineStatements(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-i"}, input, &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-i"}, input, &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -78,7 +78,7 @@ func TestRunCLIInteractiveHonorsExitStatus(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-i"}, input, &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-i"}, input, &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -105,7 +105,7 @@ func TestRunCLIInteractiveProvidesVirtualTTY(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-i"}, input, &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-i"}, input, &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -127,7 +127,7 @@ func TestRunCLIInteractiveStartupOptionsPersistAcrossEntries(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash", []string{"-iu"}, input, &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-iu"}, input, &stdout, &stderr, false)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}

--- a/contrib/awk/awk.go
+++ b/contrib/awk/awk.go
@@ -46,7 +46,7 @@ func (c *AWK) Run(ctx context.Context, inv *commands.Invocation) error {
 
 	compiled, err := parser.ParseProgram([]byte(programSource), nil)
 	if err != nil {
-		return exitf(inv, 2, "awk: parse error: %v", err)
+		return exitf(inv, "awk: parse error: %v", err)
 	}
 
 	stdinData, err := loadAWKInputs(ctx, inv, inputs)
@@ -67,7 +67,7 @@ func (c *AWK) Run(ctx context.Context, inv *commands.Invocation) error {
 	}
 	status, err := interp.ExecProgram(compiled, config)
 	if err != nil {
-		return exitf(inv, 2, "awk: %v", err)
+		return exitf(inv, "awk: %v", err)
 	}
 	if status != 0 {
 		return &commands.ExitError{Code: status}
@@ -90,7 +90,7 @@ func parseAWKArgs(inv *commands.Invocation) (opts awkOptions, programText string
 		switch {
 		case arg == "-F":
 			if len(args) < 2 {
-				return awkOptions{}, "", nil, exitf(inv, 2, "awk: option requires an argument -- 'F'")
+				return awkOptions{}, "", nil, exitf(inv, "awk: option requires an argument -- 'F'")
 			}
 			opts.fieldSeparator = args[1]
 			args = args[2:]
@@ -99,7 +99,7 @@ func parseAWKArgs(inv *commands.Invocation) (opts awkOptions, programText string
 			opts.fieldSeparator = arg[2:]
 		case arg == "-f":
 			if len(args) < 2 {
-				return awkOptions{}, "", nil, exitf(inv, 2, "awk: option requires an argument -- 'f'")
+				return awkOptions{}, "", nil, exitf(inv, "awk: option requires an argument -- 'f'")
 			}
 			opts.programFiles = append(opts.programFiles, args[1])
 			args = args[2:]
@@ -108,10 +108,10 @@ func parseAWKArgs(inv *commands.Invocation) (opts awkOptions, programText string
 			opts.programFiles = append(opts.programFiles, arg[2:])
 		case arg == "-v":
 			if len(args) < 2 {
-				return awkOptions{}, "", nil, exitf(inv, 2, "awk: option requires an argument -- 'v'")
+				return awkOptions{}, "", nil, exitf(inv, "awk: option requires an argument -- 'v'")
 			}
 			if !strings.Contains(args[1], "=") {
-				return awkOptions{}, "", nil, exitf(inv, 2, "awk: expected name=value after -v")
+				return awkOptions{}, "", nil, exitf(inv, "awk: expected name=value after -v")
 			}
 			opts.vars = append(opts.vars, args[1])
 			args = args[2:]
@@ -119,18 +119,18 @@ func parseAWKArgs(inv *commands.Invocation) (opts awkOptions, programText string
 		case strings.HasPrefix(arg, "-v") && len(arg) > 2:
 			value := arg[2:]
 			if !strings.Contains(value, "=") {
-				return awkOptions{}, "", nil, exitf(inv, 2, "awk: expected name=value after -v")
+				return awkOptions{}, "", nil, exitf(inv, "awk: expected name=value after -v")
 			}
 			opts.vars = append(opts.vars, value)
 		default:
-			return awkOptions{}, "", nil, exitf(inv, 2, "awk: unsupported flag %s", arg)
+			return awkOptions{}, "", nil, exitf(inv, "awk: unsupported flag %s", arg)
 		}
 		args = args[1:]
 	}
 
 	if len(opts.programFiles) == 0 {
 		if len(args) == 0 {
-			return awkOptions{}, "", nil, exitf(inv, 2, "awk: missing program")
+			return awkOptions{}, "", nil, exitf(inv, "awk: missing program")
 		}
 		programText = args[0]
 		args = args[1:]
@@ -249,8 +249,8 @@ func readAllFile(ctx context.Context, inv *commands.Invocation, name string) ([]
 	return data, nil
 }
 
-func exitf(inv *commands.Invocation, code int, format string, args ...any) error {
-	return commands.Exitf(inv, code, format, args...)
+func exitf(inv *commands.Invocation, format string, args ...any) error {
+	return commands.Exitf(inv, 2, format, args...)
 }
 
 var _ commands.Command = (*AWK)(nil)

--- a/contrib/extras/cmd/gbash-extras/main_test.go
+++ b/contrib/extras/cmd/gbash-extras/main_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/ewhauser/gbash/contrib/extras"
 )
 
-func runCLI(ctx context.Context, argv0 string, args []string, stdin io.Reader, stdout, stderr io.Writer, stdinTTY bool) (int, error) {
-	return runCLIWithConfig(ctx, newCLIConfig(), argv0, args, stdin, stdout, stderr, stdinTTY)
+func runCLI(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) (int, error) {
+	return runCLIWithConfig(ctx, newCLIConfig(), "gbash-extras", args, stdin, stdout, stderr, false)
 }
 
 func runCLIWithConfig(ctx context.Context, cfg rootcli.Config, argv0 string, args []string, stdin io.Reader, stdout, stderr io.Writer, stdinTTY bool) (int, error) {
@@ -82,11 +82,11 @@ func TestCLIRegistersStableExtras(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash-extras", []string{"-c", "printf 'a,b\\n' | awk -F, '{print $2}'\n" +
+	exitCode, err := runCLI(context.Background(), []string{"-c", "printf 'a,b\\n' | awk -F, '{print $2}'\n" +
 		"printf '<h1>docs</h1>' | html-to-markdown\n" +
 		"printf '{\"name\":\"alice\"}\\n' | jq -r '.name'\n" +
 		"printf 'name: alice\\n' | yq '.name'\n" +
-		`sqlite3 :memory: "select 1;"`}, strings.NewReader(""), &stdout, &stderr, false)
+		`sqlite3 :memory: "select 1;"`}, strings.NewReader(""), &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -106,7 +106,7 @@ func TestCLIDoesNotRegisterNodeJSByDefault(t *testing.T) {
 	var stdout strings.Builder
 	var stderr strings.Builder
 
-	exitCode, err := runCLI(context.Background(), "gbash-extras", []string{"-c", "nodejs -e 'console.log(1)'"}, strings.NewReader(""), &stdout, &stderr, false)
+	exitCode, err := runCLI(context.Background(), []string{"-c", "nodejs -e 'console.log(1)'"}, strings.NewReader(""), &stdout, &stderr)
 	if err != nil {
 		t.Fatalf("runCLI() error = %v", err)
 	}
@@ -132,7 +132,7 @@ func TestCLIServerServesStableExtrasRegistry(t *testing.T) {
 	var stderr strings.Builder
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := runCLI(ctx, "gbash-extras", []string{"--server", "--socket", socket}, strings.NewReader(""), &stdout, &stderr, false)
+		_, err := runCLI(ctx, []string{"--server", "--socket", socket}, strings.NewReader(""), &stdout, &stderr)
 		errCh <- err
 	}()
 
@@ -250,7 +250,7 @@ func TestCLIServerListensOnTCPWithStableExtrasRegistry(t *testing.T) {
 	var stderr strings.Builder
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := runCLI(ctx, "gbash-extras", []string{"--server", "--listen", addr}, strings.NewReader(""), &stdout, &stderr, false)
+		_, err := runCLI(ctx, []string{"--server", "--listen", addr}, strings.NewReader(""), &stdout, &stderr)
 		errCh <- err
 	}()
 

--- a/contrib/nodejs/modules.go
+++ b/contrib/nodejs/modules.go
@@ -55,9 +55,9 @@ func (rt *nodeRuntime) processModule() (*goja.Object, error) {
 	return obj, nil
 }
 
-func (rt *nodeRuntime) fsModule() (*goja.Object, error) {
+func (rt *nodeRuntime) fsModule() *goja.Object {
 	if rt.fsExports != nil {
-		return rt.fsExports, nil
+		return rt.fsExports
 	}
 
 	obj := rt.vm.NewObject()
@@ -77,12 +77,12 @@ func (rt *nodeRuntime) fsModule() (*goja.Object, error) {
 
 	rt.fsExports = obj
 	_ = freezeObject(rt.vm, obj)
-	return obj, nil
+	return obj
 }
 
-func (rt *nodeRuntime) pathModule() (*goja.Object, error) {
+func (rt *nodeRuntime) pathModule() *goja.Object {
 	if rt.pathExports != nil {
-		return rt.pathExports, nil
+		return rt.pathExports
 	}
 
 	obj := rt.vm.NewObject()
@@ -99,7 +99,7 @@ func (rt *nodeRuntime) pathModule() (*goja.Object, error) {
 
 	rt.pathExports = obj
 	_ = freezeObject(rt.vm, obj)
-	return obj, nil
+	return obj
 }
 
 func (rt *nodeRuntime) readFileSync(call goja.FunctionCall) goja.Value {

--- a/contrib/nodejs/nodejs.go
+++ b/contrib/nodejs/nodejs.go
@@ -310,20 +310,14 @@ func (rt *nodeRuntime) loadProcessModule(runtime *goja.Runtime, module *goja.Obj
 }
 
 func (rt *nodeRuntime) loadFSModule(runtime *goja.Runtime, module *goja.Object) {
-	exports, err := rt.fsModule()
-	if err != nil {
-		panic(runtime.NewGoError(err))
-	}
+	exports := rt.fsModule()
 	if err := module.Set("exports", exports); err != nil {
 		panic(runtime.NewGoError(err))
 	}
 }
 
 func (rt *nodeRuntime) loadPathModule(runtime *goja.Runtime, module *goja.Object) {
-	exports, err := rt.pathModule()
-	if err != nil {
-		panic(runtime.NewGoError(err))
-	}
+	exports := rt.pathModule()
 	if err := module.Set("exports", exports); err != nil {
 		panic(runtime.NewGoError(err))
 	}

--- a/contrib/sqlite3/sqlite3.go
+++ b/contrib/sqlite3/sqlite3.go
@@ -118,7 +118,7 @@ func (c *SQLite3) Run(ctx context.Context, inv *commands.Invocation) error {
 		_, _ = fmt.Fprintf(inv.Stdout, "sqlite3 (gbash) backed by ncruces/go-sqlite3 v0.31.1 / SQLite %s\n", version)
 		return nil
 	case parsed.database == "":
-		return exitf(inv, 1, "sqlite3: missing database argument")
+		return exitf(inv, "sqlite3: missing database argument")
 	}
 
 	if parsed.sqlText == "" {
@@ -129,7 +129,7 @@ func (c *SQLite3) Run(ctx context.Context, inv *commands.Invocation) error {
 		parsed.sqlText = string(data)
 	}
 	if strings.TrimSpace(parsed.sqlText) == "" {
-		return exitf(inv, 1, "sqlite3: missing SQL input")
+		return exitf(inv, "sqlite3: missing SQL input")
 	}
 
 	dbPath, exists, err := resolveSQLiteDatabasePath(ctx, inv, parsed.database)
@@ -137,7 +137,7 @@ func (c *SQLite3) Run(ctx context.Context, inv *commands.Invocation) error {
 		return err
 	}
 	if parsed.options.readonly && parsed.database != ":memory:" && !exists {
-		return exitf(inv, 1, "sqlite3: %s: No such file or directory", parsed.database)
+		return exitf(inv, "sqlite3: %s: No such file or directory", parsed.database)
 	}
 
 	conn, err := gosqlite.OpenContext(ctx, ":memory:")
@@ -156,7 +156,7 @@ func (c *SQLite3) Run(ctx context.Context, inv *commands.Invocation) error {
 		}
 		if len(data) > 0 {
 			if err := serdes.Deserialize(conn, "main", data); err != nil {
-				return exitf(inv, 1, "sqlite3: %v", err)
+				return exitf(inv, "sqlite3: %v", err)
 			}
 		}
 	}
@@ -179,7 +179,7 @@ func (c *SQLite3) Run(ctx context.Context, inv *commands.Invocation) error {
 	if parsed.database != ":memory:" && !parsed.options.readonly && wrote {
 		data, err := serdes.Serialize(conn, "main")
 		if err != nil {
-			return exitf(inv, 1, "sqlite3: %v", err)
+			return exitf(inv, "sqlite3: %v", err)
 		}
 		if err := writeFileContents(ctx, inv, dbPath, data, 0o644); err != nil {
 			return err
@@ -210,7 +210,7 @@ func parseSQLiteArgs(inv *commands.Invocation) (parsed sqliteParsedArgs, err err
 			case parsed.sqlText == "":
 				parsed.sqlText = arg
 			default:
-				return sqliteParsedArgs{}, exitf(inv, 1, "sqlite3: unexpected extra argument %q", arg)
+				return sqliteParsedArgs{}, exitf(inv, "sqlite3: unexpected extra argument %q", arg)
 			}
 			continue
 		}
@@ -282,7 +282,7 @@ func parseSQLiteArgs(inv *commands.Invocation) (parsed sqliteParsedArgs, err err
 				if strings.HasPrefix(arg, "--") {
 					optName = arg[1:]
 				}
-				return sqliteParsedArgs{}, exitf(inv, 1, "sqlite3: unknown option: %s\nUse -help for a list of options.", optName)
+				return sqliteParsedArgs{}, exitf(inv, "sqlite3: unknown option: %s\nUse -help for a list of options.", optName)
 			}
 			switch {
 			case parsed.database == "":
@@ -290,7 +290,7 @@ func parseSQLiteArgs(inv *commands.Invocation) (parsed sqliteParsedArgs, err err
 			case parsed.sqlText == "":
 				parsed.sqlText = arg
 			default:
-				return sqliteParsedArgs{}, exitf(inv, 1, "sqlite3: unexpected extra argument %q", arg)
+				return sqliteParsedArgs{}, exitf(inv, "sqlite3: unexpected extra argument %q", arg)
 			}
 		}
 	}
@@ -300,7 +300,7 @@ func parseSQLiteArgs(inv *commands.Invocation) (parsed sqliteParsedArgs, err err
 
 func sqliteNextArg(inv *commands.Invocation, flag string, args []string) (value string, rest []string, err error) {
 	if len(args) == 0 {
-		return "", nil, exitf(inv, 1, "sqlite3: missing argument to %s", flag)
+		return "", nil, exitf(inv, "sqlite3: missing argument to %s", flag)
 	}
 	return args[0], args[1:], nil
 }
@@ -314,7 +314,7 @@ func resolveSQLiteDatabasePath(ctx context.Context, inv *commands.Invocation, da
 		return "", false, err
 	}
 	if exists && info.IsDir() {
-		return "", false, exitf(inv, 1, "sqlite3: %s: Is a directory", database)
+		return "", false, exitf(inv, "sqlite3: %s: Is a directory", database)
 	}
 	return abs, exists, nil
 }
@@ -333,8 +333,8 @@ func readSQLiteDatabase(ctx context.Context, inv *commands.Invocation, name stri
 	return data, nil
 }
 
-func exitf(inv *commands.Invocation, code int, format string, args ...any) error {
-	return commands.Exitf(inv, code, format, args...)
+func exitf(inv *commands.Invocation, format string, args ...any) error {
+	return commands.Exitf(inv, 1, format, args...)
 }
 
 func statMaybe(ctx context.Context, inv *commands.Invocation, name string) (info stdfs.FileInfo, abs string, exists bool, err error) {
@@ -496,12 +496,12 @@ func runSQLiteBatch(_ context.Context, inv *commands.Invocation, conn *gosqlite.
 
 		currentStmtText := sqliteFirstStatementText(remaining)
 		if reason := sqliteForbiddenStatement(currentStmtText); reason != "" {
-			return wrote, exitf(inv, 1, "sqlite3: %s", reason)
+			return wrote, exitf(inv, "sqlite3: %s", reason)
 		}
 
 		stmt, tail, err := conn.Prepare(remaining)
 		if err != nil {
-			return wrote, exitf(inv, 1, "sqlite3: %v", err)
+			return wrote, exitf(inv, "sqlite3: %v", err)
 		}
 		if stmt == nil {
 			if tail == remaining {
@@ -514,7 +514,7 @@ func runSQLiteBatch(_ context.Context, inv *commands.Invocation, conn *gosqlite.
 		sqlForStmt := strings.TrimSpace(stmt.SQL())
 		if reason := sqliteForbiddenStatement(sqlForStmt); reason != "" {
 			_ = stmt.Close()
-			return wrote, exitf(inv, 1, "sqlite3: %s", reason)
+			return wrote, exitf(inv, "sqlite3: %s", reason)
 		}
 		if opts.echo {
 			_, _ = io.WriteString(inv.Stdout, sqlForStmt)

--- a/contrib/yq/yq.go
+++ b/contrib/yq/yq.go
@@ -104,15 +104,15 @@ func (c *YQ) Run(ctx context.Context, inv *commands.Invocation) error {
 	expression = processYQExpression(expression, opts.prettyPrint)
 
 	if opts.nullInput && len(inputs) > 0 {
-		return exitf(inv, 1, "yq: cannot pass files in when using null-input flag")
+		return exitf(inv, "yq: cannot pass files in when using null-input flag")
 	}
 	if opts.inPlace && (len(inputs) == 0 || inputs[0] == "-") {
-		return exitf(inv, 1, "yq: write in place flag only applicable when giving an expression and at least one file")
+		return exitf(inv, "yq: write in place flag only applicable when giving an expression and at least one file")
 	}
 
 	formats, err := resolveYQFormats(&opts, inputs)
 	if err != nil {
-		return exitf(inv, 1, "yq: %v", err)
+		return exitf(inv, "yq: %v", err)
 	}
 
 	namedInputs, err := readNamedInputs(ctx, inv, inputs, !opts.nullInput)
@@ -131,7 +131,7 @@ func (c *YQ) Run(ctx context.Context, inv *commands.Invocation) error {
 		return err
 	}
 	if opts.exitStatus && !printed {
-		return exitf(inv, 1, "yq: no matches found")
+		return exitf(inv, "yq: no matches found")
 	}
 	if opts.inPlace {
 		info, err := inv.FS.Stat(ctx, namedInputs[0].Abs)
@@ -189,10 +189,7 @@ func parseYQArgs(inv *commands.Invocation) (opts yqOptions, expression string, i
 		return opts, "", nil, nil
 	}
 
-	expression, inputs, err = classifyYQArgs(inv, &opts, args)
-	if err != nil {
-		return yqOptions{}, "", nil, err
-	}
+	expression, inputs = classifyYQArgs(inv, &opts, args)
 	return opts, expression, inputs, nil
 }
 
@@ -245,7 +242,7 @@ func parseYQLongFlag(inv *commands.Invocation, opts *yqOptions, args []string) (
 		}
 		indent, err := parseYQPositiveInt(val)
 		if err != nil {
-			return nil, exitf(inv, 1, "yq: invalid argument for %s: %v", arg, err)
+			return nil, exitf(inv, "yq: invalid argument for %s: %v", arg, err)
 		}
 		opts.indent = indent
 		return rest, nil
@@ -255,11 +252,11 @@ func parseYQLongFlag(inv *commands.Invocation, opts *yqOptions, args []string) (
 		}
 		unwrap, err := parseBoolValue(value)
 		if err != nil {
-			return nil, exitf(inv, 1, "yq: invalid argument for %s: %v", arg, err)
+			return nil, exitf(inv, "yq: invalid argument for %s: %v", arg, err)
 		}
 		opts.unwrapScalar = &unwrap
 	default:
-		return nil, exitf(inv, 1, "yq: unrecognized option %q", arg)
+		return nil, exitf(inv, "yq: unrecognized option %q", arg)
 	}
 	return args[1:], nil
 }
@@ -292,7 +289,7 @@ func parseYQShortFlags(inv *commands.Invocation, opts *yqOptions, args []string)
 			inline := arg[idx+1:]
 			if inline == "" {
 				if len(args) < 2 {
-					return nil, exitf(inv, 1, "yq: expected argument for -%c", flag)
+					return nil, exitf(inv, "yq: expected argument for -%c", flag)
 				}
 				inline = args[1]
 				args = append(args[:1], args[2:]...)
@@ -305,39 +302,39 @@ func parseYQShortFlags(inv *commands.Invocation, opts *yqOptions, args []string)
 			case 'I':
 				indent, err := parseYQPositiveInt(inline)
 				if err != nil {
-					return nil, exitf(inv, 1, "yq: invalid argument for -I: %v", err)
+					return nil, exitf(inv, "yq: invalid argument for -I: %v", err)
 				}
 				opts.indent = indent
 			}
 			return args[1:], nil
 		default:
-			return nil, exitf(inv, 1, "yq: unsupported flag -%c", flag)
+			return nil, exitf(inv, "yq: unsupported flag -%c", flag)
 		}
 	}
 	return args[1:], nil
 }
 
-func classifyYQArgs(inv *commands.Invocation, opts *yqOptions, args []string) (expression string, inputs []string, err error) {
+func classifyYQArgs(inv *commands.Invocation, opts *yqOptions, args []string) (expression string, inputs []string) {
 	if opts.expressionFile != "" {
 		if len(args) == 0 {
-			return ".", nil, nil
+			return ".", nil
 		}
 		if !opts.nullInput && len(args) == 1 && yqLooksLikeInput(inv, args[0]) {
-			return ".", args, nil
+			return ".", args
 		}
-		return ".", args, nil
+		return ".", args
 	}
 
 	switch len(args) {
 	case 0:
-		return ".", nil, nil
+		return ".", nil
 	case 1:
 		if !opts.nullInput && yqLooksLikeInput(inv, args[0]) {
-			return ".", args, nil
+			return ".", args
 		}
-		return args[0], nil, nil
+		return args[0], nil
 	default:
-		return args[0], args[1:], nil
+		return args[0], args[1:]
 	}
 }
 
@@ -439,7 +436,7 @@ func resolveYQFormats(opts *yqOptions, inputs []string) (*yqFormatConfig, error)
 func executeYQ(ctx context.Context, inv *commands.Invocation, opts *yqOptions, expression string, inputs []namedInput, formats *yqFormatConfig, out io.Writer) (bool, error) {
 	encoder, err := newYQEncoder(formats.outputFormat, opts, formats.unwrapScalar)
 	if err != nil {
-		return false, exitf(inv, 1, "yq: %v", err)
+		return false, exitf(inv, "yq: %v", err)
 	}
 	printer := yqlib.NewPrinter(encoder, yqlib.NewSinglePrinterWriter(out))
 	if opts.nulOutput {
@@ -603,7 +600,7 @@ func normalizeYQError(inv *commands.Invocation, err error) error {
 	if _, ok := commands.ExitCode(err); ok {
 		return err
 	}
-	return exitf(inv, 1, "yq: %v", err)
+	return exitf(inv, "yq: %v", err)
 }
 
 func splitYQLongFlag(arg string) (name, value string, hasValue bool) {
@@ -617,7 +614,7 @@ func parseYQValue(inv *commands.Invocation, arg, inline string, hasValue bool, r
 		return inline, rest, nil
 	}
 	if len(rest) == 0 {
-		return "", nil, exitf(inv, 1, "yq: expected argument for %s", arg)
+		return "", nil, exitf(inv, "yq: expected argument for %s", arg)
 	}
 	return rest[0], rest[1:], nil
 }
@@ -663,8 +660,8 @@ func normalizeYQFormat(format string) string {
 	return format
 }
 
-func exitf(inv *commands.Invocation, code int, format string, args ...any) error {
-	return commands.Exitf(inv, code, format, args...)
+func exitf(inv *commands.Invocation, format string, args ...any) error {
+	return commands.Exitf(inv, 1, format, args...)
 }
 
 func readAllFile(ctx context.Context, inv *commands.Invocation, name string) (data []byte, abs string, err error) {

--- a/examples/adk-bash-chat/app.go
+++ b/examples/adk-bash-chat/app.go
@@ -133,7 +133,7 @@ func (a *chatApp) run(ctx context.Context, stdin io.Reader, stdout, stderr io.Wr
 			continue
 		}
 
-		if err := a.runTurn(ctx, line, stdout, stderr); err != nil {
+		if err := a.runTurn(ctx, line, stdout); err != nil {
 			_, _ = fmt.Fprintf(stderr, "turn failed: %v\n", err)
 		}
 	}
@@ -151,7 +151,7 @@ func (a *chatApp) resetChatSession(ctx context.Context) error {
 	return nil
 }
 
-func (a *chatApp) runTurn(ctx context.Context, input string, stdout, stderr io.Writer) error {
+func (a *chatApp) runTurn(ctx context.Context, input string, stdout io.Writer) error {
 	msg := genai.NewContentFromText(input, genai.RoleUser)
 
 	var firstErr error

--- a/examples/oauth-network-extension/main.go
+++ b/examples/oauth-network-extension/main.go
@@ -107,7 +107,7 @@ func runDemo(ctx context.Context) (*demoReport, error) {
 
 	scenarios := make([]scenarioReport, 0, len(specs))
 	for _, spec := range specs {
-		scenario, err := buildScenarioReport(spec, responseRecords, traceArgvByRequestID, auditByRequestID, serverByRequestID, vault.mustSecret(tokenRef).Token)
+		scenario, err := buildScenarioReport(spec, responseRecords, traceArgvByRequestID, auditByRequestID, serverByRequestID, vault.mustSecret().Token)
 		if err != nil {
 			return nil, err
 		}
@@ -216,10 +216,10 @@ func newDemoVault() *demoVault {
 	}
 }
 
-func (v *demoVault) mustSecret(ref string) oauthSecret {
-	secret, ok := v.secrets[ref]
+func (v *demoVault) mustSecret() oauthSecret {
+	secret, ok := v.secrets[tokenRef]
 	if !ok {
-		panic("missing demo vault secret: " + ref)
+		panic("missing demo vault secret: " + tokenRef)
 	}
 	return secret
 }
@@ -257,7 +257,7 @@ func (s *demoAPIServer) Close() {
 }
 
 func (s *demoAPIServer) handleProfile(w http.ResponseWriter, r *http.Request) {
-	expectedAuth := "Bearer " + s.vault.mustSecret(tokenRef).Token
+	expectedAuth := "Bearer " + s.vault.mustSecret().Token
 	gotAuth := r.Header.Get("Authorization")
 
 	s.mu.Lock()
@@ -282,7 +282,7 @@ func (s *demoAPIServer) handleProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	secret := s.vault.mustSecret(tokenRef)
+	secret := s.vault.mustSecret()
 	_ = json.NewEncoder(w).Encode(apiResponse{
 		OK:                  true,
 		Service:             "crm",
@@ -406,7 +406,7 @@ func (c *oauthInjectingClient) Do(ctx context.Context, req *network.Request) (*n
 		httpReq.Header.Set(name, value)
 	}
 
-	secret := c.vault.mustSecret(tokenRef)
+	secret := c.vault.mustSecret()
 	incomingAuthorization := headerValue(req.Headers, "Authorization")
 	requestID := headerValue(req.Headers, "X-Request-ID")
 	httpReq.Header.Set("Authorization", "Bearer "+secret.Token)

--- a/examples/otel/main.go
+++ b/examples/otel/main.go
@@ -61,7 +61,7 @@ func run(ctx context.Context, telemetryOut, statusOut io.Writer) (err error) {
 		gbash.WithTracing(gbash.TraceConfig{
 			Mode: gbash.TraceRedacted,
 			OnEvent: func(ctx context.Context, event gbashtrace.Event) {
-				bridge.onTraceEvent(ctx, &event)
+				bridge.onTraceEvent(&event)
 			},
 		}),
 		gbash.WithLogger(func(ctx context.Context, event gbash.LogEvent) {
@@ -221,7 +221,7 @@ func (b *telemetryBridge) onLogEvent(ctx context.Context, event *gbash.LogEvent)
 	}
 }
 
-func (b *telemetryBridge) onTraceEvent(ctx context.Context, event *gbashtrace.Event) {
+func (b *telemetryBridge) onTraceEvent(event *gbashtrace.Event) {
 	if event == nil {
 		return
 	}

--- a/examples/transactional-workspaces/demo.go
+++ b/examples/transactional-workspaces/demo.go
@@ -220,18 +220,18 @@ func (d scriptedDemo) branchFixes(ctx context.Context, snapshotName string) erro
 
 	d.section("Patch Branches")
 	d.command("patch fix-filter /workspace/scripts/clean.sh")
-	if err := d.manager.replaceInFile(ctx, "fix-filter", "/workspace/scripts/clean.sh", "| grep ',ok$' \\\n", "| grep -Ev ',invalid$' \\\n"); err != nil {
+	if err := d.manager.replaceInFile(ctx, "fix-filter", "| grep ',ok$' \\\n", "| grep -Ev ',invalid$' \\\n"); err != nil {
 		return err
 	}
-	if err := d.manager.replaceInFile(ctx, "fix-filter", "/workspace/scripts/clean.sh", "status=ok", "status!=invalid"); err != nil {
+	if err := d.manager.replaceInFile(ctx, "fix-filter", "status=ok", "status!=invalid"); err != nil {
 		return err
 	}
 
 	d.command("patch keep-everything /workspace/scripts/clean.sh")
-	if err := d.manager.replaceInFile(ctx, "keep-everything", "/workspace/scripts/clean.sh", "| grep ',ok$' \\\n", "| cat \\\n"); err != nil {
+	if err := d.manager.replaceInFile(ctx, "keep-everything", "| grep ',ok$' \\\n", "| cat \\\n"); err != nil {
 		return err
 	}
-	if err := d.manager.replaceInFile(ctx, "keep-everything", "/workspace/scripts/clean.sh", "status=ok", "all rows"); err != nil {
+	if err := d.manager.replaceInFile(ctx, "keep-everything", "status=ok", "all rows"); err != nil {
 		return err
 	}
 
@@ -622,7 +622,8 @@ func (m *workspaceManager) runFile(ctx context.Context, workspaceName, name, fil
 	return m.run(ctx, workspaceName, name, script)
 }
 
-func (m *workspaceManager) replaceInFile(ctx context.Context, workspaceName, filePath, old, replacement string) error {
+func (m *workspaceManager) replaceInFile(ctx context.Context, workspaceName, old, replacement string) error {
+	const filePath = "/workspace/scripts/clean.sh"
 	workspace, ok := m.workspaces[workspaceName]
 	if !ok {
 		return fmt.Errorf("unknown workspace %q", workspaceName)

--- a/internal/builtins/arch.go
+++ b/internal/builtins/arch.go
@@ -48,10 +48,7 @@ func (c *Arch) RunParsed(_ context.Context, inv *Invocation, matches *ParsedComm
 		return commandUsageError(inv, c.Name(), "extra operand %s", quoteGNUOperand(positionals[0]))
 	}
 
-	machine, err := archMachine(inv)
-	if err != nil {
-		return exitf(inv, 1, "%s: cannot get system name", c.Name())
-	}
+	machine := archMachine(inv)
 	if _, err := fmt.Fprintln(inv.Stdout, machine); err != nil {
 		return &ExitError{Code: 1, Err: err}
 	}

--- a/internal/builtins/arch_machine.go
+++ b/internal/builtins/arch_machine.go
@@ -7,13 +7,13 @@ import (
 
 const archEnvKey = "GBASH_ARCH"
 
-func archMachine(inv *Invocation) (string, error) {
+func archMachine(inv *Invocation) string {
 	if inv != nil && inv.Env != nil {
 		if machine := strings.TrimSpace(inv.Env[archEnvKey]); machine != "" {
-			return machine, nil
+			return machine
 		}
 	}
-	return archMachineFromGOARCH(), nil
+	return archMachineFromGOARCH()
 }
 
 func archMachineFromGOARCH() string {

--- a/internal/builtins/basenc_helpers.go
+++ b/internal/builtins/basenc_helpers.go
@@ -20,7 +20,7 @@ func readSingleBaseEncInput(ctx context.Context, inv *Invocation, name string, a
 		return nil, exitf(inv, 1, "%s: extra operand '%s'\nTry '%s --help' for more information.", name, args[1], name)
 	}
 
-	inputs, err := readNamedInputs(ctx, inv, args, true)
+	inputs, err := readNamedInputs(ctx, inv, args)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/builtins/cat.go
+++ b/internal/builtins/cat.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/ewhauser/gbash/internal/commandutil"
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Cat struct{}
@@ -180,10 +179,7 @@ func catWouldUnsafeOverwrite(ctx context.Context, inv *Invocation, name string) 
 			return catIsUnsafeOverwrite(input.RedirectOffset(), output), nil
 		}
 
-		abs, err := allowPath(ctx, inv, policy.FileActionRead, name)
-		if err != nil {
-			return false, err
-		}
+		abs := allowPath(inv, name)
 		if abs != output.RedirectPath() {
 			return false, nil
 		}
@@ -199,7 +195,7 @@ func catWouldUnsafeOverwrite(ctx context.Context, inv *Invocation, name string) 
 		if !ok {
 			return false, nil
 		}
-		return catIsUnsafeHostOverwrite(inputHost, outputHost)
+		return catIsUnsafeHostOverwrite(inputHost, outputHost), nil
 	}
 
 	info, _, err := statPath(ctx, inv, name)
@@ -232,16 +228,16 @@ func catIsUnsafeOverwrite(inputOffset int64, output catRedirectHandle) bool {
 	return catUnsafeByOffsets(inputOffset, info.Size(), output.RedirectFlags()&os.O_APPEND != 0, output.RedirectOffset())
 }
 
-func catIsUnsafeHostOverwrite(input, output catHostHandle) (bool, error) {
+func catIsUnsafeHostOverwrite(input, output catHostHandle) bool {
 	inputInfo, err := input.Stat()
 	if err != nil {
-		return false, nil //nolint:nilerr // stat failure means not the same file
+		return false
 	}
 	outputInfo, err := output.Stat()
 	if err != nil || !testSameFile(inputInfo, outputInfo) {
-		return false, nil //nolint:nilerr // stat failure means not the same file
+		return false
 	}
-	return catUnsafeByOffsets(catHostOffset(input), outputInfo.Size(), catHostAppendMode(output), catHostOffset(output)), nil
+	return catUnsafeByOffsets(catHostOffset(input), outputInfo.Size(), catHostAppendMode(output), catHostOffset(output))
 }
 
 func catUnsafeByOffsets(inputOffset, outputSize int64, appendMode bool, outputOffset int64) bool {
@@ -267,10 +263,7 @@ func readCatInput(ctx context.Context, inv *Invocation, name string) (data []byt
 		data, err := readAllReader(ctx, inv, inv.Stdin)
 		return data, name, err
 	}
-	abs, err := allowPath(ctx, inv, policy.FileActionRead, name)
-	if err != nil {
-		return nil, "", err
-	}
+	abs := allowPath(inv, name)
 	file, openErr := inv.FS.Open(ctx, abs)
 	if openErr != nil {
 		if errors.Is(openErr, stdfs.ErrInvalid) {

--- a/internal/builtins/column.go
+++ b/internal/builtins/column.go
@@ -77,10 +77,7 @@ func (c *Column) RunParsed(ctx context.Context, inv *Invocation, matches *Parsed
 		return RenderCommandHelp(inv.Stdout, &spec)
 	}
 
-	opts, err := parseColumnMatches(matches)
-	if err != nil {
-		return err
-	}
+	opts := parseColumnMatches(matches)
 
 	content, err := readColumnContent(ctx, inv, matches.Positionals())
 	if err != nil {
@@ -131,13 +128,13 @@ func (c *Column) RunParsed(ctx context.Context, inv *Invocation, matches *Parsed
 	return nil
 }
 
-func parseColumnMatches(matches *ParsedCommand) (columnOptions, error) {
+func parseColumnMatches(matches *ParsedCommand) columnOptions {
 	opts := columnOptions{
 		width:      80,
 		widthValid: true,
 	}
 	if matches == nil {
-		return opts, nil
+		return opts
 	}
 	if matches.Has("table") {
 		opts.table = true
@@ -155,7 +152,7 @@ func parseColumnMatches(matches *ParsedCommand) (columnOptions, error) {
 	if matches.Has("no-merge") {
 		opts.noMerge = true
 	}
-	return opts, nil
+	return opts
 }
 
 func hasColumnHelpFlag(args []string) bool {

--- a/internal/builtins/comm.go
+++ b/internal/builtins/comm.go
@@ -257,10 +257,7 @@ func readCommInput(ctx context.Context, inv *Invocation, name string) (data []by
 		data, err := readAllStdin(ctx, inv)
 		return data, name, err
 	}
-	abs, err := allowPath(ctx, inv, "", name)
-	if err != nil {
-		return nil, "", err
-	}
+	abs := allowPath(inv, name)
 	file, err := inv.FS.Open(ctx, abs)
 	if err != nil {
 		if errors.Is(err, stdfs.ErrInvalid) {

--- a/internal/builtins/command_helpers.go
+++ b/internal/builtins/command_helpers.go
@@ -26,18 +26,15 @@ func exitCodeForError(err error) int {
 	return 1
 }
 
-func allowPath(_ context.Context, inv *Invocation, _ policy.FileAction, name string) (string, error) {
+func allowPath(inv *Invocation, name string) string {
 	if inv == nil || inv.FS == nil {
-		return gbfs.Clean(name), nil
+		return gbfs.Clean(name)
 	}
-	return inv.FS.Resolve(name), nil
+	return inv.FS.Resolve(name)
 }
 
 func openRead(ctx context.Context, inv *Invocation, name string) (gbfs.File, string, error) {
-	abs, err := allowPath(ctx, inv, policy.FileActionRead, name)
-	if err != nil {
-		return nil, "", err
-	}
+	abs := allowPath(inv, name)
 	file, err := inv.FS.Open(ctx, abs)
 	if err != nil {
 		return nil, "", err
@@ -45,23 +42,17 @@ func openRead(ctx context.Context, inv *Invocation, name string) (gbfs.File, str
 	return file, abs, nil
 }
 
-func readDir(ctx context.Context, inv *Invocation, name string) ([]stdfs.DirEntry, string, error) {
-	abs, err := allowPath(ctx, inv, policy.FileActionReadDir, name)
-	if err != nil {
-		return nil, "", err
-	}
+func readDir(ctx context.Context, inv *Invocation, name string) ([]stdfs.DirEntry, error) {
+	abs := allowPath(inv, name)
 	entries, err := inv.FS.ReadDir(ctx, abs)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
-	return entries, abs, nil
+	return entries, nil
 }
 
 func statPath(ctx context.Context, inv *Invocation, name string) (stdfs.FileInfo, string, error) {
-	abs, err := allowPath(ctx, inv, policy.FileActionStat, name)
-	if err != nil {
-		return nil, "", err
-	}
+	abs := allowPath(inv, name)
 	info, err := inv.FS.Stat(ctx, abs)
 	if err != nil {
 		return nil, "", err
@@ -70,10 +61,7 @@ func statPath(ctx context.Context, inv *Invocation, name string) (stdfs.FileInfo
 }
 
 func lstatPath(ctx context.Context, inv *Invocation, name string) (stdfs.FileInfo, string, error) {
-	abs, err := allowPath(ctx, inv, policy.FileActionLstat, name)
-	if err != nil {
-		return nil, "", err
-	}
+	abs := allowPath(inv, name)
 	info, err := inv.FS.Lstat(ctx, abs)
 	if err != nil {
 		return nil, "", err
@@ -81,11 +69,8 @@ func lstatPath(ctx context.Context, inv *Invocation, name string) (stdfs.FileInf
 	return info, abs, nil
 }
 
-func statMaybe(ctx context.Context, inv *Invocation, action policy.FileAction, name string) (info stdfs.FileInfo, abs string, exists bool, err error) {
-	abs, err = allowPath(ctx, inv, action, name)
-	if err != nil {
-		return nil, "", false, err
-	}
+func statMaybe(ctx context.Context, inv *Invocation, name string) (info stdfs.FileInfo, abs string, exists bool, err error) {
+	abs = allowPath(inv, name)
 	info, err = inv.FS.Stat(ctx, abs)
 	if err != nil {
 		if errors.Is(err, stdfs.ErrNotExist) {
@@ -96,11 +81,8 @@ func statMaybe(ctx context.Context, inv *Invocation, action policy.FileAction, n
 	return info, abs, true, nil
 }
 
-func lstatMaybe(ctx context.Context, inv *Invocation, action policy.FileAction, name string) (info stdfs.FileInfo, abs string, exists bool, err error) {
-	abs, err = allowPath(ctx, inv, action, name)
-	if err != nil {
-		return nil, "", false, err
-	}
+func lstatMaybe(ctx context.Context, inv *Invocation, name string) (info stdfs.FileInfo, abs string, exists bool, err error) {
+	abs = allowPath(inv, name)
 	info, err = inv.FS.Lstat(ctx, abs)
 	if err != nil {
 		if errors.Is(err, stdfs.ErrNotExist) {

--- a/internal/builtins/completion_test.go
+++ b/internal/builtins/completion_test.go
@@ -59,10 +59,10 @@ func TestCompoptModifiesDefaultAndEmptyCompletionScopes(t *testing.T) {
 	state := shellstate.NewCompletionState()
 	ctx := shellstate.WithCompletionState(context.Background(), state)
 
-	if _, _, exitCode := runBuiltin(t, ctx, builtins.NewComplete(), "-F", "myfunc", "-D"); exitCode != 0 {
+	if exitCode := runBuiltin(t, ctx, builtins.NewComplete(), "-F", "myfunc", "-D"); exitCode != 0 {
 		t.Fatalf("complete -F myfunc -D exit code = %d, want 0", exitCode)
 	}
-	if _, _, exitCode := runBuiltin(t, ctx, builtins.NewCompopt(), "-D", "-o", "nospace", "-o", "filenames"); exitCode != 0 {
+	if exitCode := runBuiltin(t, ctx, builtins.NewCompopt(), "-D", "-o", "nospace", "-o", "filenames"); exitCode != 0 {
 		t.Fatalf("compopt -D exit code = %d, want 0", exitCode)
 	}
 	defaultSpec, ok := state.Get(shellstate.CompletionSpecDefaultKey)
@@ -79,7 +79,7 @@ func TestCompoptModifiesDefaultAndEmptyCompletionScopes(t *testing.T) {
 		t.Fatalf("default completion options = %v, want %v", got, want)
 	}
 
-	if _, _, exitCode := runBuiltin(t, ctx, builtins.NewCompopt(), "-E", "-o", "default"); exitCode != 0 {
+	if exitCode := runBuiltin(t, ctx, builtins.NewCompopt(), "-E", "-o", "default"); exitCode != 0 {
 		t.Fatalf("compopt -E exit code = %d, want 0", exitCode)
 	}
 	emptySpec, ok := state.Get(shellstate.CompletionSpecEmptyKey)
@@ -96,10 +96,10 @@ func TestCompoptPreservesExistingSpecWhileDisablingOptions(t *testing.T) {
 	state := shellstate.NewCompletionState()
 	ctx := shellstate.WithCompletionState(context.Background(), state)
 
-	if _, _, exitCode := runBuiltin(t, ctx, builtins.NewComplete(), "-o", "nospace", "-o", "filenames", "-F", "myfunc", "cmd"); exitCode != 0 {
+	if exitCode := runBuiltin(t, ctx, builtins.NewComplete(), "-o", "nospace", "-o", "filenames", "-F", "myfunc", "cmd"); exitCode != 0 {
 		t.Fatalf("complete exit code = %d, want 0", exitCode)
 	}
-	if _, _, exitCode := runBuiltin(t, ctx, builtins.NewCompopt(), "+o", "nospace", "cmd"); exitCode != 0 {
+	if exitCode := runBuiltin(t, ctx, builtins.NewCompopt(), "+o", "nospace", "cmd"); exitCode != 0 {
 		t.Fatalf("compopt exit code = %d, want 0", exitCode)
 	}
 
@@ -143,7 +143,7 @@ func TestCompoptPersistsAcrossInteractiveEntries(t *testing.T) {
 	}
 }
 
-func runBuiltin(tb testing.TB, ctx context.Context, cmd commands.Command, args ...string) (stdout, stderr string, exitCode int) {
+func runBuiltin(tb testing.TB, ctx context.Context, cmd commands.Command, args ...string) (exitCode int) {
 	tb.Helper()
 
 	var outBuf strings.Builder
@@ -166,5 +166,5 @@ func runBuiltin(tb testing.TB, ctx context.Context, cmd commands.Command, args .
 		exitCode = code
 	}
 
-	return outBuf.String(), errBuf.String(), exitCode
+	return exitCode
 }

--- a/internal/builtins/cp.go
+++ b/internal/builtins/cp.go
@@ -7,8 +7,6 @@ import (
 	stdfs "io/fs"
 	"path"
 	"strings"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type CP struct{}
@@ -96,7 +94,7 @@ func (c *CP) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 		if err != nil {
 			return err
 		}
-		destInfo, _, destExists, err := lstatMaybe(ctx, inv, policy.FileActionLstat, destAbs)
+		destInfo, _, destExists, err := lstatMaybe(ctx, inv, destAbs)
 		if err != nil {
 			return err
 		}
@@ -107,14 +105,12 @@ func (c *CP) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 		if err != nil {
 			return err
 		}
-		if same, err := cpSameFile(ctx, inv, srcAbs, srcInfo, destAbs, destInfo, destExists); err != nil {
-			return err
-		} else if same {
+		if cpSameFile(ctx, inv, srcAbs, srcInfo, destAbs, destInfo, destExists) {
 			return exitf(inv, 1, "cp: %s and %s are the same file", quoteGNUOperand(source), quoteGNUOperand(path.Base(destAbs)))
 		}
 
 		if srcLinkInfo != nil {
-			if err := copySymlink(ctx, inv, srcAbs, destAbs, opts); err != nil {
+			if err := copySymlink(ctx, inv, srcAbs, destAbs); err != nil {
 				return err
 			}
 			continue
@@ -239,7 +235,7 @@ func cpOperands(inv *Invocation, opts cpOptions, args []string) (sources []strin
 
 func resolveCPDestination(ctx context.Context, inv *Invocation, opts cpOptions, sourceArg, destArg string, multipleSources bool) (destAbs string, destInfo stdfs.FileInfo, destExists bool, err error) {
 	if opts.noTargetDirectory {
-		info, abs, exists, err := lstatMaybe(ctx, inv, policy.FileActionLstat, destArg)
+		info, abs, exists, err := lstatMaybe(ctx, inv, destArg)
 		if err != nil {
 			return "", nil, false, err
 		}
@@ -251,7 +247,7 @@ func resolveCPDestination(ctx context.Context, inv *Invocation, opts cpOptions, 
 		}
 		return abs, info, exists, nil
 	}
-	destInfo, destAbs, destExists, err = lstatMaybe(ctx, inv, policy.FileActionLstat, destArg)
+	destInfo, destAbs, destExists, err = lstatMaybe(ctx, inv, destArg)
 	if err != nil {
 		return "", nil, false, err
 	}
@@ -320,22 +316,22 @@ func resolveCPSource(ctx context.Context, inv *Invocation, source string, opts c
 	return info, abs, nil, nil
 }
 
-func cpSameFile(ctx context.Context, inv *Invocation, srcAbs string, srcInfo stdfs.FileInfo, destAbs string, destInfo stdfs.FileInfo, destExists bool) (bool, error) {
+func cpSameFile(ctx context.Context, inv *Invocation, srcAbs string, srcInfo stdfs.FileInfo, destAbs string, destInfo stdfs.FileInfo, destExists bool) bool {
 	if !destExists {
-		return false, nil
+		return false
 	}
 	if srcAbs == destAbs {
-		return true, nil
+		return true
 	}
 	if realSrc, err := inv.FS.Realpath(ctx, srcAbs); err == nil {
 		if realDst, err := inv.FS.Realpath(ctx, destAbs); err == nil && realSrc == realDst {
-			return true, nil
+			return true
 		}
 	}
 	if srcInfo != nil && destInfo != nil && testSameFile(srcInfo, destInfo) {
-		return true, nil
+		return true
 	}
-	return false, nil
+	return false
 }
 
 func prepareCPDestination(ctx context.Context, inv *Invocation, source, srcAbs string, srcInfo stdfs.FileInfo, copyingSymlink bool, destAbs string, destInfo stdfs.FileInfo, destExists bool, opts cpOptions) (stdfs.FileInfo, bool, error) {
@@ -389,7 +385,7 @@ func cpIsSymlinkLoop(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "too many link")
 }
 
-func copySymlink(ctx context.Context, inv *Invocation, srcAbs, dstAbs string, opts cpOptions) error {
+func copySymlink(ctx context.Context, inv *Invocation, srcAbs, dstAbs string) error {
 	if err := ensureParentDirExists(ctx, inv, dstAbs); err != nil {
 		return err
 	}
@@ -397,7 +393,7 @@ func copySymlink(ctx context.Context, inv *Invocation, srcAbs, dstAbs string, op
 	if err != nil {
 		return &ExitError{Code: 1, Err: err}
 	}
-	if info, _, exists, err := lstatMaybe(ctx, inv, policy.FileActionLstat, dstAbs); err != nil {
+	if info, _, exists, err := lstatMaybe(ctx, inv, dstAbs); err != nil {
 		return err
 	} else if exists {
 		if info.IsDir() {

--- a/internal/builtins/csplit.go
+++ b/internal/builtins/csplit.go
@@ -14,8 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf8"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Csplit struct{}
@@ -326,7 +324,7 @@ func readCsplitLines(ctx context.Context, inv *Invocation, name string) ([]strin
 	if name == "-" {
 		reader = inv.Stdin
 	} else {
-		info, _, exists, err := statMaybe(ctx, inv, policy.FileActionStat, name)
+		info, _, exists, err := statMaybe(ctx, inv, name)
 		if err == nil && exists && info.IsDir() {
 			return nil, errors.New("read error: Is a directory")
 		}

--- a/internal/builtins/cut.go
+++ b/internal/builtins/cut.go
@@ -245,7 +245,7 @@ func parseCutRanges(inv *Invocation, mode cutMode, value string, complement bool
 	ranges := make([]cutRange, 0, len(parts))
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
-		current, err := parseCutRangePart(mode, part)
+		current, err := parseCutRangePart(part)
 		if err != nil {
 			return nil, cutRangeError(inv, mode, part, err)
 		}
@@ -257,7 +257,7 @@ func parseCutRanges(inv *Invocation, mode cutMode, value string, complement bool
 	return ranges, nil
 }
 
-func parseCutRangePart(mode cutMode, part string) (cutRange, error) {
+func parseCutRangePart(part string) (cutRange, error) {
 	if part == "" {
 		return cutRange{}, errCutRangeStartsAtOne
 	}

--- a/internal/builtins/dir.go
+++ b/internal/builtins/dir.go
@@ -6,8 +6,6 @@ import (
 	stdfs "io/fs"
 	"strconv"
 	"strings"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Dir struct{}
@@ -69,7 +67,7 @@ func (c *Dir) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCom
 }
 
 func (c *Dir) listPath(ctx context.Context, inv *Invocation, commandName, target string, opts *lsOptions, showHeader, defaultColumns bool) (output string, status int, rendered lsRenderResult, err error) {
-	info, abs, exists, err := statMaybe(ctx, inv, policy.FileActionStat, target)
+	info, abs, exists, err := statMaybe(ctx, inv, target)
 	if err != nil {
 		return "", 0, lsRenderResult{}, err
 	}
@@ -79,10 +77,11 @@ func (c *Dir) listPath(ctx context.Context, inv *Invocation, commandName, target
 	}
 
 	if opts.directoryOnly || !info.IsDir() {
-		return c.renderPathEntry(ctx, inv, target, abs, info, opts, defaultColumns)
+		out, rendered, err := c.renderPathEntry(ctx, inv, target, abs, info, opts, defaultColumns)
+		return out, 0, rendered, err
 	}
 
-	entries, _, err := readDir(ctx, inv, target)
+	entries, err := readDir(ctx, inv, target)
 	if err != nil {
 		return "", 0, lsRenderResult{}, err
 	}
@@ -148,21 +147,21 @@ func (c *Dir) listPath(ctx context.Context, inv *Invocation, commandName, target
 	return out.String(), 0, lsRenderResult{text: out.String()}, nil
 }
 
-func (c *Dir) renderPathEntry(ctx context.Context, inv *Invocation, target, abs string, info stdfs.FileInfo, opts *lsOptions, defaultColumns bool) (output string, status int, rendered lsRenderResult, err error) {
+func (c *Dir) renderPathEntry(ctx context.Context, inv *Invocation, target, abs string, info stdfs.FileInfo, opts *lsOptions, defaultColumns bool) (output string, rendered lsRenderResult, err error) {
 	name, _, err := lsDecoratedName(ctx, inv, target, abs, info, opts, dirQuoteName)
 	if err != nil {
-		return "", 0, lsRenderResult{}, err
+		return "", lsRenderResult{}, err
 	}
 	if opts.longFormat {
-		line, _ := formatLSLongLine(inv, name, info, opts, nil)
-		return line, 0, lsRenderResult{text: line}, nil
+		line, _ := formatLSLongLine(name, info, opts, nil)
+		return line, lsRenderResult{text: line}, nil
 	}
 	if defaultColumns {
 		line := name + lsTerminator(opts)
-		return line, 0, lsRenderResult{text: line}, nil
+		return line, lsRenderResult{text: line}, nil
 	}
 	line := name + lsTerminator(opts)
-	return line, 0, lsRenderResult{text: line}, nil
+	return line, lsRenderResult{text: line}, nil
 }
 
 func lsHasExplicitFormat(matches *ParsedCommand) bool {

--- a/internal/builtins/dircolors.go
+++ b/internal/builtins/dircolors.go
@@ -7,8 +7,6 @@ import (
 	"path"
 	"slices"
 	"strings"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Dircolors struct{}
@@ -113,7 +111,7 @@ func (c *Dircolors) RunParsed(ctx context.Context, inv *Invocation, matches *Par
 		}
 		lines = textLines(data)
 	} else {
-		info, _, exists, err := statMaybe(ctx, inv, policy.FileActionStat, fp)
+		info, _, exists, err := statMaybe(ctx, inv, fp)
 		if err != nil {
 			return err
 		}

--- a/internal/builtins/du.go
+++ b/internal/builtins/du.go
@@ -131,7 +131,7 @@ func (c *DU) emit(ctx context.Context, inv *Invocation, abs string, info stdfs.F
 		return size, nil
 	}
 
-	entries, _, err := readDir(ctx, inv, abs)
+	entries, err := readDir(ctx, inv, abs)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/builtins/env.go
+++ b/internal/builtins/env.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"maps"
 	"strings"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Env struct{}
@@ -251,7 +249,7 @@ func validateEnvUnsetName(inv *Invocation, name string) error {
 }
 
 func resolveEnvWorkingDir(ctx context.Context, inv *Invocation, dir string) (string, error) {
-	_, abs, exists, err := statMaybe(ctx, inv, policy.FileActionStat, dir)
+	_, abs, exists, err := statMaybe(ctx, inv, dir)
 	if err != nil {
 		return "", err
 	}

--- a/internal/builtins/file_helpers.go
+++ b/internal/builtins/file_helpers.go
@@ -8,13 +8,11 @@ import (
 	"os"
 	"path"
 	"strings"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 func ensureParentDirExists(ctx context.Context, inv *Invocation, targetAbs string) error {
 	parent := path.Dir(targetAbs)
-	info, _, exists, err := statMaybe(ctx, inv, policy.FileActionStat, parent)
+	info, _, exists, err := statMaybe(ctx, inv, parent)
 	if err != nil {
 		return err
 	}
@@ -73,7 +71,7 @@ func copyTree(ctx context.Context, inv *Invocation, srcAbs, dstAbs string) error
 		return &ExitError{Code: 1, Err: err}
 	}
 
-	entries, _, err := readDir(ctx, inv, srcAbs)
+	entries, err := readDir(ctx, inv, srcAbs)
 	if err != nil {
 		return err
 	}
@@ -119,7 +117,7 @@ func writeFileContents(ctx context.Context, inv *Invocation, targetAbs string, d
 }
 
 func resolveDestination(ctx context.Context, inv *Invocation, sourceAbs, destArg string, multipleSources bool) (destAbs string, destInfo stdfs.FileInfo, destExists bool, err error) {
-	destInfo, destAbs, destExists, err = statMaybe(ctx, inv, policy.FileActionStat, destArg)
+	destInfo, destAbs, destExists, err = statMaybe(ctx, inv, destArg)
 	if err != nil {
 		return "", nil, false, err
 	}

--- a/internal/builtins/find.go
+++ b/internal/builtins/find.go
@@ -7,8 +7,6 @@ import (
 	"path"
 	"sort"
 	"strings"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Find struct{}
@@ -114,7 +112,7 @@ func (c *Find) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCo
 		if strings.HasPrefix(root, "/") {
 			rootAbs = root
 		}
-		if _, _, exists, err := statMaybe(ctx, inv, policy.FileActionStat, rootAbs); err != nil {
+		if _, _, exists, err := statMaybe(ctx, inv, rootAbs); err != nil {
 			return err
 		} else if !exists {
 			_, _ = fmt.Fprintf(inv.Stderr, "find: %s: No such file or directory\n", root)
@@ -173,7 +171,7 @@ func (c *Find) walk(
 	var entries []stdfs.DirEntry
 	entriesLoaded := false
 	if needsEntries {
-		entries, _, err = readDir(ctx, inv, currentAbs)
+		entries, err = readDir(ctx, inv, currentAbs)
 		if err != nil {
 			return err
 		}
@@ -206,7 +204,7 @@ func (c *Find) walk(
 
 	if info.IsDir() && (!opts.hasMaxDepth || depth < opts.maxDepth) && !eval.pruned {
 		if !entriesLoaded {
-			entries, _, err = readDir(ctx, inv, currentAbs)
+			entries, err = readDir(ctx, inv, currentAbs)
 			if err != nil {
 				return err
 			}
@@ -279,10 +277,7 @@ func (c *Find) runActions(ctx context.Context, inv *Invocation, actions []findAc
 				}
 			}
 		case *findDeleteAction:
-			deleteExitCode, err := deleteFindResults(ctx, inv, state.results)
-			if err != nil {
-				return 0, err
-			}
+			deleteExitCode := deleteFindResults(ctx, inv, state.results)
 			if deleteExitCode > exitCode {
 				exitCode = deleteExitCode
 			}
@@ -344,7 +339,7 @@ func replaceFindExecPlaceholders(parts, replacements []string) []string {
 	return argv
 }
 
-func deleteFindResults(ctx context.Context, inv *Invocation, results []string) (int, error) {
+func deleteFindResults(ctx context.Context, inv *Invocation, results []string) int {
 	exitCode := 0
 	sorted := append([]string(nil), results...)
 	sort.SliceStable(sorted, func(i, j int) bool {
@@ -355,17 +350,14 @@ func deleteFindResults(ctx context.Context, inv *Invocation, results []string) (
 	})
 
 	for _, name := range sorted {
-		abs, err := allowPath(ctx, inv, policy.FileActionRemove, name)
-		if err != nil {
-			return 0, err
-		}
+		abs := allowPath(inv, name)
 		if err := inv.FS.Remove(ctx, abs, false); err != nil {
 			_, _ = fmt.Fprintf(inv.Stderr, "find: cannot delete '%s': %v\n", name, err)
 			exitCode = 1
 			continue
 		}
 	}
-	return exitCode, nil
+	return exitCode
 }
 
 func writeFindSeparated(inv *Invocation, values []string, sep string, trailing bool) error {

--- a/internal/builtins/find_matcher.go
+++ b/internal/builtins/find_matcher.go
@@ -7,8 +7,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 func resolveFindExpr(ctx context.Context, inv *Invocation, expr findExpr) error {
@@ -16,7 +14,7 @@ func resolveFindExpr(ctx context.Context, inv *Invocation, expr findExpr) error 
 	case nil:
 		return nil
 	case *findNewerExpr:
-		info, _, exists, err := statMaybe(ctx, inv, policy.FileActionStat, e.refPath)
+		info, _, exists, err := statMaybe(ctx, inv, e.refPath)
 		if err != nil {
 			return err
 		}

--- a/internal/builtins/grep.go
+++ b/internal/builtins/grep.go
@@ -11,7 +11,6 @@ import (
 
 	gbfs "github.com/ewhauser/gbash/fs"
 	"github.com/ewhauser/gbash/internal/searchadapter"
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Grep struct{}
@@ -311,7 +310,7 @@ func compileGrepPattern(opts grepOptions) (*regexp.Regexp, error) {
 	return regexp.Compile(pattern)
 }
 
-func grepSearchContent(re *regexp.Regexp, data []byte, name string, showName bool, opts grepOptions) (grepSearchResult, error) {
+func grepSearchContent(re *regexp.Regexp, data []byte, name string, showName bool, opts grepOptions) grepSearchResult {
 	if opts.count {
 		matchCount := 0
 		countMatches := opts.onlyMatching && !opts.invert
@@ -337,7 +336,7 @@ func grepSearchContent(re *regexp.Regexp, data []byte, name string, showName boo
 			output:     fmt.Sprintf("%s%d\n", prefix, matchCount),
 			matched:    matchCount > 0,
 			matchCount: matchCount,
-		}, nil
+		}
 	}
 
 	lines := textLines(data)
@@ -376,7 +375,7 @@ func grepSearchContent(re *regexp.Regexp, data []byte, name string, showName boo
 			output:     grepJoinOutput(outputLines),
 			matched:    hasMatch,
 			matchCount: matchCount,
-		}, nil
+		}
 	}
 
 	matchingLines := make([]int, 0)
@@ -448,7 +447,7 @@ func grepSearchContent(re *regexp.Regexp, data []byte, name string, showName boo
 		output:     grepJoinOutput(outputLines),
 		matched:    matchCount > 0,
 		matchCount: matchCount,
-	}, nil
+	}
 }
 
 func grepJoinOutput(lines []string) string {
@@ -477,10 +476,7 @@ func grepLinePrefix(name string, showName bool, lineNumber int, showLineNumber, 
 }
 
 func writeGrepResult(inv *Invocation, re *regexp.Regexp, data []byte, name string, showName bool, opts grepOptions, state *grepRunState) error {
-	result, err := grepSearchContent(re, data, name, showName, opts)
-	if err != nil {
-		return err
-	}
+	result := grepSearchContent(re, data, name, showName, opts)
 
 	if result.matched {
 		state.matchedAny = true
@@ -550,7 +546,7 @@ func writeGrepGuaranteedMiss(inv *Invocation, name string, showName bool, opts g
 }
 
 func (c *Grep) enumerateTopLevelPath(ctx context.Context, inv *Invocation, file string, opts grepOptions, state *grepRunState, records *[]grepFileRecord) (*grepSearchScope, error) {
-	linfo, abs, exists, err := lstatMaybe(ctx, inv, policy.FileActionLstat, file)
+	linfo, abs, exists, err := lstatMaybe(ctx, inv, file)
 	if err != nil {
 		return nil, err
 	}
@@ -632,7 +628,7 @@ func (c *Grep) enumerateRecursive(ctx context.Context, inv *Invocation, currentA
 		return nil
 	}
 
-	entries, _, err := readDir(ctx, inv, currentAbs)
+	entries, err := readDir(ctx, inv, currentAbs)
 	if err != nil {
 		return err
 	}

--- a/internal/builtins/gzip.go
+++ b/internal/builtins/gzip.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"path"
 	"strings"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Gzip struct {
@@ -150,9 +148,6 @@ func runGzipItem(ctx context.Context, inv *Invocation, opts *gzipOptions, name, 
 	if err := ensureParentDirExists(ctx, inv, targetAbs); err != nil {
 		return err
 	}
-	if _, err := allowPath(ctx, inv, policy.FileActionWrite, targetAbs); err != nil {
-		return err
-	}
 	if exists, err := gzipTargetExists(ctx, inv, targetAbs); err != nil {
 		return err
 	} else if exists {
@@ -236,7 +231,7 @@ func resolveGzipOutputPath(inv *Invocation, opts *gzipOptions, sourceAbs string)
 }
 
 func gzipTargetExists(ctx context.Context, inv *Invocation, targetAbs string) (bool, error) {
-	_, _, exists, err := lstatMaybe(ctx, inv, policy.FileActionLstat, targetAbs)
+	_, _, exists, err := lstatMaybe(ctx, inv, targetAbs)
 	if err != nil {
 		return false, err
 	}

--- a/internal/builtins/id.go
+++ b/internal/builtins/id.go
@@ -107,10 +107,7 @@ func (c *ID) RunParsed(_ context.Context, inv *Invocation, matches *ParsedComman
 			continue
 		}
 
-		output, err := idFormatOutput(&identity, opts, delimiter, len(opts.users) > 1)
-		if err != nil {
-			return err
-		}
+		output := idFormatOutput(&identity, opts, delimiter, len(opts.users) > 1)
 		if _, err := fmt.Fprint(inv.Stdout, output, lineEnding); err != nil {
 			return &ExitError{Code: 1, Err: err}
 		}
@@ -318,18 +315,18 @@ func idLookupIdentity(current *idIdentity, user string) (idIdentity, bool) {
 	return idIdentity{}, false
 }
 
-func idFormatOutput(identity *idIdentity, opts idOptions, delimiter string, multiUser bool) (string, error) {
+func idFormatOutput(identity *idIdentity, opts idOptions, delimiter string, multiUser bool) string {
 	if identity == nil {
-		return "", nil
+		return ""
 	}
 	if opts.audit {
-		return "", nil
+		return ""
 	}
 	if opts.passwordStyle {
-		return fmt.Sprintf("%s:x:%d:%d::%s:%s", identity.userName, identity.uid, identity.group.id, identity.homeDir, identity.shell), nil
+		return fmt.Sprintf("%s:x:%d:%d::%s:%s", identity.userName, identity.uid, identity.group.id, identity.homeDir, identity.shell)
 	}
 	if opts.humanReadable {
-		return idPretty(identity), nil
+		return idPretty(identity)
 	}
 	if opts.groupOnly {
 		idValue := identity.group.id
@@ -337,9 +334,9 @@ func idFormatOutput(identity *idIdentity, opts idOptions, delimiter string, mult
 			idValue = identity.egid
 		}
 		if opts.nameOnly {
-			return identity.group.name, nil
+			return identity.group.name
 		}
-		return strconv.FormatUint(uint64(idValue), 10), nil
+		return strconv.FormatUint(uint64(idValue), 10)
 	}
 	if opts.userOnly {
 		idValue := identity.uid
@@ -347,9 +344,9 @@ func idFormatOutput(identity *idIdentity, opts idOptions, delimiter string, mult
 			idValue = identity.euid
 		}
 		if opts.nameOnly {
-			return identity.userName, nil
+			return identity.userName
 		}
-		return strconv.FormatUint(uint64(idValue), 10), nil
+		return strconv.FormatUint(uint64(idValue), 10)
 	}
 	if opts.groupsOnly {
 		parts := make([]string, 0, len(identity.groups))
@@ -364,7 +361,7 @@ func idFormatOutput(identity *idIdentity, opts idOptions, delimiter string, mult
 		if opts.zero && multiUser {
 			out += "\x00"
 		}
-		return out, nil
+		return out
 	}
 
 	parts := []string{
@@ -383,7 +380,7 @@ func idFormatOutput(identity *idIdentity, opts idOptions, delimiter string, mult
 		groupParts = append(groupParts, fmt.Sprintf("%d(%s)", group.id, group.name))
 	}
 	parts = append(parts, "groups="+strings.Join(groupParts, ","))
-	return strings.Join(parts, " "), nil
+	return strings.Join(parts, " ")
 }
 
 func idPretty(identity *idIdentity) string {

--- a/internal/builtins/join.go
+++ b/internal/builtins/join.go
@@ -134,8 +134,8 @@ func (c *Join) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCo
 		opts.output = joinAutoOutput(leftRecords, rightRecords, leftHeader, rightHeader)
 	}
 
-	leftDisorder := joinDetectDisorder(leftRecords, leftName, &opts)
-	rightDisorder := joinDetectDisorder(rightRecords, rightName, &opts)
+	leftDisorder := joinDetectDisorder(leftRecords, leftName)
+	rightDisorder := joinDetectDisorder(rightRecords, rightName)
 
 	if opts.header {
 		if err := writeJoinLine(inv, &opts, leftHeader, rightHeader); err != nil {
@@ -474,7 +474,7 @@ func joinAutoWidth(records []joinRecord, header *joinRecord) int {
 	return len(records[0].fields)
 }
 
-func joinDetectDisorder(records []joinRecord, fileName string, opts *joinOptions) *joinDisorder {
+func joinDetectDisorder(records []joinRecord, fileName string) *joinDisorder {
 	for i := 1; i < len(records); i++ {
 		if joinCompareKeys(records[i-1].key, records[i].key) > 0 {
 			return &joinDisorder{

--- a/internal/builtins/link.go
+++ b/internal/builtins/link.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	stdfs "io/fs"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Link struct{}
@@ -51,10 +49,7 @@ func (c *Link) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCo
 		return exitf(inv, 1, "link: cannot create link %s to %s: Operation not permitted", quoteGNUOperand(newName), quoteGNUOperand(oldName))
 	}
 
-	newAbs, err := allowPath(ctx, inv, policy.FileActionWrite, newName)
-	if err != nil {
-		return err
-	}
+	newAbs := allowPath(inv, newName)
 	if err := ensureParentDirExists(ctx, inv, newAbs); err != nil {
 		return exitf(inv, 1, "link: cannot create link %s to %s: %s", quoteGNUOperand(newName), quoteGNUOperand(oldName), linkErrText(err))
 	}

--- a/internal/builtins/ln.go
+++ b/internal/builtins/ln.go
@@ -7,8 +7,6 @@ import (
 	stdfs "io/fs"
 	"path"
 	"path/filepath"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type LN struct{}
@@ -127,7 +125,7 @@ func runLN(ctx context.Context, inv *Invocation, opts *lnOptions, files []string
 		return lnLinkIntoDirectory(ctx, inv, opts, files, ".")
 	case 2:
 		if !opts.noTargetDir {
-			if info, _, exists, err := statMaybe(ctx, inv, policy.FileActionStat, files[1]); err != nil {
+			if info, _, exists, err := statMaybe(ctx, inv, files[1]); err != nil {
 				return err
 			} else if exists && info.IsDir() {
 				return lnLinkIntoDirectory(ctx, inv, opts, files[:1], files[1])
@@ -173,10 +171,7 @@ func lnLinkIntoDirectory(ctx context.Context, inv *Invocation, opts *lnOptions, 
 }
 
 func lnCreateOne(ctx context.Context, inv *Invocation, opts *lnOptions, target, linkName string) error {
-	linkAbs, err := allowPath(ctx, inv, policy.FileActionWrite, linkName)
-	if err != nil {
-		return err
-	}
+	linkAbs := allowPath(inv, linkName)
 	if err := ensureParentDirExists(ctx, inv, linkAbs); err != nil {
 		return err
 	}
@@ -222,7 +217,7 @@ func lnCreateOne(ctx context.Context, inv *Invocation, opts *lnOptions, target, 
 }
 
 func lnPrepareDestination(ctx context.Context, inv *Invocation, opts *lnOptions, target, linkName, linkAbs string) error {
-	info, _, exists, err := lstatMaybe(ctx, inv, policy.FileActionLstat, linkName)
+	info, _, exists, err := lstatMaybe(ctx, inv, linkName)
 	if err != nil {
 		return err
 	}

--- a/internal/builtins/ls.go
+++ b/internal/builtins/ls.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	gbfs "github.com/ewhauser/gbash/fs"
-	"github.com/ewhauser/gbash/policy"
 	"golang.org/x/term"
 )
 
@@ -476,7 +475,7 @@ func (c *LS) listPath(ctx context.Context, inv *Invocation, target string, opts 
 		return c.renderPathEntry(ctx, inv, target, abs, info, opts)
 	}
 
-	entries, _, err := readDir(ctx, inv, target)
+	entries, err := readDir(ctx, inv, target)
 	if err != nil {
 		return "", 0, lsRenderResult{}, err
 	}
@@ -604,11 +603,11 @@ func (c *LS) listPath(ctx context.Context, inv *Invocation, target string, opts 
 
 func lsStatMaybeForTarget(ctx context.Context, inv *Invocation, target string, opts *lsOptions) (info stdfs.FileInfo, abs string, exists bool, err error) {
 	if target != "/" && strings.HasSuffix(target, "/") {
-		return statMaybe(ctx, inv, policy.FileActionStat, target)
+		return statMaybe(ctx, inv, target)
 	}
 	switch {
 	case opts == nil || opts.dereference == lsDerefAll || opts.dereference == lsDerefArgs:
-		linfo, lAbs, lExists, lErr := lstatMaybe(ctx, inv, policy.FileActionLstat, target)
+		linfo, lAbs, lExists, lErr := lstatMaybe(ctx, inv, target)
 		if lErr != nil || !lExists {
 			return linfo, lAbs, lExists, lErr
 		}
@@ -621,7 +620,7 @@ func lsStatMaybeForTarget(ctx context.Context, inv *Invocation, target string, o
 		}
 		return targetInfo, lAbs, true, nil
 	case opts.dereference == lsDerefDirArgs:
-		linfo, lAbs, lExists, lErr := lstatMaybe(ctx, inv, policy.FileActionLstat, target)
+		linfo, lAbs, lExists, lErr := lstatMaybe(ctx, inv, target)
 		if lErr != nil || !lExists {
 			return linfo, lAbs, lExists, lErr
 		}
@@ -634,7 +633,7 @@ func lsStatMaybeForTarget(ctx context.Context, inv *Invocation, target string, o
 		}
 		return linfo, lAbs, true, nil
 	default:
-		return lstatMaybe(ctx, inv, policy.FileActionLstat, target)
+		return lstatMaybe(ctx, inv, target)
 	}
 }
 
@@ -644,7 +643,7 @@ func (c *LS) renderPathEntry(ctx context.Context, inv *Invocation, target, abs s
 		return "", 0, lsRenderResult{}, err
 	}
 	if opts.longFormat {
-		line, dired := formatLSLongLine(inv, name, info, opts, ranges)
+		line, dired := formatLSLongLine(name, info, opts, ranges)
 		if opts.dired {
 			line = "  " + line
 			for i := range dired {
@@ -694,7 +693,7 @@ func lsRenderEntries(ctx context.Context, inv *Invocation, dirAbs string, entrie
 			return lsRenderResult{}, err
 		}
 		if opts.longFormat {
-			line, dired := formatLSLongLine(inv, name, entry.info, opts, ranges)
+			line, dired := formatLSLongLine(name, entry.info, opts, ranges)
 			if opts.dired {
 				line = "  " + line
 				for i := range dired {
@@ -729,7 +728,7 @@ func lsRenderPathArgs(ctx context.Context, inv *Invocation, args []lsPathArg, op
 			return lsRenderResult{}, err
 		}
 		if opts.longFormat {
-			line, dired := formatLSLongLine(inv, name, arg.info, opts, ranges)
+			line, dired := formatLSLongLine(name, arg.info, opts, ranges)
 			if opts.dired {
 				line = "  " + line
 				for i := range dired {
@@ -1693,7 +1692,7 @@ func parseLSColorsEnv(value string) lsParsedColors {
 func lsColorIndicator(ctx context.Context, inv *Invocation, abs string, info, linfo stdfs.FileInfo, entries map[string]string) (string, error) {
 	if linfo.Mode()&stdfs.ModeSymlink != 0 {
 		if entries["ln"] == "target" {
-			targetInfo, _, exists, err := statMaybe(ctx, inv, policy.FileActionStat, abs)
+			targetInfo, _, exists, err := statMaybe(ctx, inv, abs)
 			if err != nil {
 				return "", err
 			}
@@ -2071,7 +2070,7 @@ func lsNumericChunk(value string) (chunk, rest string) {
 	return value[:index], value[index:]
 }
 
-func formatLSLongLine(inv *Invocation, name string, info stdfs.FileInfo, opts *lsOptions, nameRanges []lsByteRange) (string, []lsByteRange) {
+func formatLSLongLine(name string, info stdfs.FileInfo, opts *lsOptions, nameRanges []lsByteRange) (string, []lsByteRange) {
 	fields := make([]string, 0, 9)
 	userToken, groupToken, authorToken := lsIdentityTokens(info, opts.numericIDs, opts.identityDB)
 	if opts.showInode {

--- a/internal/builtins/mkdir.go
+++ b/internal/builtins/mkdir.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	stdfs "io/fs"
 	"path"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Mkdir struct{}
@@ -73,10 +71,7 @@ func (c *Mkdir) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedC
 	}
 
 	for _, name := range args {
-		abs, err := allowPath(ctx, inv, policy.FileActionMkdir, name)
-		if err != nil {
-			return err
-		}
+		abs := allowPath(inv, name)
 
 		created, err := mkdirPath(ctx, inv, abs, createMode, opts.parents)
 		if err != nil {

--- a/internal/builtins/mktemp.go
+++ b/internal/builtins/mktemp.go
@@ -127,7 +127,7 @@ func (c *Mktemp) RunParsed(ctx context.Context, inv *Invocation, matches *Parsed
 
 	var output string
 	if opts.dryRun {
-		output, err = mktempDryRun(params)
+		output = mktempDryRun(params)
 	} else {
 		output, err = mktempExec(ctx, inv, params, opts.directory)
 	}
@@ -314,12 +314,9 @@ func mktempTrimVisibleDir(value string) string {
 	}
 }
 
-func mktempDryRun(params mktempParams) (string, error) {
-	randomPart, err := mktempRandomString(params.numRandom)
-	if err != nil {
-		return "", err
-	}
-	return mktempCandidatePath(params, randomPart), nil
+func mktempDryRun(params mktempParams) string {
+	randomPart := mktempRandomString(params.numRandom)
+	return mktempCandidatePath(params, randomPart)
 }
 
 func mktempExec(ctx context.Context, inv *Invocation, params mktempParams, makeDir bool) (string, error) {
@@ -333,12 +330,10 @@ func mktempExec(ctx context.Context, inv *Invocation, params mktempParams, makeD
 		if err := ctx.Err(); err != nil {
 			return "", err
 		}
-		randomPart, err := mktempRandomString(params.numRandom)
-		if err != nil {
-			return "", &mktempCreateError{kind: kind, template: templatePath, err: err}
-		}
+		randomPart := mktempRandomString(params.numRandom)
 		visiblePath := mktempCandidatePath(params, randomPart)
 		absPath := inv.FS.Resolve(visiblePath)
+		var err error
 		if makeDir {
 			err = mktempCreateDir(ctx, inv, absPath)
 		} else {
@@ -399,9 +394,9 @@ func mktempCandidatePath(params mktempParams, randomPart string) string {
 	return mktempJoinVisible(params.directory, params.prefix+randomPart+params.suffix)
 }
 
-func mktempRandomString(length int) (string, error) {
+func mktempRandomString(length int) string {
 	if length <= 0 {
-		return "", nil
+		return ""
 	}
 
 	buf := make([]byte, length)
@@ -420,7 +415,7 @@ func mktempRandomString(length int) (string, error) {
 	for i, b := range buf {
 		out[i] = mktempAlphabet[int(b)]
 	}
-	return string(out), nil
+	return string(out)
 }
 
 func mktempCreateErrorText(err error) string {

--- a/internal/builtins/mv.go
+++ b/internal/builtins/mv.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	stdfs "io/fs"
 	"strings"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type MV struct{}
@@ -75,7 +73,7 @@ func (c *MV) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 		if err != nil {
 			return err
 		}
-		destInfo, _, destExists, err := statMaybe(ctx, inv, policy.FileActionStat, destAbs)
+		destInfo, _, destExists, err := statMaybe(ctx, inv, destAbs)
 		if err != nil {
 			return err
 		}

--- a/internal/builtins/nl.go
+++ b/internal/builtins/nl.go
@@ -309,10 +309,7 @@ func readNLInput(ctx context.Context, inv *Invocation, name string, stdinData *[
 		return *stdinData, false, nil
 	}
 
-	abs, err := allowPath(ctx, inv, "", name)
-	if err != nil {
-		return nil, false, err
-	}
+	abs := allowPath(inv, name)
 	info, err := inv.FS.Stat(ctx, abs)
 	if err != nil {
 		return nil, false, err

--- a/internal/builtins/rev.go
+++ b/internal/builtins/rev.go
@@ -35,7 +35,7 @@ func (c *Rev) Spec() CommandSpec {
 
 func (c *Rev) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCommand) error {
 	args := matches.Args("file")
-	inputs, err := readNamedInputs(ctx, inv, args, true)
+	inputs, err := readNamedInputs(ctx, inv, args)
 	if err != nil {
 		return err
 	}

--- a/internal/builtins/rg.go
+++ b/internal/builtins/rg.go
@@ -16,7 +16,6 @@ import (
 
 	gbfs "github.com/ewhauser/gbash/fs"
 	"github.com/ewhauser/gbash/internal/searchadapter"
-	"github.com/ewhauser/gbash/policy"
 )
 
 type RG struct{}
@@ -625,7 +624,7 @@ func (c *RG) collectFiles(ctx context.Context, inv *Invocation, roots []string, 
 	explicitFileCount := 0
 	directoryCount := 0
 	for _, root := range roots {
-		linfo, abs, exists, err := lstatMaybe(ctx, inv, policy.FileActionLstat, root)
+		linfo, abs, exists, err := lstatMaybe(ctx, inv, root)
 		if err != nil {
 			return rgCollectResult{}, err
 		}
@@ -719,7 +718,7 @@ func (c *RG) walkRoot(ctx context.Context, inv *Invocation, state *rgWalkState, 
 		}
 	}
 
-	entries, _, err := readDir(ctx, inv, state.rootAbs)
+	entries, err := readDir(ctx, inv, state.rootAbs)
 	if err != nil {
 		return err
 	}

--- a/internal/builtins/rg_ignore.go
+++ b/internal/builtins/rg_ignore.go
@@ -5,8 +5,6 @@ import (
 	"path"
 	"regexp"
 	"strings"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type rgIgnoreRule struct {
@@ -34,7 +32,7 @@ func (m *rgIgnoreMatcher) loadPath(ctx context.Context, inv *Invocation, targetA
 		return nil
 	}
 	current := targetAbs
-	info, _, exists, err := lstatMaybe(ctx, inv, policy.FileActionLstat, targetAbs)
+	info, _, exists, err := lstatMaybe(ctx, inv, targetAbs)
 	if err != nil {
 		return err
 	}
@@ -180,18 +178,18 @@ func rgIgnorePatternRegexp(pattern string, rooted bool) (*regexp.Regexp, error) 
 }
 
 func (m *rgIgnoreMatcher) matches(abs string, isDir bool) bool {
-	_, ignored, _ := m.state(abs, isDir)
+	ignored, _ := m.state(abs, isDir)
 	return ignored
 }
 
 func (m *rgIgnoreMatcher) whitelisted(abs string, isDir bool) bool {
-	_, ignored, negated := m.state(abs, isDir)
+	ignored, negated := m.state(abs, isDir)
 	return !ignored && negated
 }
 
-func (m *rgIgnoreMatcher) state(abs string, isDir bool) (matched, ignored, negated bool) {
+func (m *rgIgnoreMatcher) state(abs string, isDir bool) (ignored, negated bool) {
 	if m == nil {
-		return false, false, false
+		return false, false
 	}
 	for _, rule := range m.rules {
 		if rule.base != "/" && abs != rule.base && !strings.HasPrefix(abs, rule.base+"/") {
@@ -203,10 +201,9 @@ func (m *rgIgnoreMatcher) state(abs string, isDir bool) (matched, ignored, negat
 			continue
 		}
 		if rule.regex.MatchString(rel) {
-			matched = true
 			ignored = !rule.negated
 			negated = rule.negated
 		}
 	}
-	return matched, ignored, negated
+	return ignored, negated
 }

--- a/internal/builtins/rm.go
+++ b/internal/builtins/rm.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	stdfs "io/fs"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type RM struct{}
@@ -49,10 +47,7 @@ func (c *RM) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedComm
 	args := matches.Args("file")
 
 	for _, name := range args {
-		abs, err := allowPath(ctx, inv, policy.FileActionRemove, name)
-		if err != nil {
-			return err
-		}
+		abs := allowPath(inv, name)
 		info, err := inv.FS.Lstat(ctx, abs)
 		if err != nil {
 			if force && errors.Is(err, stdfs.ErrNotExist) {

--- a/internal/builtins/rmdir.go
+++ b/internal/builtins/rmdir.go
@@ -9,8 +9,6 @@ import (
 	"path"
 	"strings"
 	"syscall"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Rmdir struct{}
@@ -57,10 +55,7 @@ func (c *Rmdir) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedC
 	args := matches.Args("dir")
 
 	for _, dir := range args {
-		abs, err := allowPath(ctx, inv, policy.FileActionRemove, dir)
-		if err != nil {
-			return err
-		}
+		abs := allowPath(inv, dir)
 		if err := removeEmptyDir(ctx, inv, dir, abs, opts); err != nil {
 			return err
 		}

--- a/internal/builtins/source_helpers.go
+++ b/internal/builtins/source_helpers.go
@@ -13,11 +13,8 @@ type namedInput struct {
 	FromStdin bool
 }
 
-func readNamedInputs(ctx context.Context, inv *Invocation, names []string, defaultStdin bool) ([]namedInput, error) {
+func readNamedInputs(ctx context.Context, inv *Invocation, names []string) ([]namedInput, error) {
 	if len(names) == 0 {
-		if !defaultStdin {
-			return nil, nil
-		}
 		data, err := readAllStdin(ctx, inv)
 		if err != nil {
 			return nil, err

--- a/internal/builtins/stat.go
+++ b/internal/builtins/stat.go
@@ -77,7 +77,7 @@ func (c *Stat) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCo
 			exitCode = 1
 			continue
 		}
-		output, err := renderStatOutput(ctx, inv, name, abs, info, opts)
+		output, err := renderStatOutput(ctx, inv, abs, info, opts)
 		if err != nil {
 			return err
 		}
@@ -117,7 +117,7 @@ func hasTrailingSlash(name string) bool {
 	return len(name) > 1 && strings.HasSuffix(name, "/")
 }
 
-func renderStatOutput(ctx context.Context, inv *Invocation, rawName, abs string, info stdfs.FileInfo, opts statOptions) (string, error) {
+func renderStatOutput(ctx context.Context, inv *Invocation, abs string, info stdfs.FileInfo, opts statOptions) (string, error) {
 	if opts.format == "" {
 		return defaultStatOutput(abs, info), nil
 	}
@@ -129,7 +129,7 @@ func renderStatOutput(ctx context.Context, inv *Invocation, rawName, abs string,
 		}
 		format = decoded
 	}
-	rendered, err := renderStatFormat(ctx, inv, rawName, abs, info, format)
+	rendered, err := renderStatFormat(ctx, inv, abs, info, format)
 	if err != nil {
 		return "", &ExitError{Code: 1, Err: err}
 	}
@@ -150,7 +150,7 @@ func defaultStatOutput(abs string, info stdfs.FileInfo) string {
 	)
 }
 
-func renderStatFormat(ctx context.Context, inv *Invocation, rawName, abs string, info stdfs.FileInfo, format string) (string, error) {
+func renderStatFormat(ctx context.Context, inv *Invocation, abs string, info stdfs.FileInfo, format string) (string, error) {
 	identities := loadPermissionIdentityDB(ctx, inv)
 	owner := permissionLookupOwnership(identities, info)
 	var b strings.Builder
@@ -166,7 +166,7 @@ func renderStatFormat(ctx context.Context, inv *Invocation, rawName, abs string,
 		}
 		start := i
 		leftAlign, zeroPad, width, precision, directive := parseStatDirective(format, &i)
-		value, err := statDirectiveValue(ctx, inv, rawName, abs, info, owner, directive, precision)
+		value, err := statDirectiveValue(ctx, inv, abs, info, owner, directive, precision)
 		if err != nil {
 			return "", err
 		}
@@ -225,7 +225,7 @@ widthParse:
 	return
 }
 
-func statDirectiveValue(ctx context.Context, inv *Invocation, rawName, abs string, info stdfs.FileInfo, owner permissionOwnership, directive byte, precision int) (string, error) {
+func statDirectiveValue(ctx context.Context, inv *Invocation, abs string, info stdfs.FileInfo, owner permissionOwnership, directive byte, precision int) (string, error) {
 	switch directive {
 	case 'n':
 		return abs, nil

--- a/internal/builtins/strings.go
+++ b/internal/builtins/strings.go
@@ -75,7 +75,7 @@ func (c *Strings) RunParsed(ctx context.Context, inv *Invocation, matches *Parse
 		return err
 	}
 
-	inputs, err := readNamedInputs(ctx, inv, matches.Args("file"), true)
+	inputs, err := readNamedInputs(ctx, inv, matches.Args("file"))
 	if err != nil {
 		return err
 	}

--- a/internal/builtins/subexec_helpers.go
+++ b/internal/builtins/subexec_helpers.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	gbfs "github.com/ewhauser/gbash/fs"
-	"github.com/ewhauser/gbash/policy"
 )
 
 type commandResolution struct {
@@ -76,7 +75,7 @@ type executeCommandOptions struct {
 
 func resolveCommand(ctx context.Context, inv *Invocation, env map[string]string, dir, name string) (*commandResolution, bool, error) {
 	if strings.Contains(name, "/") {
-		info, abs, exists, err := statMaybe(ctx, inv, policy.FileActionStat, name)
+		info, abs, exists, err := statMaybe(ctx, inv, name)
 		if err != nil {
 			return nil, false, err
 		}
@@ -88,7 +87,7 @@ func resolveCommand(ctx context.Context, inv *Invocation, env map[string]string,
 
 	for _, pathDir := range commandSearchDirs(env, dir) {
 		candidate := gbfs.Resolve(pathDir, name)
-		info, abs, exists, err := statMaybe(ctx, inv, policy.FileActionStat, candidate)
+		info, abs, exists, err := statMaybe(ctx, inv, candidate)
 		if err != nil {
 			return nil, false, err
 		}
@@ -102,7 +101,7 @@ func resolveCommand(ctx context.Context, inv *Invocation, env map[string]string,
 
 func resolveAllCommands(ctx context.Context, inv *Invocation, env map[string]string, dir, name string) ([]string, error) {
 	if strings.Contains(name, "/") {
-		info, abs, exists, err := statMaybe(ctx, inv, policy.FileActionStat, name)
+		info, abs, exists, err := statMaybe(ctx, inv, name)
 		if err != nil {
 			return nil, err
 		}
@@ -116,7 +115,7 @@ func resolveAllCommands(ctx context.Context, inv *Invocation, env map[string]str
 	seen := make(map[string]struct{})
 	for _, pathDir := range commandSearchDirs(env, dir) {
 		candidate := gbfs.Resolve(pathDir, name)
-		info, abs, exists, err := statMaybe(ctx, inv, policy.FileActionStat, candidate)
+		info, abs, exists, err := statMaybe(ctx, inv, candidate)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/builtins/tac.go
+++ b/internal/builtins/tac.go
@@ -52,12 +52,9 @@ func (c *Tac) Spec() CommandSpec {
 }
 
 func (c *Tac) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCommand) error {
-	opts, err := parseTacMatches(matches)
-	if err != nil {
-		return err
-	}
+	opts := parseTacMatches(matches)
 
-	inputs, err := readNamedInputs(ctx, inv, matches.Args("file"), true)
+	inputs, err := readNamedInputs(ctx, inv, matches.Args("file"))
 	if err != nil {
 		return err
 	}
@@ -84,7 +81,7 @@ func (c *Tac) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCom
 	return nil
 }
 
-func parseTacMatches(matches *ParsedCommand) (tacOptions, error) {
+func parseTacMatches(matches *ParsedCommand) tacOptions {
 	opts := tacOptions{
 		before:    matches.Has("before"),
 		regex:     matches.Has("regex"),
@@ -98,7 +95,7 @@ func parseTacMatches(matches *ParsedCommand) (tacOptions, error) {
 			opts.separator = []byte(value)
 		}
 	}
-	return opts, nil
+	return opts
 }
 
 func tacReverseFixed(data, separator []byte, before bool) []byte {

--- a/internal/builtins/tail.go
+++ b/internal/builtins/tail.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	gbfs "github.com/ewhauser/gbash/fs"
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Tail struct{}
@@ -260,7 +259,7 @@ func (c *Tail) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCo
 
 	for {
 		if opts.follow != tailFollowNone && opts.pid != 0 {
-			alive, err := tailPIDIsAlive(ctx, inv, opts.pid)
+			alive, err := tailPIDIsAlive(inv)
 			if err != nil {
 				return err
 			}
@@ -379,7 +378,7 @@ func (c *Tail) pollTailByName(
 	process func([]byte) []byte,
 	outputState *tailOutputState,
 ) error {
-	info, _, exists, err := statMaybe(ctx, inv, policy.FileActionStat, state.path)
+	info, _, exists, err := statMaybe(ctx, inv, state.path)
 	if err != nil {
 		return &ExitError{Code: exitCodeForError(err), Err: err}
 	}
@@ -595,14 +594,14 @@ func tailOptionsFromParsed(inv *Invocation, matches *ParsedCommand) (tailOptions
 }
 
 func tailPathIsUntailable(ctx context.Context, inv *Invocation, name string) bool {
-	info, _, exists, err := statMaybe(ctx, inv, policy.FileActionStat, name)
+	info, _, exists, err := statMaybe(ctx, inv, name)
 	if err != nil || !exists {
 		return false
 	}
 	return info.IsDir()
 }
 
-func tailPIDIsAlive(ctx context.Context, inv *Invocation, pid int) (bool, error) {
+func tailPIDIsAlive(inv *Invocation) (bool, error) {
 	return false, exitf(inv, 1, "tail: --pid is unsupported in this sandbox")
 }
 

--- a/internal/builtins/tar.go
+++ b/internal/builtins/tar.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	gbfs "github.com/ewhauser/gbash/fs"
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Tar struct{}
@@ -285,10 +284,7 @@ func openTarWriter(ctx context.Context, inv *Invocation, opts *tarOptions) (*tar
 	closers := make([]io.Closer, 0, 3)
 
 	if opts.archive != "-" {
-		archiveAbs, err := allowPath(ctx, inv, policy.FileActionWrite, opts.archive)
-		if err != nil {
-			return nil, nil, err
-		}
+		archiveAbs := allowPath(inv, opts.archive)
 		if err := ensureParentDirExists(ctx, inv, archiveAbs); err != nil {
 			return nil, nil, err
 		}
@@ -426,7 +422,7 @@ func tarWriteHeader(ctx context.Context, inv *Invocation, tw *tar.Writer, abs, n
 }
 
 func tarWriteDirChildren(ctx context.Context, inv *Invocation, tw *tar.Writer, abs, name string) error {
-	entries, _, err := readDir(ctx, inv, abs)
+	entries, err := readDir(ctx, inv, abs)
 	if err != nil {
 		return err
 	}
@@ -477,9 +473,6 @@ func sanitizeTarEntryName(name string) (string, error) {
 }
 
 func tarEnsureDir(ctx context.Context, inv *Invocation, targetAbs string, perm stdfs.FileMode) error {
-	if _, err := allowPath(ctx, inv, policy.FileActionMkdir, targetAbs); err != nil {
-		return err
-	}
 	if err := inv.FS.MkdirAll(ctx, targetAbs, perm.Perm()); err != nil {
 		return &ExitError{Code: 1, Err: err}
 	}
@@ -488,9 +481,6 @@ func tarEnsureDir(ctx context.Context, inv *Invocation, targetAbs string, perm s
 
 func tarExtractFile(ctx context.Context, inv *Invocation, tr *tar.Reader, targetAbs string, header *tar.Header, keepOld bool) error {
 	if err := tarEnsureParents(ctx, inv, targetAbs); err != nil {
-		return err
-	}
-	if _, err := allowPath(ctx, inv, policy.FileActionWrite, targetAbs); err != nil {
 		return err
 	}
 	if exists, err := gzipTargetExists(ctx, inv, targetAbs); err != nil {
@@ -532,9 +522,6 @@ func tarExtractSymlink(ctx context.Context, inv *Invocation, entryName, targetAb
 	if err := tarEnsureParents(ctx, inv, targetAbs); err != nil {
 		return err
 	}
-	if _, err := allowPath(ctx, inv, policy.FileActionWrite, targetAbs); err != nil {
-		return err
-	}
 	if exists, err := gzipTargetExists(ctx, inv, targetAbs); err != nil {
 		return err
 	} else if exists {
@@ -558,12 +545,6 @@ func tarExtractHardlink(ctx context.Context, inv *Invocation, baseDir, targetAbs
 	}
 	linkAbs := gbfs.Resolve(baseDir, linkName)
 	if err := tarEnsureParents(ctx, inv, targetAbs); err != nil {
-		return err
-	}
-	if _, err := allowPath(ctx, inv, policy.FileActionWrite, targetAbs); err != nil {
-		return err
-	}
-	if _, err := allowPath(ctx, inv, policy.FileActionRead, linkAbs); err != nil {
 		return err
 	}
 	if exists, err := gzipTargetExists(ctx, inv, targetAbs); err != nil {
@@ -600,9 +581,6 @@ func tarEnsureParents(ctx context.Context, inv *Invocation, targetAbs string) er
 	parent := path.Dir(targetAbs)
 	if parent == "." || parent == "/" {
 		return nil
-	}
-	if _, err := allowPath(ctx, inv, policy.FileActionMkdir, parent); err != nil {
-		return err
 	}
 	if err := inv.FS.MkdirAll(ctx, parent, 0o755); err != nil {
 		return &ExitError{Code: 1, Err: err}

--- a/internal/builtins/tee.go
+++ b/internal/builtins/tee.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"strings"
 	"syscall"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 const teeBufferSize = 8 * 1024
@@ -231,10 +229,7 @@ func openTeeWriters(ctx context.Context, inv *Invocation, opts teeOptions) ([]*t
 	hadOpenErrors := false
 
 	for _, name := range opts.files {
-		abs, err := allowPath(ctx, inv, policy.FileActionWrite, name)
-		if err != nil {
-			return nil, false, err
-		}
+		abs := allowPath(inv, name)
 		if err := ensureParentDirExists(ctx, inv, abs); err != nil {
 			reported := teeWriteOpenError(inv.Stderr, name, err)
 			if teeOutputErrorExitsOnOpen(opts.outputError) {
@@ -316,22 +311,14 @@ func (w *teeMultiWriter) writeAndFlush(buf []byte) error {
 	kept := w.writers[:0]
 	for _, writer := range w.writers {
 		if err := teeWriteAll(writer.writer, buf); err != nil {
-			action, actionErr := w.handleWriteError(writer, err)
-			if actionErr != nil {
+			if actionErr := w.handleWriteError(writer, err); actionErr != nil {
 				return actionErr
-			}
-			if action == "keep" {
-				kept = append(kept, writer)
 			}
 			continue
 		}
 		if err := teeFlush(writer.writer); err != nil {
-			action, actionErr := w.handleWriteError(writer, err)
-			if actionErr != nil {
+			if actionErr := w.handleWriteError(writer, err); actionErr != nil {
 				return actionErr
-			}
-			if action == "keep" {
-				kept = append(kept, writer)
 			}
 			continue
 		}
@@ -345,37 +332,37 @@ func (w *teeMultiWriter) writeAndFlush(buf []byte) error {
 	return nil
 }
 
-func (w *teeMultiWriter) handleWriteError(writer *teeWriter, err error) (string, error) {
+func (w *teeMultiWriter) handleWriteError(writer *teeWriter, err error) error {
 	switch mode := w.outputError; {
 	case mode == nil:
 		if teeIsBrokenPipe(err) {
 			w.silentWriteFail = true
-			return "drop", errTeeAbortQuiet
+			return errTeeAbortQuiet
 		}
 		teeWriteWriterError(w.stderr, writer.name, err)
 		w.ignoredErrors++
-		return "drop", nil
+		return nil
 	case *mode == teeOutputErrorWarn:
 		teeWriteWriterError(w.stderr, writer.name, err)
 		w.ignoredErrors++
-		return "drop", nil
+		return nil
 	case *mode == teeOutputErrorWarnNoPipe:
 		if !teeIsBrokenPipe(err) {
 			teeWriteWriterError(w.stderr, writer.name, err)
 			w.ignoredErrors++
 		}
-		return "drop", nil
+		return nil
 	case *mode == teeOutputErrorExit:
 		teeWriteWriterError(w.stderr, writer.name, err)
-		return "drop", errTeeAbort
+		return errTeeAbort
 	case *mode == teeOutputErrorExitNoPipe:
 		if teeIsBrokenPipe(err) {
-			return "drop", nil
+			return nil
 		}
 		teeWriteWriterError(w.stderr, writer.name, err)
-		return "drop", errTeeAbort
+		return errTeeAbort
 	default:
-		return "drop", err
+		return err
 	}
 }
 

--- a/internal/builtins/test.go
+++ b/internal/builtins/test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	gbfs "github.com/ewhauser/gbash/fs"
-	"github.com/ewhauser/gbash/policy"
 	"golang.org/x/term"
 )
 
@@ -180,12 +179,12 @@ func (p *testParser) peekIsBoolOp() bool {
 	return p.peek().kind == testSymbolBoolOp
 }
 
-func (p *testParser) expect(value string) error {
+func (p *testParser) expect() error {
 	symbol := p.nextToken()
-	if symbol.kind == testSymbolLiteral && symbol.token == value {
+	if symbol.kind == testSymbolLiteral && symbol.token == ")" {
 		return nil
 	}
-	return testParseExpected(value)
+	return testParseExpected(")")
 }
 
 func (p *testParser) expr() error {
@@ -229,7 +228,7 @@ func (p *testParser) lparen() error {
 	case (peek3[0].kind == testSymbolUnaryStr || peek3[0].kind == testSymbolUnaryFile) && peek3[2].kind == testSymbolLiteral && peek3[2].token == ")":
 		symbol := p.nextToken()
 		p.uop(symbol)
-		return p.expect(")")
+		return p.expect()
 	case peek3[0].isBinaryOp() && peek3[1].kind == testSymbolLiteral && peek3[1].token == ")":
 		return p.literal(testSymbol{kind: testSymbolLParen}.intoLiteral())
 	case peek3[1].kind == testSymbolLiteral && peek3[1].token == ")":
@@ -237,20 +236,20 @@ func (p *testParser) lparen() error {
 		if err := p.literal(symbol); err != nil {
 			return err
 		}
-		return p.expect(")")
+		return p.expect()
 	case peek3[0].isBinaryOp() && peek3[1].isBinaryOp():
 		symbol := p.nextToken()
 		if err := p.literal(symbol); err != nil {
 			return err
 		}
-		return p.expect(")")
+		return p.expect()
 	case peek3[0].isBinaryOp():
 		return p.literal(testSymbol{kind: testSymbolLParen}.intoLiteral())
 	default:
 		if err := p.expr(); err != nil {
 			return err
 		}
-		return p.expect(")")
+		return p.expect()
 	}
 }
 
@@ -509,11 +508,11 @@ func testCompareIntegers(a, b, op string) (bool, error) {
 }
 
 func testCompareFiles(ctx context.Context, inv *Invocation, a, b, op string) (bool, error) {
-	infoA, absA, existsA, err := statMaybe(ctx, inv, policy.FileActionStat, a)
+	infoA, absA, existsA, err := statMaybe(ctx, inv, a)
 	if err != nil {
 		return false, err
 	}
-	infoB, absB, existsB, err := statMaybe(ctx, inv, policy.FileActionStat, b)
+	infoB, absB, existsB, err := statMaybe(ctx, inv, b)
 	if err != nil {
 		return false, err
 	}
@@ -563,14 +562,14 @@ func testFilePredicate(ctx context.Context, inv *Invocation, name, op string) (b
 		return testIsTTY(inv, int(fd.Int64())), nil
 	}
 	if op == "-h" || op == "-L" {
-		info, _, exists, err := lstatMaybe(ctx, inv, policy.FileActionLstat, name)
+		info, _, exists, err := lstatMaybe(ctx, inv, name)
 		if err != nil {
 			return false, err
 		}
 		return exists && info.Mode()&stdfs.ModeSymlink != 0, nil
 	}
 
-	info, _, exists, err := statMaybe(ctx, inv, policy.FileActionStat, name)
+	info, _, exists, err := statMaybe(ctx, inv, name)
 	if err != nil {
 		return false, err
 	}

--- a/internal/builtins/touch.go
+++ b/internal/builtins/touch.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Touch struct{}
@@ -221,10 +219,7 @@ func touchOne(ctx context.Context, inv *Invocation, opts *touchOptions, times to
 		if opts.noDereference && !hasTrailingSlash(name) {
 			return exitf(inv, 1, "touch: cannot touch %q: No such file or directory", name)
 		}
-		abs, err = allowPath(ctx, inv, policy.FileActionWrite, name)
-		if err != nil {
-			return err
-		}
+		abs = allowPath(inv, name)
 		if err := ensureParentDirExists(ctx, inv, abs); err != nil {
 			return err
 		}
@@ -238,10 +233,6 @@ func touchOne(ctx context.Context, inv *Invocation, opts *touchOptions, times to
 		recordFileMutation(inv.TraceRecorder(), "touch", abs, "", abs)
 		info, _, err = statPath(ctx, inv, name)
 		if err != nil {
-			return err
-		}
-	} else if info.IsDir() {
-		if _, err := allowPath(ctx, inv, policy.FileActionWrite, name); err != nil {
 			return err
 		}
 	}
@@ -268,35 +259,35 @@ func touchOne(ctx context.Context, inv *Invocation, opts *touchOptions, times to
 
 func touchStatMaybe(ctx context.Context, inv *Invocation, name string, noDereference bool) (info stdfs.FileInfo, abs string, exists bool, err error) {
 	if noDereference && !hasTrailingSlash(name) {
-		return lstatMaybe(ctx, inv, policy.FileActionLstat, name)
+		return lstatMaybe(ctx, inv, name)
 	}
-	return statMaybe(ctx, inv, policy.FileActionStat, name)
+	return statMaybe(ctx, inv, name)
 }
 
 func parseTouchDateValue(base time.Time, value string) (time.Time, error) {
 	if value == "now" {
 		return time.Now().UTC(), nil
 	}
-	if shifted, ok, err := parseTouchRelativeDate(base, value); ok || err != nil {
-		return shifted, err
+	if shifted, ok := parseTouchRelativeDate(base, value); ok {
+		return shifted, nil
 	}
 	return parseTouchTime(value)
 }
 
-func parseTouchRelativeDate(base time.Time, value string) (time.Time, bool, error) {
+func parseTouchRelativeDate(base time.Time, value string) (time.Time, bool) {
 	fields := strings.Fields(value)
 	if len(fields) != 2 {
-		return time.Time{}, false, nil
+		return time.Time{}, false
 	}
 	amount, err := strconv.Atoi(fields[0])
 	if err != nil {
-		return time.Time{}, false, nil //nolint:nilerr // unparseable amount means not a relative date
+		return time.Time{}, false
 	}
 	switch fields[1] {
 	case "day", "days":
-		return base.AddDate(0, 0, amount).UTC(), true, nil
+		return base.AddDate(0, 0, amount).UTC(), true
 	default:
-		return time.Time{}, false, nil
+		return time.Time{}, false
 	}
 }
 

--- a/internal/builtins/tr.go
+++ b/internal/builtins/tr.go
@@ -323,10 +323,7 @@ func parseTRSequences(input []byte) ([]trSequence, error) {
 			i = next
 			continue
 		}
-		if seq, next, ok, err := parseTRCharStar(input, i); ok || err != nil {
-			if err != nil {
-				return nil, err
-			}
+		if seq, next, ok := parseTRCharStar(input, i); ok {
 			seqs = append(seqs, seq)
 			i = next
 			continue
@@ -383,18 +380,18 @@ func parseTRCharRange(input []byte, i int) (seq trSequence, next int, ok bool, e
 	return trSequence{kind: trSequenceRange, start: left, end: right}, end, true, nil
 }
 
-func parseTRCharStar(input []byte, i int) (seq trSequence, next int, ok bool, err error) {
+func parseTRCharStar(input []byte, i int) (trSequence, int, bool) {
 	if i+4 > len(input) || input[i] != '[' {
-		return trSequence{}, 0, false, nil
+		return trSequence{}, 0, false
 	}
 	ch, next, err := parseTRByte(input, i+1)
 	if err != nil {
-		return trSequence{}, 0, false, nil //nolint:nilerr // parse failure means this parser doesn't match
+		return trSequence{}, 0, false
 	}
 	if next+2 <= len(input) && input[next] == '*' && input[next+1] == ']' {
-		return trSequence{kind: trSequenceStar, char: ch}, next + 2, true, nil
+		return trSequence{kind: trSequenceStar, char: ch}, next + 2, true
 	}
-	return trSequence{}, 0, false, nil
+	return trSequence{}, 0, false
 }
 
 func parseTRCharRepeat(input []byte, i int) (seq trSequence, next int, ok bool, err error) {

--- a/internal/builtins/tree.go
+++ b/internal/builtins/tree.go
@@ -111,7 +111,7 @@ func (c *Tree) renderChildren(ctx context.Context, inv *Invocation, abs string, 
 		return 0, 0, nil
 	}
 
-	entries, _, err := readDir(ctx, inv, abs)
+	entries, err := readDir(ctx, inv, abs)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/internal/builtins/truncate.go
+++ b/internal/builtins/truncate.go
@@ -12,8 +12,6 @@ import (
 	"path"
 	"strings"
 	"syscall"
-
-	"github.com/ewhauser/gbash/policy"
 )
 
 type Truncate struct{}
@@ -473,10 +471,7 @@ func truncateReferenceSize(ctx context.Context, inv *Invocation, raw string) (ui
 }
 
 func (c *Truncate) truncatePath(ctx context.Context, inv *Invocation, raw string, noCreate bool, referenceSize *uint64, mode truncateMode) error {
-	abs, err := allowPath(ctx, inv, policy.FileActionWrite, raw)
-	if err != nil {
-		return &ExitError{Code: exitCodeForError(err), Err: err}
-	}
+	abs := allowPath(inv, raw)
 
 	info, err := inv.FS.Stat(ctx, abs)
 	switch {

--- a/internal/builtins/uname.go
+++ b/internal/builtins/uname.go
@@ -76,10 +76,7 @@ func (c *Uname) RunParsed(_ context.Context, inv *Invocation, matches *ParsedCom
 		processor:        matches.Has("processor"),
 		hardwarePlatform: matches.Has("hardware-platform"),
 	}
-	output, err := newUnameOutput(inv, opts)
-	if err != nil {
-		return exitf(inv, 1, "%s: cannot get system name", c.Name())
-	}
+	output := newUnameOutput(inv, opts)
 	if _, err := fmt.Fprintln(inv.Stdout, output.display()); err != nil {
 		return &ExitError{Code: 1, Err: err}
 	}
@@ -138,11 +135,8 @@ type unameInfo struct {
 	operatingSystem string
 }
 
-func newUnameOutput(inv *Invocation, opts unameOptions) (unameOutput, error) {
-	info, err := currentUnameInfo(inv)
-	if err != nil {
-		return unameOutput{}, err
-	}
+func newUnameOutput(inv *Invocation, opts unameOptions) unameOutput {
+	info := currentUnameInfo(inv)
 
 	none := !opts.all &&
 		!opts.kernelName &&
@@ -179,18 +173,15 @@ func newUnameOutput(inv *Invocation, opts unameOptions) (unameOutput, error) {
 	if opts.operatingSystem || opts.all {
 		out.operatingSystem = info.operatingSystem
 	}
-	return out, nil
+	return out
 }
 
-func currentUnameInfo(inv *Invocation) (unameInfo, error) {
+func currentUnameInfo(inv *Invocation) unameInfo {
 	if info, complete := unameEnvInfo(inv); complete {
-		return info, nil
+		return info
 	}
 
-	info, err := unameHostInfo()
-	if err != nil {
-		return unameInfo{}, err
-	}
+	info := unameHostInfo()
 	applyUnameEnvOverrides(inv, &info)
 	if info.machine == "" {
 		info.machine = archMachineFromGOARCH()
@@ -198,7 +189,7 @@ func currentUnameInfo(inv *Invocation) (unameInfo, error) {
 	if info.operatingSystem == "" {
 		info.operatingSystem = unameOperatingSystemName()
 	}
-	return info, nil
+	return info
 }
 
 func unameEnvInfo(inv *Invocation) (unameInfo, bool) {
@@ -215,7 +206,7 @@ func unameEnvInfo(inv *Invocation) (unameInfo, bool) {
 		operatingSystem: unameEnvValue(inv.Env, unameOperatingSystemEnvKey),
 	}
 	if info.machine == "" {
-		if machine, err := archMachine(inv); err == nil {
+		if machine := archMachine(inv); strings.TrimSpace(machine) != "" {
 			info.machine = strings.TrimSpace(machine)
 		}
 	}
@@ -246,7 +237,7 @@ func applyUnameEnvOverrides(inv *Invocation, info *unameInfo) {
 	}
 	if value := unameEnvValue(inv.Env, unameMachineEnvKey); value != "" {
 		info.machine = value
-	} else if machine, err := archMachine(inv); err == nil && strings.TrimSpace(machine) != "" {
+	} else if machine := archMachine(inv); strings.TrimSpace(machine) != "" {
 		info.machine = strings.TrimSpace(machine)
 	}
 	if value := unameEnvValue(inv.Env, unameOperatingSystemEnvKey); value != "" {
@@ -315,7 +306,7 @@ func unameKernelName() string {
 	}
 }
 
-func unameHostInfo() (unameInfo, error) {
+func unameHostInfo() unameInfo {
 	return unameInfo{
 		kernelName:      unameKernelName(),
 		nodename:        unameDefaultNodename,
@@ -323,7 +314,7 @@ func unameHostInfo() (unameInfo, error) {
 		kernelVersion:   unameUnknown,
 		machine:         archMachineFromGOARCH(),
 		operatingSystem: unameOperatingSystemName(),
-	}, nil
+	}
 }
 
 var _ Command = (*Uname)(nil)

--- a/internal/builtins/who.go
+++ b/internal/builtins/who.go
@@ -153,21 +153,21 @@ func (c *Who) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedCom
 				}
 			case whoBootTimeType:
 				if opts.needBootTime {
-					writeErr = whoWriteNamedRecord(inv, opts, "", ' ', "system boot", record, "", "")
+					writeErr = whoWriteNamedRecord(inv, opts, "", "system boot", record, "", "")
 				}
 			case whoNewTimeType:
 				if opts.needClockChange {
-					writeErr = whoWriteNamedRecord(inv, opts, "", ' ', "clock change", record, "", "")
+					writeErr = whoWriteNamedRecord(inv, opts, "", "clock change", record, "", "")
 				}
 			case whoInitProcessType:
 				if opts.needInitSpawn {
 					comment := fmt.Sprintf("id=%s", record.id)
-					writeErr = whoWriteNamedRecord(inv, opts, "", ' ', record.line, record, fmt.Sprintf("%d", record.pid), comment)
+					writeErr = whoWriteNamedRecord(inv, opts, "", record.line, record, fmt.Sprintf("%d", record.pid), comment)
 				}
 			case whoLoginType:
 				if opts.needLogin {
 					comment := fmt.Sprintf("id=%s", record.id)
-					writeErr = whoWriteNamedRecord(inv, opts, "LOGIN", ' ', record.line, record, fmt.Sprintf("%d", record.pid), comment)
+					writeErr = whoWriteNamedRecord(inv, opts, "LOGIN", record.line, record, fmt.Sprintf("%d", record.pid), comment)
 				}
 			case whoDeadType:
 				if opts.needDeadProcs {
@@ -386,8 +386,8 @@ func whoWriteRunlevel(inv *Invocation, opts whoOptions, record *whoRecord) error
 	)
 }
 
-func whoWriteNamedRecord(inv *Invocation, opts whoOptions, user string, state rune, line string, record *whoRecord, pid, comment string) error {
-	return whoWriteLine(inv, opts, user, state, line, whoTimeString(inv.Env, record.timestamp), "", pid, comment, "")
+func whoWriteNamedRecord(inv *Invocation, opts whoOptions, user, line string, record *whoRecord, pid, comment string) error {
+	return whoWriteLine(inv, opts, user, ' ', line, whoTimeString(inv.Env, record.timestamp), "", pid, comment, "")
 }
 
 func whoWriteLine(inv *Invocation, opts whoOptions, user string, state rune, line, when, idle, pid, comment, exit string) error {

--- a/internal/builtins/xan_expr.go
+++ b/internal/builtins/xan_expr.go
@@ -122,13 +122,13 @@ func (e xanBinaryExpr) eval(ctx *xanEvalContext) (any, error) {
 	case "ne":
 		return xanValueString(left) != xanValueString(right), nil
 	case "<":
-		return xanCompareOrdered(left, right, func(c int) bool { return c < 0 })
+		return xanCompareOrdered(left, right, func(c int) bool { return c < 0 }), nil
 	case "<=":
-		return xanCompareOrdered(left, right, func(c int) bool { return c <= 0 })
+		return xanCompareOrdered(left, right, func(c int) bool { return c <= 0 }), nil
 	case ">":
-		return xanCompareOrdered(left, right, func(c int) bool { return c > 0 })
+		return xanCompareOrdered(left, right, func(c int) bool { return c > 0 }), nil
 	case ">=":
-		return xanCompareOrdered(left, right, func(c int) bool { return c >= 0 })
+		return xanCompareOrdered(left, right, func(c int) bool { return c >= 0 }), nil
 	case "lt":
 		return xanCompareOrderedStrings(left, right, func(c int) bool { return c < 0 }), nil
 	case "le":
@@ -424,20 +424,20 @@ func xanCompareEq(left, right any) bool {
 	return xanValueString(left) == xanValueString(right)
 }
 
-func xanCompareOrdered(left, right any, match func(int) bool) (bool, error) {
+func xanCompareOrdered(left, right any, match func(int) bool) bool {
 	if lnum, lok := xanAsFloat(left); lok {
 		if rnum, rok := xanAsFloat(right); rok {
 			switch {
 			case lnum < rnum:
-				return match(-1), nil
+				return match(-1)
 			case lnum > rnum:
-				return match(1), nil
+				return match(1)
 			default:
-				return match(0), nil
+				return match(0)
 			}
 		}
 	}
-	return match(strings.Compare(xanValueString(left), xanValueString(right))), nil
+	return match(strings.Compare(xanValueString(left), xanValueString(right)))
 }
 
 func xanCompareOrderedStrings(left, right any, match func(int) bool) bool {

--- a/internal/builtins/xargs.go
+++ b/internal/builtins/xargs.go
@@ -161,7 +161,7 @@ func (c *XArgs) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedC
 		opts.exitIfTooLarge = true
 	}
 	if opts.showLimits {
-		if err := writeXArgsLimits(inv, &opts, maxSupported); err != nil {
+		if err := writeXArgsLimits(inv, &opts); err != nil {
 			return err
 		}
 	}
@@ -264,7 +264,7 @@ func parseXArgsMatches(inv *Invocation, matches *ParsedCommand) (opts xargsOptio
 			value := nextValue(name)
 			count := 1
 			if value != "" {
-				parsed, parseErr := parseXArgsNumber(inv, value, 'L', 1, math.MaxInt, true)
+				parsed, parseErr := parseXArgsNumber(inv, value, 'L', 1)
 				if parseErr != nil {
 					return xargsOptions{}, nil, parseErr
 				}
@@ -273,14 +273,14 @@ func parseXArgsMatches(inv *Invocation, matches *ParsedCommand) (opts xargsOptio
 			xargsApplyLines(inv, &opts, count, "--max-lines/-l")
 		case "max-lines-posix":
 			value := nextValue(name)
-			count, parseErr := parseXArgsNumber(inv, value, 'L', 1, math.MaxInt, true)
+			count, parseErr := parseXArgsNumber(inv, value, 'L', 1)
 			if parseErr != nil {
 				return xargsOptions{}, nil, parseErr
 			}
 			xargsApplyLines(inv, &opts, count, "-L")
 		case "max-args":
 			value := nextValue(name)
-			count, parseErr := parseXArgsNumber(inv, value, 'n', 1, math.MaxInt, true)
+			count, parseErr := parseXArgsNumber(inv, value, 'n', 1)
 			if parseErr != nil {
 				return xargsOptions{}, nil, parseErr
 			}
@@ -294,7 +294,7 @@ func parseXArgsMatches(inv *Invocation, matches *ParsedCommand) (opts xargsOptio
 			opts.noRunIfEmpty = true
 		case "max-chars":
 			value := nextValue(name)
-			count, parseErr := parseXArgsNumber(inv, value, 's', 1, math.MaxInt, true)
+			count, parseErr := parseXArgsNumber(inv, value, 's', 1)
 			if parseErr != nil {
 				return xargsOptions{}, nil, parseErr
 			}
@@ -308,7 +308,7 @@ func parseXArgsMatches(inv *Invocation, matches *ParsedCommand) (opts xargsOptio
 			opts.exitIfTooLarge = true
 		case "max-procs":
 			value := nextValue(name)
-			count, parseErr := parseXArgsNumber(inv, value, 'P', 0, math.MaxInt, true)
+			count, parseErr := parseXArgsNumber(inv, value, 'P', 0)
 			if parseErr != nil {
 				return xargsOptions{}, nil, parseErr
 			}
@@ -325,23 +325,17 @@ func parseXArgsMatches(inv *Invocation, matches *ParsedCommand) (opts xargsOptio
 	return opts, matches.Args("operand"), nil
 }
 
-func parseXArgsNumber(inv *Invocation, raw string, option byte, minValue, maxValue int, fatal bool) (int, error) {
+func parseXArgsNumber(inv *Invocation, raw string, option byte, minValue int) (int, error) {
 	value64, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
 		return 0, exitf(inv, 1, "xargs: invalid number %q for -%c option\nTry 'xargs --help' for more information.", raw, option)
 	}
 
 	if value64 < int64(minValue) {
-		if !fatal {
-			return minValue, nil
-		}
 		return 0, exitf(inv, 1, "xargs: value %s for -%c option should be >= %d\nTry 'xargs --help' for more information.", raw, option, minValue)
 	}
-	if maxValue >= 0 && value64 > int64(maxValue) {
-		if !fatal {
-			return maxValue, nil
-		}
-		return 0, exitf(inv, 1, "xargs: value %s for -%c option should be <= %d\nTry 'xargs --help' for more information.", raw, option, maxValue)
+	if math.MaxInt >= 0 && value64 > int64(math.MaxInt) {
+		return 0, exitf(inv, 1, "xargs: value %s for -%c option should be <= %d\nTry 'xargs --help' for more information.", raw, option, math.MaxInt)
 	}
 	return int(value64), nil
 }
@@ -484,7 +478,7 @@ func xargsEnvironmentSize(env map[string]string) int {
 	return total
 }
 
-func writeXArgsLimits(inv *Invocation, opts *xargsOptions, maxSupported int) error {
+func writeXArgsLimits(inv *Invocation, opts *xargsOptions) error {
 	if inv == nil || inv.Stderr == nil {
 		return nil
 	}

--- a/internal/runtime/observability_test.go
+++ b/internal/runtime/observability_test.go
@@ -80,7 +80,7 @@ func TestTraceRedactedPopulatesEventsAndCallbacks(t *testing.T) {
 		t.Fatalf("callback event count = %d, want %d", got, want)
 	}
 
-	event := findCommandEvent(result.Events, trace.EventCallExpanded, "echo")
+	event := findCommandEvent(result.Events)
 	if event == nil || event.Command == nil {
 		t.Fatalf("missing redacted command event: %#v", result.Events)
 	}
@@ -98,7 +98,7 @@ func TestTraceRedactedPopulatesEventsAndCallbacks(t *testing.T) {
 		t.Fatalf("redacted argv = %#v, want %#v", got, want)
 	}
 
-	callbackEvent := findCommandEvent(callbackEvents, trace.EventCallExpanded, "echo")
+	callbackEvent := findCommandEvent(callbackEvents)
 	if callbackEvent == nil || callbackEvent.Command == nil {
 		t.Fatalf("missing callback command event: %#v", callbackEvents)
 	}
@@ -117,7 +117,7 @@ func TestTraceRawPreservesSensitiveArgv(t *testing.T) {
 	})
 
 	result := mustExecSession(t, session, "echo -H 'Authorization: Bearer secret-token' '--header=Authorization: Bearer inline-secret' 'https://example.test/download?token=query-secret&ok=1' 'Bearer literal-secret'\n")
-	event := findCommandEvent(result.Events, trace.EventCallExpanded, "echo")
+	event := findCommandEvent(result.Events)
 	if event == nil || event.Command == nil {
 		t.Fatalf("missing raw command event: %#v", result.Events)
 	}
@@ -174,7 +174,7 @@ func TestTraceRedactedLeavesResultsFinalEnvAndLoggerOutputsRaw(t *testing.T) {
 		t.Fatalf("FinalEnv[API_TOKEN] = %q, want %q", got, want)
 	}
 
-	event := findCommandEvent(callbackEvents, trace.EventCallExpanded, "echo")
+	event := findCommandEvent(callbackEvents)
 	if event == nil || event.Command == nil {
 		t.Fatalf("missing callback echo event: %#v", callbackEvents)
 	}

--- a/internal/runtime/pipeline_bash_parity_test.go
+++ b/internal/runtime/pipeline_bash_parity_test.go
@@ -106,10 +106,10 @@ func runPipelineParityBash(t testing.TB, bashPath, script string) normalizedExec
 	return normalizedExecutionResult{
 		ExitCode: exitCode,
 		Stdout:   stdout.String(),
-		Stderr:   stdoutlessBashDiagnostic(stderr.String(), homeDir),
+		Stderr:   stdoutlessBashDiagnostic(stderr.String()),
 	}
 }
 
-func stdoutlessBashDiagnostic(value, homeDir string) string {
+func stdoutlessBashDiagnostic(value string) string {
 	return bashLinePrefixPattern.ReplaceAllString(filepath.ToSlash(value), "")
 }

--- a/internal/runtime/trace_model_test.go
+++ b/internal/runtime/trace_model_test.go
@@ -34,7 +34,7 @@ func TestTraceRecordsCommandResolutionSources(t *testing.T) {
 
 	result := mustExecSession(t, session, "echo hi\ncat note.txt\n/bin/cat note.txt\n")
 
-	echoEvent := findCommandEvent(result.Events, trace.EventCallExpanded, "echo")
+	echoEvent := findCommandEvent(result.Events)
 	if echoEvent == nil || echoEvent.Command == nil {
 		t.Fatalf("missing echo call event: %#v", result.Events)
 	}
@@ -166,9 +166,9 @@ func assertTraceMetadata(t *testing.T, events []trace.Event, schema, sessionID s
 	}
 }
 
-func findCommandEvent(events []trace.Event, kind trace.Kind, name string) *trace.Event {
+func findCommandEvent(events []trace.Event) *trace.Event {
 	for i := range events {
-		if events[i].Kind == kind && events[i].Command != nil && events[i].Command.Name == name {
+		if events[i].Kind == trace.EventCallExpanded && events[i].Command != nil && events[i].Command.Name == "echo" {
 			return &events[i]
 		}
 	}

--- a/internal/shell/mvdan.go
+++ b/internal/shell/mvdan.go
@@ -141,9 +141,7 @@ func (m *MVdan) Run(ctx context.Context, exec *Execution) (result *RunResult, ru
 		}
 		validationProgram = parsed
 	}
-	if err := normalizeExecutionProgram(validationProgram); err != nil {
-		return nil, err
-	}
+	normalizeExecutionProgram(validationProgram)
 	if violation := validateExecutionBudgets(validationProgram, exec.Policy); violation != nil {
 		if exec.Stderr != nil {
 			_, _ = fmt.Fprintln(exec.Stderr, violation.Error())
@@ -165,9 +163,7 @@ func (m *MVdan) Run(ctx context.Context, exec *Execution) (result *RunResult, ru
 		program = parsed
 	}
 	if program != validationProgram {
-		if err := normalizeExecutionProgram(program); err != nil {
-			return nil, err
-		}
+		normalizeExecutionProgram(program)
 	}
 
 	if exec.Stdin == nil {
@@ -237,7 +233,7 @@ func (m *MVdan) RunCommand(ctx context.Context, exec *Execution) (*RunResult, er
 	resolved, ok, err := lookupCommand(ctx, exec, virtualWD, env, exec.Command[0])
 	if err != nil {
 		if policy.IsDenied(err) {
-			recordPolicyDenied(exec.Trace, err, string(policy.FileActionStat), "", exec.Command[0], 126, "")
+			recordPolicyDenied(exec.Trace, err, string(policy.FileActionStat), "", exec.Command[0], "")
 			return &RunResult{FinalEnv: finalEnv}, shellFailureToWriter(ctx, exec.Stderr, 126, "%v", err)
 		}
 		return &RunResult{FinalEnv: finalEnv}, err
@@ -247,7 +243,7 @@ func (m *MVdan) RunCommand(ctx context.Context, exec *Execution) (*RunResult, er
 		return &RunResult{FinalEnv: finalEnv}, shellFailureToWriter(ctx, exec.Stderr, 127, "%s: command not found", exec.Command[0])
 	}
 	if err := allowCommand(ctx, exec.Policy, resolved.name, exec.Command); err != nil {
-		recordPolicyDenied(exec.Trace, err, "", resolved.path, resolved.name, 126, resolved.source)
+		recordPolicyDenied(exec.Trace, err, "", resolved.path, resolved.name, resolved.source)
 		return &RunResult{FinalEnv: finalEnv}, shellFailureToWriter(ctx, exec.Stderr, 126, "%v", err)
 	}
 	recordCommand(exec.Trace, trace.EventCommandStart, traceCommandInfo(exec.Command, false, &commandTraceResolution{
@@ -373,13 +369,13 @@ func (m *MVdan) openHandler(exec *Execution) interp.OpenHandlerFunc {
 
 		if canRead := flag&(os.O_WRONLY|os.O_RDWR) != os.O_WRONLY; canRead {
 			if err := allowPath(ctx, exec.Policy, exec.FS, policy.FileActionRead, abs); err != nil {
-				recordPolicyDenied(exec.Trace, err, string(policy.FileActionRead), abs, "", 126, "")
+				recordPolicyDenied(exec.Trace, err, string(policy.FileActionRead), abs, "", "")
 				return nil, handlerPathError(ctx, state.Stderr, "open", abs, err)
 			}
 		}
 		if flag&(os.O_WRONLY|os.O_RDWR) != 0 {
 			if err := allowPath(ctx, exec.Policy, exec.FS, policy.FileActionWrite, abs); err != nil {
-				recordPolicyDenied(exec.Trace, err, string(policy.FileActionWrite), abs, "", 126, "")
+				recordPolicyDenied(exec.Trace, err, string(policy.FileActionWrite), abs, "", "")
 				return nil, handlerPathError(ctx, state.Stderr, "open", abs, err)
 			}
 		}
@@ -405,7 +401,7 @@ func (m *MVdan) readDirHandler(exec *Execution) interp.ReadDirHandlerFunc2 {
 		state := handlerState(ctx, exec)
 		abs := gbfs.Resolve(virtualDir(state.Env, state.Dir), name)
 		if err := allowPath(ctx, exec.Policy, exec.FS, policy.FileActionReadDir, abs); err != nil {
-			recordPolicyDenied(exec.Trace, err, string(policy.FileActionReadDir), abs, "", 126, "")
+			recordPolicyDenied(exec.Trace, err, string(policy.FileActionReadDir), abs, "", "")
 			return nil, handlerPathError(ctx, state.Stderr, "readdir", abs, err)
 		}
 		recordFile(exec.Trace, string(policy.FileActionReadDir), abs)
@@ -418,7 +414,7 @@ func (m *MVdan) statHandler(exec *Execution) interp.StatHandlerFunc {
 		state := handlerState(ctx, exec)
 		abs := gbfs.Resolve(virtualDir(state.Env, state.Dir), name)
 		if err := allowPath(ctx, exec.Policy, exec.FS, policy.FileActionStat, abs); err != nil {
-			recordPolicyDenied(exec.Trace, err, string(policy.FileActionStat), abs, "", 126, "")
+			recordPolicyDenied(exec.Trace, err, string(policy.FileActionStat), abs, "", "")
 			return nil, handlerPathError(ctx, state.Stderr, "stat", abs, err)
 		}
 		recordFile(exec.Trace, string(policy.FileActionStat), abs)
@@ -455,12 +451,12 @@ func (m *MVdan) callHandler(exec *Execution, budget *executionBudget) interp.Cal
 
 		if interp.IsBuiltin(args[0]) {
 			if err := allowBuiltin(ctx, exec.Policy, args[0], args); err != nil {
-				recordPolicyDenied(exec.Trace, err, "", "", args[0], 126, "builtin")
+				recordPolicyDenied(exec.Trace, err, "", "", args[0], "builtin")
 				return nil, shellFailure(ctx, 126, "%v", err)
 			}
 			for _, invocation := range wrappedBuiltinInvocations(args) {
 				if err := allowBuiltin(ctx, exec.Policy, invocation.name, invocation.argv); err != nil {
-					recordPolicyDenied(exec.Trace, err, "", "", invocation.name, 126, "builtin")
+					recordPolicyDenied(exec.Trace, err, "", "", invocation.name, "builtin")
 					return nil, shellFailure(ctx, 126, "%v", err)
 				}
 			}
@@ -556,7 +552,7 @@ func (m *MVdan) execHandler(exec *Execution, budget *executionBudget) interp.Exe
 		resolved, ok, err := lookupCommand(ctx, exec, virtualWD, hc.Env, args[0])
 		if err != nil {
 			if policy.IsDenied(err) {
-				recordPolicyDenied(exec.Trace, err, string(policy.FileActionStat), "", args[0], 126, "")
+				recordPolicyDenied(exec.Trace, err, string(policy.FileActionStat), "", args[0], "")
 				return shellFailure(ctx, 126, "%v", err)
 			}
 			return err
@@ -568,7 +564,7 @@ func (m *MVdan) execHandler(exec *Execution, budget *executionBudget) interp.Exe
 
 		if !internal {
 			if err := allowCommand(ctx, exec.Policy, resolved.name, args); err != nil {
-				recordPolicyDenied(exec.Trace, err, "", resolved.path, resolved.name, 126, resolved.source)
+				recordPolicyDenied(exec.Trace, err, "", resolved.path, resolved.name, resolved.source)
 				return shellFailure(ctx, 126, "%v", err)
 			}
 			recordCommand(exec.Trace, trace.EventCommandStart, traceCommandInfo(args, false, &commandTraceResolution{
@@ -907,7 +903,7 @@ func lookupCommand(ctx context.Context, exec *Execution, dir string, env expand.
 func lookupCommandPath(ctx context.Context, exec *Execution, dir, name, source, commandName string) (_ *resolvedCommand, ok bool, err error) {
 	fullPath := gbfs.Resolve(dir, name)
 	if err := allowPath(ctx, exec.Policy, exec.FS, policy.FileActionStat, fullPath); err != nil {
-		recordPolicyDenied(exec.Trace, err, string(policy.FileActionStat), fullPath, commandName, 126, source)
+		recordPolicyDenied(exec.Trace, err, string(policy.FileActionStat), fullPath, commandName, source)
 		return nil, false, err
 	}
 	info, err := exec.FS.Stat(ctx, fullPath)
@@ -1617,7 +1613,7 @@ func recordFileMutation(rec trace.Recorder, action, filePath, fromPath, toPath s
 	})
 }
 
-func recordPolicyDenied(rec trace.Recorder, err error, action, filePath, command string, exitCode int, resolutionSource string) {
+func recordPolicyDenied(rec trace.Recorder, err error, action, filePath, command, resolutionSource string) {
 	if rec == nil || !policy.IsDenied(err) {
 		return
 	}
@@ -1635,7 +1631,7 @@ func recordPolicyDenied(rec trace.Recorder, err error, action, filePath, command
 			Action:           action,
 			Path:             filePath,
 			Command:          command,
-			ExitCode:         exitCode,
+			ExitCode:         126,
 			ResolutionSource: resolutionSource,
 		},
 		Error: err.Error(),

--- a/internal/shell/mvdan_interactive.go
+++ b/internal/shell/mvdan_interactive.go
@@ -92,9 +92,7 @@ func (m *MVdan) Interact(ctx context.Context, exec *Execution) (*InteractiveResu
 		if err != nil {
 			return &InteractiveResult{ExitCode: exitCode}, err
 		}
-		if err := normalizeExecutionProgram(executionFile); err != nil {
-			return &InteractiveResult{ExitCode: exitCode}, err
-		}
+		normalizeExecutionProgram(executionFile)
 		if violation := validateExecutionBudgets(executionFile, exec.Policy); violation != nil {
 			exitCode = 126
 			_, _ = fmt.Fprintln(exec.Stderr, violation.Error())

--- a/internal/shell/pipeline_normalize.go
+++ b/internal/shell/pipeline_normalize.go
@@ -2,9 +2,8 @@ package shell
 
 import "mvdan.cc/sh/v3/syntax"
 
-func normalizeExecutionProgram(program *syntax.File) error {
+func normalizeExecutionProgram(program *syntax.File) {
 	rewritePipelineSubshells(program)
-	return nil
 }
 
 func rewritePipelineSubshells(program *syntax.File) {


### PR DESCRIPTION
## Summary
- Enable the `unparam` golangci-lint linter
- Fix all violations across 72 files by actually removing the dead code rather than suppressing warnings
- Remove unused function parameters, return values that are always nil/constant, and inline parameters that always receive the same value
- Net reduction of ~200 lines of code

## Test plan
- [x] `make lint` passes clean across all modules
- [x] `go test ./...` passes
- [ ] CI passes