### PR TITLE
shell: synchronize proc-sub hidden flag under entry mutex

### DIFF
--- a/internal/shell/proc_subst.go
+++ b/internal/shell/proc_subst.go
@@ -184,13 +184,18 @@ func (m *procSubstManager) entry(name string, includeHidden bool) (*procSubstEnt
 	}
 	abs := gbfs.Clean(name)
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	entry, ok := m.entries[abs]
+	m.mu.Unlock()
 	if !ok {
 		return nil, false
 	}
-	if !includeHidden && entry.hidden {
-		return nil, false
+	if !includeHidden {
+		entry.mu.Lock()
+		hidden := entry.hidden
+		entry.mu.Unlock()
+		if hidden {
+			return nil, false
+		}
 	}
 	return entry, true
 }


### PR DESCRIPTION
## Summary
- `procSubstManager.entry` read `entry.hidden` while holding `m.mu` (manager mutex), but `procSubstEntry.open` wrote `hidden` while holding `e.mu` (entry mutex), creating a data race on concurrent access to the same endpoint
- Fixed by reading `entry.hidden` under `e.mu` in the `entry` method to match the write path in `open`

## Test plan
- [ ] Run `go test -race ./internal/shell/...` to verify no data races
- [ ] Verify concurrent proc-sub access (e.g. `cat "$p"` racing with `[ -p "$p" ]`) works correctly