### PR TITLE
ci: drop redundant gofmt formatter in favor of goimports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ version: "2"
 
 formatters:
   enable:
-    - gofmt
     - goimports
 linters:
   enable:


### PR DESCRIPTION
## Summary
- Remove `gofmt` from the golangci-lint formatters list since `goimports` is already enabled and is a superset of `gofmt`

## Test plan
- [ ] Verify golangci-lint still runs successfully with only `goimports` enabled