### PR TITLE
conformance: fix special builtin arg parsing

### DIFF
--- a/internal/conformance/manifest.json
+++ b/internal/conformance/manifest.json
@@ -10,10 +10,6 @@
           "mode": "xfail",
           "reason": "known gbash divergence from bash semantics in this upstream spec file"
         },
-        "oils/arg-parse.test.sh": {
-          "mode": "xfail",
-          "reason": "known gbash divergence from bash semantics in this upstream spec file"
-        },
         "oils/arith-context.test.sh": {
           "mode": "xfail",
           "reason": "known gbash divergence from bash semantics in this upstream spec file"

--- a/third_party/mvdan-sh/interp/builtin.go
+++ b/third_party/mvdan-sh/interp/builtin.go
@@ -180,13 +180,17 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 		switch len(args) {
 		case 0:
 		case 1:
-			if n2, err := strconv.Atoi(args[0]); err == nil {
-				n = n2
-				break
+			n2, err := strconv.Atoi(args[0])
+			if err != nil {
+				exit = failf(2, "shift: %s: numeric argument required\n", args[0])
+				exit.exiting = true
+				return exit
 			}
-			fallthrough
+			n = n2
 		default:
-			return failf(2, "usage: shift [n]\n")
+			exit = failf(1, "shift: too many arguments\n")
+			exit.exiting = true
+			return exit
 		}
 		if n >= len(r.Params) {
 			r.Params = nil
@@ -271,13 +275,17 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 		case 0:
 			*enclosing = 1
 		case 1:
-			if n, err := strconv.Atoi(args[0]); err == nil {
-				*enclosing = n
-				break
+			n, err := strconv.Atoi(args[0])
+			if err != nil {
+				exit = failf(2, "%s: %s: numeric argument required\n", name, args[0])
+				exit.exiting = true
+				return exit
 			}
-			fallthrough
+			*enclosing = n
 		default:
-			return failf(2, "usage: %s [n]\n", name)
+			exit = failf(1, "%s: too many arguments\n", name)
+			exit.exiting = true
+			return exit
 		}
 	case "pwd":
 		evalSymlinks := false

--- a/third_party/mvdan-sh/interp/interp_test.go
+++ b/third_party/mvdan-sh/interp/interp_test.go
@@ -250,18 +250,30 @@ var runTests = []runTest{
 	{"break", "break is only useful in a loop\n #JUSTERR"},
 	{"continue", "continue is only useful in a loop\n #JUSTERR"},
 	{"cd a b", "usage: cd [dir]\nexit status 2 #JUSTERR"},
-	{"shift a", "usage: shift [n]\nexit status 2 #JUSTERR"},
+	{"shift a", "shift: a: numeric argument required\nexit status 2 #JUSTERR"},
 	{
 		"shouldnotexist",
 		"\"shouldnotexist\": executable file not found in $PATH\nexit status 127 #JUSTERR",
 	},
 	{
 		"for i in 1; do continue a; done",
-		"usage: continue [n]\nexit status 2 #JUSTERR",
+		"continue: a: numeric argument required\nexit status 2 #JUSTERR",
 	},
 	{
 		"for i in 1; do break a; done",
-		"usage: break [n]\nexit status 2 #JUSTERR",
+		"break: a: numeric argument required\nexit status 2 #JUSTERR",
+	},
+	{
+		"set -- a b c; shift 1 extra; echo no",
+		"shift: too many arguments\nexit status 1 #JUSTERR",
+	},
+	{
+		"for i in 1; do continue 1 extra; done; echo no",
+		"continue: too many arguments\nexit status 1 #JUSTERR",
+	},
+	{
+		"for i in 1; do break 1 extra; done; echo no",
+		"break: too many arguments\nexit status 1 #JUSTERR",
 	},
 	{"false; a=b", ""},
 	{"false; false &", ""},


### PR DESCRIPTION
## Summary
- match bash argument parsing for `shift`, `break`, and `continue`, including `numeric argument required`, `too many arguments`, and noninteractive shell termination on those parse errors
- add interpreter regression coverage for both one-argument and extra-argument failure paths
- remove the `oils/arg-parse.test.sh` xfail after the file now matches bash

## Verification
- `go test ./third_party/mvdan-sh/interp`
- `GBASH_RUN_CONFORMANCE=1 go test ./internal/conformance -run 'TestConformance/bash/oils/arg-parse.test.sh' -count=1 -timeout=5m -v`
- `make lint`