### PR TITLE
find: normalize root-relative output paths

### DIFF
--- a/internal/builtins/find.go
+++ b/internal/builtins/find.go
@@ -385,7 +385,8 @@ func walkDisplayPath(rootArg, rootAbs, currentAbs string) string {
 		return rootArg
 	}
 
-	rel := strings.TrimPrefix(currentAbs, rootAbs+"/")
+	rel := strings.TrimPrefix(currentAbs, rootAbs)
+	rel = strings.TrimPrefix(rel, "/")
 	if strings.HasPrefix(rootArg, "/") {
 		return currentAbs
 	}

--- a/internal/builtins/find_test.go
+++ b/internal/builtins/find_test.go
@@ -217,3 +217,18 @@ func TestFindSupportsExecPrint0PrintfAndDelete(t *testing.T) {
 		t.Fatalf("delete output = %q, want %q", got, want)
 	}
 }
+
+func TestFindFromRootKeepsRelativePathsNormalized(t *testing.T) {
+	t.Parallel()
+	session := newSession(t, &Config{})
+
+	writeSessionFile(t, session, "/pkg/testdata/fuzz/FuzzFoo/corpus1", []byte("data"))
+
+	result := mustExecSession(t, session, "cd /\nfind . -type f -path '*/testdata/fuzz/Fuzz*/*'\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := strings.TrimSpace(result.Stdout), "./pkg/testdata/fuzz/FuzzFoo/corpus1"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- normalize `find` relative output when the sandbox cwd is `/`
- add a regression test for `cd /; find . ...` path formatting

## Testing
- go test ./internal/builtins -run 'TestFind'
- go test ./internal/builtins
- make lint

Closes #299