### PR TITLE
conformance: fix classic test parsing ambiguities

### DIFF
--- a/internal/builtins/test.go
+++ b/internal/builtins/test.go
@@ -85,262 +85,226 @@ type testSymbol struct {
 	token string
 }
 
-func newTestSymbol(token *string) testSymbol {
-	if token == nil {
-		return testSymbol{kind: testSymbolNone}
-	}
-	switch *token {
-	case "(":
-		return testSymbol{kind: testSymbolLParen, token: *token}
-	case "!":
-		return testSymbol{kind: testSymbolBang, token: *token}
-	case "-a", "-o":
-		return testSymbol{kind: testSymbolBoolOp, token: *token}
-	case "=", "==", "!=", "<", ">":
-		return testSymbol{kind: testSymbolStringOp, token: *token}
-	case "-eq", "-ge", "-gt", "-le", "-lt", "-ne":
-		return testSymbol{kind: testSymbolIntOp, token: *token}
-	case "-ef", "-nt", "-ot":
-		return testSymbol{kind: testSymbolFileOp, token: *token}
-	case "-n", "-z":
-		return testSymbol{kind: testSymbolUnaryStr, token: *token}
-	case "-b", "-c", "-d", "-e", "-f", "-g", "-G", "-h", "-k", "-L", "-N", "-O", "-p", "-r", "-s", "-S", "-t", "-u", "-w", "-x":
-		return testSymbol{kind: testSymbolUnaryFile, token: *token}
-	default:
-		return testSymbol{kind: testSymbolLiteral, token: *token}
-	}
-}
-
-func (s testSymbol) intoLiteral() testSymbol {
-	if s.kind == testSymbolNone {
-		panic("none cannot be literal")
-	}
-	switch s.kind {
-	case testSymbolLParen:
-		return testSymbol{kind: testSymbolLiteral, token: "("}
-	case testSymbolBang:
-		return testSymbol{kind: testSymbolLiteral, token: "!"}
-	default:
-		return testSymbol{kind: testSymbolLiteral, token: s.token}
-	}
-}
-
-type testParser struct {
-	tokens []string
-	pos    int
-	stack  []testSymbol
-}
-
 func parseTest(args []string) ([]testSymbol, error) {
-	p := &testParser{tokens: append([]string(nil), args...)}
-	if err := p.parse(); err != nil {
+	p := &testRPNParser{args: append([]string(nil), args...)}
+	return p.parseArgs(p.args)
+}
+
+type testRPNParser struct {
+	args []string
+}
+
+func (p *testRPNParser) parseArgs(args []string) ([]testSymbol, error) {
+	switch len(args) {
+	case 0:
+		return nil, nil
+	case 1:
+		return []testSymbol{testLiteralSymbol(args[0])}, nil
+	case 2:
+		return p.parseTwoArgs(args)
+	case 3:
+		return p.parseThreeArgs(args)
+	case 4:
+		switch {
+		case args[0] == "!":
+			stack, err := p.parseArgs(args[1:])
+			if err != nil {
+				return nil, err
+			}
+			return append(stack, testSymbol{kind: testSymbolBang, token: "!"}), nil
+		case args[0] == "(" && args[3] == ")":
+			return p.parseArgs(args[1:3])
+		}
+	}
+	stack, pos, err := p.parseOr(args, 0)
+	if err != nil {
 		return nil, err
 	}
-	return p.stack, nil
-}
-
-func (p *testParser) parse() error {
-	if err := p.expr(); err != nil {
-		return err
+	if pos != len(args) {
+		return nil, testParseExtraArgument(args[pos])
 	}
-	if p.pos < len(p.tokens) {
-		return testParseExtraArgument(p.tokens[p.pos])
-	}
-	return nil
+	return stack, nil
 }
 
-func (p *testParser) nextToken() testSymbol {
-	if p.pos >= len(p.tokens) {
-		return testSymbol{kind: testSymbolNone}
-	}
-	token := p.tokens[p.pos]
-	p.pos++
-	return newTestSymbol(&token)
-}
-
-func (p *testParser) peek() testSymbol {
-	if p.pos >= len(p.tokens) {
-		return testSymbol{kind: testSymbolNone}
-	}
-	token := p.tokens[p.pos]
-	return newTestSymbol(&token)
-}
-
-func (p *testParser) peekN(n int) testSymbol {
-	idx := p.pos + n
-	if idx >= len(p.tokens) {
-		return testSymbol{kind: testSymbolNone}
-	}
-	token := p.tokens[idx]
-	return newTestSymbol(&token)
-}
-
-func (p *testParser) peekIsBoolOp() bool {
-	return p.peek().kind == testSymbolBoolOp
-}
-
-func (p *testParser) expect() error {
-	symbol := p.nextToken()
-	if symbol.kind == testSymbolLiteral && symbol.token == ")" {
-		return nil
-	}
-	return testParseExpected(")")
-}
-
-func (p *testParser) expr() error {
-	if !p.peekIsBoolOp() {
-		if err := p.term(); err != nil {
-			return err
-		}
-	}
-	return p.maybeBoolOp()
-}
-
-func (p *testParser) term() error {
-	symbol := p.nextToken()
-	switch symbol.kind {
-	case testSymbolLParen:
-		return p.lparen()
-	case testSymbolBang:
-		return p.bang()
-	case testSymbolUnaryStr, testSymbolUnaryFile:
-		isStringCmp := p.peek().kind == testSymbolStringOp && p.peekN(1).kind != testSymbolNone
-		if isStringCmp {
-			return p.literal(symbol.intoLiteral())
-		}
-		p.uop(symbol)
-		return nil
-	case testSymbolNone:
-		p.stack = append(p.stack, symbol)
-		return nil
-	default:
-		return p.literal(symbol)
-	}
-}
-
-func (p *testParser) lparen() error {
-	peek3 := []testSymbol{p.peekN(0), p.peekN(1), p.peekN(2)}
+func (p *testRPNParser) parseTwoArgs(args []string) ([]testSymbol, error) {
 	switch {
-	case peek3[0].kind == testSymbolNone:
-		return p.literal(testSymbol{kind: testSymbolLParen}.intoLiteral())
-	case peek3[1].kind == testSymbolNone:
-		return testParseMissingArgument(peek3[0].display())
-	case (peek3[0].kind == testSymbolUnaryStr || peek3[0].kind == testSymbolUnaryFile) && peek3[2].kind == testSymbolLiteral && peek3[2].token == ")":
-		symbol := p.nextToken()
-		p.uop(symbol)
-		return p.expect()
-	case peek3[0].isBinaryOp() && peek3[1].kind == testSymbolLiteral && peek3[1].token == ")":
-		return p.literal(testSymbol{kind: testSymbolLParen}.intoLiteral())
-	case peek3[1].kind == testSymbolLiteral && peek3[1].token == ")":
-		symbol := p.nextToken()
-		if err := p.literal(symbol); err != nil {
-			return err
-		}
-		return p.expect()
-	case peek3[0].isBinaryOp() && peek3[1].isBinaryOp():
-		symbol := p.nextToken()
-		if err := p.literal(symbol); err != nil {
-			return err
-		}
-		return p.expect()
-	case peek3[0].isBinaryOp():
-		return p.literal(testSymbol{kind: testSymbolLParen}.intoLiteral())
+	case args[0] == "!":
+		return []testSymbol{
+			testLiteralSymbol(args[1]),
+			{kind: testSymbolBang, token: "!"},
+		}, nil
+	case isTestUnaryOp(args[0]):
+		return []testSymbol{
+			testLiteralSymbol(args[1]),
+			testUnarySymbol(args[0]),
+		}, nil
+	case args[1] == "-a" || args[1] == "-o":
+		return nil, testParseMissingExpression(args[1])
+	case isTestExprBinaryOp(args[1]):
+		return nil, testParseMissingArgument(quoteGNUOperand(args[1]))
 	default:
-		if err := p.expr(); err != nil {
-			return err
-		}
-		return p.expect()
+		return nil, testParseUnaryOperatorExpected(quoteGNUOperand(args[0]))
 	}
 }
 
-func (p *testParser) bang() error {
-	switch p.peek().kind {
-	case testSymbolStringOp, testSymbolIntOp, testSymbolFileOp, testSymbolBoolOp:
-		peek2 := p.peekN(1)
-		if peek2.isBinaryOp() || peek2.kind == testSymbolNone {
-			op := p.nextToken().intoLiteral()
-			if err := p.literal(op); err != nil {
-				return err
-			}
-			p.stack = append(p.stack, testSymbol{kind: testSymbolBang, token: "!"})
-			return nil
+func (p *testRPNParser) parseThreeArgs(args []string) ([]testSymbol, error) {
+	if op, ok := testBinarySymbol(args[1], true); ok {
+		return []testSymbol{
+			testLiteralSymbol(args[0]),
+			testLiteralSymbol(args[2]),
+			op,
+		}, nil
+	}
+	switch {
+	case args[0] == "!":
+		stack, err := p.parseArgs(args[1:])
+		if err != nil {
+			return nil, err
 		}
-		if err := p.literal(testSymbol{kind: testSymbolBang}.intoLiteral()); err != nil {
-			return err
-		}
-		return p.maybeBoolOp()
-	case testSymbolNone:
-		p.stack = append(p.stack, testSymbol{kind: testSymbolLiteral, token: "!"})
-		return nil
+		return append(stack, testSymbol{kind: testSymbolBang, token: "!"}), nil
+	case args[0] == "(" && args[2] == ")":
+		return []testSymbol{testLiteralSymbol(args[1])}, nil
 	default:
-		peek4 := []testSymbol{p.peekN(0), p.peekN(1), p.peekN(2), p.peekN(3)}
-		if peek4[0].kind == testSymbolLiteral && peek4[1].kind == testSymbolBoolOp && peek4[2].kind == testSymbolLiteral && peek4[3].kind == testSymbolNone {
-			if err := p.expr(); err != nil {
-				return err
-			}
-			p.stack = append(p.stack, testSymbol{kind: testSymbolBang, token: "!"})
-			return nil
-		}
-		if err := p.term(); err != nil {
-			return err
-		}
-		p.stack = append(p.stack, testSymbol{kind: testSymbolBang, token: "!"})
-		return nil
+		return nil, testParseBinaryOperatorExpected(quoteGNUOperand(args[1]))
 	}
 }
 
-func (p *testParser) maybeBoolOp() error {
-	if !p.peekIsBoolOp() {
-		return nil
+func (p *testRPNParser) parseOr(args []string, pos int) ([]testSymbol, int, error) {
+	stack, pos, err := p.parseAnd(args, pos)
+	if err != nil {
+		return nil, pos, err
 	}
-	symbol := p.nextToken()
-	if p.peek().kind == testSymbolNone {
-		if err := p.literal(symbol.intoLiteral()); err != nil {
-			return err
+	for pos < len(args) && args[pos] == "-o" {
+		if pos+1 >= len(args) {
+			return nil, pos, testParseExpectedValue()
 		}
-		return nil
+		right, next, err := p.parseAnd(args, pos+1)
+		if err != nil {
+			return nil, pos, err
+		}
+		stack = append(stack, right...)
+		stack = append(stack, testSymbol{kind: testSymbolBoolOp, token: "-o"})
+		pos = next
 	}
-	if err := p.boolOp(symbol); err != nil {
-		return err
-	}
-	return p.maybeBoolOp()
+	return stack, pos, nil
 }
 
-func (p *testParser) boolOp(op testSymbol) error {
-	if op.token == "-a" {
-		if err := p.term(); err != nil {
-			return err
-		}
-	} else {
-		if err := p.expr(); err != nil {
-			return err
-		}
+func (p *testRPNParser) parseAnd(args []string, pos int) ([]testSymbol, int, error) {
+	stack, pos, err := p.parseNot(args, pos)
+	if err != nil {
+		return nil, pos, err
 	}
-	p.stack = append(p.stack, op)
-	return nil
+	for pos < len(args) && args[pos] == "-a" {
+		if pos+1 >= len(args) {
+			return nil, pos, testParseExpectedValue()
+		}
+		right, next, err := p.parseNot(args, pos+1)
+		if err != nil {
+			return nil, pos, err
+		}
+		stack = append(stack, right...)
+		stack = append(stack, testSymbol{kind: testSymbolBoolOp, token: "-a"})
+		pos = next
+	}
+	return stack, pos, nil
 }
 
-func (p *testParser) uop(op testSymbol) {
-	symbol := p.nextToken()
-	if symbol.kind == testSymbolNone {
-		p.stack = append(p.stack, op.intoLiteral())
-		return
+func (p *testRPNParser) parseNot(args []string, pos int) ([]testSymbol, int, error) {
+	if pos >= len(args) {
+		return nil, pos, testParseExpectedValue()
 	}
-	p.stack = append(p.stack, symbol.intoLiteral(), op)
+	if args[pos] == "!" {
+		stack, next, err := p.parseNot(args, pos+1)
+		if err != nil {
+			return nil, pos, err
+		}
+		return append(stack, testSymbol{kind: testSymbolBang, token: "!"}), next, nil
+	}
+	return p.parsePrimary(args, pos)
 }
 
-func (p *testParser) literal(token testSymbol) error {
-	p.stack = append(p.stack, token.intoLiteral())
-	if !p.peek().isBinaryOp() {
-		return nil
+func (p *testRPNParser) parsePrimary(args []string, pos int) ([]testSymbol, int, error) {
+	if pos >= len(args) {
+		return nil, pos, testParseExpectedValue()
 	}
-	op := p.nextToken()
-	value := p.nextToken()
-	if value.kind == testSymbolNone {
-		return testParseMissingArgument(op.display())
+	if args[pos] == "(" {
+		stack, next, err := p.parseOr(args, pos+1)
+		if err != nil {
+			return nil, pos, err
+		}
+		if next >= len(args) || args[next] != ")" {
+			return nil, pos, testParseExpected(")")
+		}
+		return stack, next + 1, nil
 	}
-	p.stack = append(p.stack, value.intoLiteral(), op)
-	return nil
+	if pos+2 < len(args) && isTestExprBinaryOp(args[pos+1]) {
+		op, _ := testBinarySymbol(args[pos+1], false)
+		return []testSymbol{
+			testLiteralSymbol(args[pos]),
+			testLiteralSymbol(args[pos+2]),
+			op,
+		}, pos + 3, nil
+	}
+	if isTestUnaryOp(args[pos]) && pos+1 < len(args) {
+		return []testSymbol{
+			testLiteralSymbol(args[pos+1]),
+			testUnarySymbol(args[pos]),
+		}, pos + 2, nil
+	}
+	return []testSymbol{testLiteralSymbol(args[pos])}, pos + 1, nil
+}
+
+func testLiteralSymbol(token string) testSymbol {
+	return testSymbol{kind: testSymbolLiteral, token: token}
+}
+
+func isTestUnaryOp(token string) bool {
+	switch token {
+	case "-n", "-z",
+		"-a",
+		"-b", "-c", "-d", "-e", "-f", "-g", "-G", "-h", "-k", "-L", "-N", "-O", "-p", "-r", "-s", "-S", "-t", "-u", "-w", "-x":
+		return true
+	default:
+		return false
+	}
+}
+
+func testUnarySymbol(token string) testSymbol {
+	switch token {
+	case "-n", "-z":
+		return testSymbol{kind: testSymbolUnaryStr, token: token}
+	default:
+		return testSymbol{kind: testSymbolUnaryFile, token: token}
+	}
+}
+
+func isTestExprBinaryOp(token string) bool {
+	switch token {
+	case "=", "==", "!=", "<", ">",
+		"-eq", "-ge", "-gt", "-le", "-lt", "-ne",
+		"-ef", "-nt", "-ot":
+		return true
+	default:
+		return false
+	}
+}
+
+func testBinarySymbol(token string, allowBool bool) (testSymbol, bool) {
+	switch token {
+	case "-a", "-o":
+		if !allowBool {
+			return testSymbol{}, false
+		}
+		return testSymbol{kind: testSymbolBoolOp, token: token}, true
+	case "=", "==", "!=", "<", ">":
+		return testSymbol{kind: testSymbolStringOp, token: token}, true
+	case "-eq", "-ge", "-gt", "-le", "-lt", "-ne":
+		return testSymbol{kind: testSymbolIntOp, token: token}, true
+	case "-ef", "-nt", "-ot":
+		return testSymbol{kind: testSymbolFileOp, token: token}, true
+	default:
+		return testSymbol{}, false
+	}
 }
 
 func evalTest(ctx context.Context, inv *Invocation, stack []testSymbol) (bool, error) {
@@ -461,10 +425,6 @@ func testPopLiteral(stack *[]testSymbol) (string, error) {
 		return "", testParseExpectedValue()
 	}
 	return symbol.token, nil
-}
-
-func (s testSymbol) isBinaryOp() bool {
-	return s.kind == testSymbolStringOp || s.kind == testSymbolIntOp || s.kind == testSymbolFileOp
 }
 
 func (s testSymbol) display() string {
@@ -845,12 +805,20 @@ func testParseMissingArgument(argument string) error {
 	return testParseError{message: fmt.Sprintf("missing argument after %s", argument)}
 }
 
+func testParseMissingExpression(argument string) error {
+	return testParseError{message: fmt.Sprintf("%s must be followed by an expression", quoteGNUOperand(argument))}
+}
+
 func testParseUnknownOperator(operator string) error {
 	return testParseError{message: fmt.Sprintf("unknown operator %s", quoteGNUOperand(operator))}
 }
 
 func testParseInvalidInteger(value string) error {
 	return testParseError{message: fmt.Sprintf("invalid integer %s", quoteGNUOperand(value))}
+}
+
+func testParseBinaryOperatorExpected(operator string) error {
+	return testParseError{message: fmt.Sprintf("%s: binary operator expected", operator)}
 }
 
 func testParseUnaryOperatorExpected(operator string) error {

--- a/internal/builtins/test_test.go
+++ b/internal/builtins/test_test.go
@@ -91,3 +91,23 @@ func TestTestReportsParseErrorsAndBracketMismatch(t *testing.T) {
 		t.Fatalf("Stderr = %q, want missing-closing-bracket error", result.Stderr)
 	}
 }
+
+func TestTestMatchesBashAmbiguousClassicForms(t *testing.T) {
+	t.Parallel()
+	session := newSession(t, &Config{})
+
+	result := mustExecSession(t, session,
+		"[ -a -a -a ] && echo triple\n"+
+			"[ -a -a -a -a -a ] || echo quint\n"+
+			"test 0 -eq 0 -a '(' = ')' && echo paren_eq\n"+
+			"set -- -o; test $# -ne 0 -a \"$1\" != \"--\" && echo trailing_word\n"+
+			"[ -f = ] || echo file_eq\n"+
+			"[ -f == ] || echo file_eqeq\n",
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "triple\nquint\nparen_eq\ntrailing_word\nfile_eq\nfile_eqeq\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/conformance/manifest.json
+++ b/internal/conformance/manifest.json
@@ -90,13 +90,9 @@
           "mode": "xfail",
           "reason": "known gbash divergence from bash semantics in this upstream spec file"
         },
-        "oils/blog2.test.sh": {
+        "oils/bool-parse.test.sh::Not allowed: [[ ) ]] and [[ ( ]]": {
           "mode": "xfail",
-          "reason": "known gbash divergence from bash semantics in this upstream spec file"
-        },
-        "oils/bool-parse.test.sh": {
-          "mode": "xfail",
-          "reason": "known gbash divergence from bash semantics in this upstream spec file"
+          "reason": "the [[ parser still reports a generic missing-expression syntax error instead of bash's token-specific conditional parse diagnostics for lone ) and ("
         },
         "oils/brace-expansion.test.sh": {
           "mode": "xfail",

--- a/third_party/mvdan-sh/interp/builtin.go
+++ b/third_party/mvdan-sh/interp/builtin.go
@@ -526,14 +526,13 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 	case "test":
 		parseErr := false
 		p := testParser{
-			rem: args,
+			args: args,
 			err: func(err error) {
 				r.errf("%v: %v\n", pos, err)
 				parseErr = true
 			},
 		}
-		p.next()
-		expr := p.classicTest("[", false)
+		expr := p.classicTest()
 		if parseErr {
 			exit.code = 2
 			return exit

--- a/third_party/mvdan-sh/interp/interp_test.go
+++ b/third_party/mvdan-sh/interp/interp_test.go
@@ -1701,6 +1701,22 @@ var runTests = []runTest{
 		"",
 	},
 	{
+		"[ -a -a -a ]; echo $?",
+		"0\n",
+	},
+	{
+		"[ -a -a -a -a -a ]; echo $?",
+		"1\n",
+	},
+	{
+		"test 0 -eq 0 -a '(' = ')'; echo $?",
+		"0\n",
+	},
+	{
+		"set -- -o; test $# -ne 0 -a \"$1\" != \"--\"; echo $?",
+		"0\n",
+	},
+	{
 		"[[ a -ef b ]]",
 		"exit status 1",
 	},

--- a/third_party/mvdan-sh/interp/test_classic.go
+++ b/third_party/mvdan-sh/interp/test_classic.go
@@ -12,104 +12,189 @@ import (
 const illegalTok = 0
 
 type testParser struct {
-	eof bool
-	val string
-	rem []string
-
-	err func(err error)
+	args []string
+	err  func(err error)
 }
 
 func (p *testParser) errf(format string, a ...any) {
 	p.err(fmt.Errorf(format, a...))
 }
 
-func (p *testParser) next() {
-	if p.eof || len(p.rem) == 0 {
-		p.eof = true
-		p.val = ""
-		return
-	}
-	p.val = p.rem[0]
-	p.rem = p.rem[1:]
-}
-
-func (p *testParser) followWord(fval string) *syntax.Word {
-	if p.eof {
-		p.errf("%s must be followed by a word", fval)
-	}
-	w := &syntax.Word{Parts: []syntax.WordPart{
-		&syntax.Lit{Value: p.val},
+func testWord(val string) *syntax.Word {
+	return &syntax.Word{Parts: []syntax.WordPart{
+		&syntax.Lit{Value: val},
 	}}
-	p.next()
-	return w
 }
 
-func (p *testParser) classicTest(fval string, pastAndOr bool) syntax.TestExpr {
-	var left syntax.TestExpr
-	if pastAndOr {
-		left = p.testExprBase(fval)
-	} else {
-		left = p.classicTest(fval, true)
-	}
-	if left == nil || p.eof || p.val == ")" {
-		return left
-	}
-	opStr := p.val
-	op := testBinaryOp(p.val)
-	if op == illegalTok {
-		p.errf("not a valid test operator: %#q", p.val)
-	}
-	b := &syntax.BinaryTest{
-		Op: op,
-		X:  left,
-	}
-	p.next()
-	switch b.Op {
-	case syntax.AndTest, syntax.OrTest:
-		if b.Y = p.classicTest(opStr, false); b.Y == nil {
-			p.errf("%s must be followed by an expression", opStr)
-		}
-	default:
-		b.Y = p.followWord(opStr)
-	}
-	return b
-}
-
-func (p *testParser) testExprBase(fval string) syntax.TestExpr {
-	if p.eof || p.val == ")" {
+func (p *testParser) classicTest() syntax.TestExpr {
+	expr, err := p.parseArgs(p.args)
+	if err != nil {
+		p.err(err)
 		return nil
 	}
-	op := testUnaryOp(p.val)
-	switch op {
-	case syntax.TsNot:
-		u := &syntax.UnaryTest{Op: op}
-		p.next()
-		u.X = p.classicTest(op.String(), false)
-		return u
-	case syntax.TsParen:
-		pe := &syntax.ParenTest{}
-		p.next()
-		pe.X = p.classicTest(op.String(), false)
-		if p.val != ")" {
-			p.errf("reached %s without matching '(' with ')'", p.val)
+	return expr
+}
+
+func (p *testParser) parseArgs(args []string) (syntax.TestExpr, error) {
+	switch len(args) {
+	case 0:
+		return nil, nil
+	case 1:
+		return testWord(args[0]), nil
+	case 2:
+		return p.parseTwoArgs(args)
+	case 3:
+		return p.parseThreeArgs(args)
+	case 4:
+		switch {
+		case args[0] == "!":
+			expr, err := p.parseArgs(args[1:])
+			if err != nil {
+				return nil, err
+			}
+			return &syntax.UnaryTest{Op: syntax.TsNot, X: expr}, nil
+		case args[0] == "(" && args[3] == ")":
+			expr, err := p.parseArgs(args[1:3])
+			if err != nil {
+				return nil, err
+			}
+			return &syntax.ParenTest{X: expr}, nil
 		}
-		p.next()
-		return pe
-	case illegalTok:
-		return p.followWord(fval)
-	default:
-		u := &syntax.UnaryTest{Op: op}
-		p.next()
-		if p.eof {
-			// make [ -e ] fall back to [ -n -e ], i.e. use
-			// the operator as an argument
-			return &syntax.Word{Parts: []syntax.WordPart{
-				&syntax.Lit{Value: op.String()},
-			}}
-		}
-		u.X = p.followWord(op.String())
-		return u
 	}
+	expr, pos, err := p.parseOr(args, 0)
+	if err != nil {
+		return nil, err
+	}
+	if pos != len(args) {
+		return nil, fmt.Errorf("extra argument %q", args[pos])
+	}
+	return expr, nil
+}
+
+func (p *testParser) parseTwoArgs(args []string) (syntax.TestExpr, error) {
+	switch {
+	case args[1] == "-a" || args[1] == "-o":
+		return nil, fmt.Errorf("%s must be followed by an expression", args[1])
+	case testExprBinaryOp(args[1]) != illegalTok:
+		return nil, fmt.Errorf("%s must be followed by a word", args[1])
+	case args[0] == "!":
+		return &syntax.UnaryTest{Op: syntax.TsNot, X: testWord(args[1])}, nil
+	case isClassicUnaryOp(args[0]):
+		return &syntax.UnaryTest{Op: testUnaryOp(args[0]), X: testWord(args[1])}, nil
+	default:
+		return nil, fmt.Errorf("%s: unary operator expected", args[0])
+	}
+}
+
+func (p *testParser) parseThreeArgs(args []string) (syntax.TestExpr, error) {
+	if op := testBinaryOp(args[1]); op != illegalTok {
+		return &syntax.BinaryTest{
+			Op: op,
+			X:  testWord(args[0]),
+			Y:  testWord(args[2]),
+		}, nil
+	}
+	switch {
+	case args[0] == "!":
+		expr, err := p.parseArgs(args[1:])
+		if err != nil {
+			return nil, err
+		}
+		return &syntax.UnaryTest{Op: syntax.TsNot, X: expr}, nil
+	case args[0] == "(" && args[2] == ")":
+		return testWord(args[1]), nil
+	default:
+		return nil, fmt.Errorf("not a valid test operator: %#q", args[1])
+	}
+}
+
+func (p *testParser) parseOr(args []string, pos int) (syntax.TestExpr, int, error) {
+	expr, pos, err := p.parseAnd(args, pos)
+	if err != nil {
+		return nil, pos, err
+	}
+	for pos < len(args) && args[pos] == "-o" {
+		if pos+1 >= len(args) {
+			return nil, pos, fmt.Errorf("argument expected")
+		}
+		right, next, err := p.parseAnd(args, pos+1)
+		if err != nil {
+			return nil, pos, err
+		}
+		expr = &syntax.BinaryTest{Op: syntax.OrTest, X: expr, Y: right}
+		pos = next
+	}
+	return expr, pos, nil
+}
+
+func (p *testParser) parseAnd(args []string, pos int) (syntax.TestExpr, int, error) {
+	expr, pos, err := p.parseNot(args, pos)
+	if err != nil {
+		return nil, pos, err
+	}
+	for pos < len(args) && args[pos] == "-a" {
+		if pos+1 >= len(args) {
+			return nil, pos, fmt.Errorf("argument expected")
+		}
+		right, next, err := p.parseNot(args, pos+1)
+		if err != nil {
+			return nil, pos, err
+		}
+		expr = &syntax.BinaryTest{Op: syntax.AndTest, X: expr, Y: right}
+		pos = next
+	}
+	return expr, pos, nil
+}
+
+func (p *testParser) parseNot(args []string, pos int) (syntax.TestExpr, int, error) {
+	if pos >= len(args) {
+		return nil, pos, fmt.Errorf("argument expected")
+	}
+	if args[pos] == "!" {
+		expr, next, err := p.parseNot(args, pos+1)
+		if err != nil {
+			return nil, pos, err
+		}
+		return &syntax.UnaryTest{Op: syntax.TsNot, X: expr}, next, nil
+	}
+	return p.parsePrimary(args, pos)
+}
+
+func (p *testParser) parsePrimary(args []string, pos int) (syntax.TestExpr, int, error) {
+	if pos >= len(args) {
+		return nil, pos, fmt.Errorf("argument expected")
+	}
+	if args[pos] == "(" {
+		expr, next, err := p.parseOr(args, pos+1)
+		if err != nil {
+			return nil, pos, err
+		}
+		if next >= len(args) || args[next] != ")" {
+			return nil, pos, fmt.Errorf("reached %q without matching '(' with ')'", args[len(args)-1])
+		}
+		return &syntax.ParenTest{X: expr}, next + 1, nil
+	}
+	if pos+2 < len(args) {
+		if op := testExprBinaryOp(args[pos+1]); op != illegalTok {
+			return &syntax.BinaryTest{
+				Op: op,
+				X:  testWord(args[pos]),
+				Y:  testWord(args[pos+2]),
+			}, pos + 3, nil
+		}
+	}
+	if isClassicUnaryOp(args[pos]) && pos+1 < len(args) {
+		return &syntax.UnaryTest{
+			Op: testUnaryOp(args[pos]),
+			X:  testWord(args[pos+1]),
+		}, pos + 2, nil
+	}
+	return testWord(args[pos]), pos + 1, nil
+}
+
+func isClassicUnaryOp(val string) bool {
+	op := testUnaryOp(val)
+	return op != illegalTok && op != syntax.TsNot && op != syntax.TsParen
 }
 
 // testUnaryOp is an exact copy of syntax's.
@@ -172,17 +257,16 @@ func testUnaryOp(val string) syntax.UnTestOperator {
 	}
 }
 
-// testBinaryOp is like syntax's, but with -a and -o, and without =~.
-func testBinaryOp(val string) syntax.BinTestOperator {
+func testExprBinaryOp(val string) syntax.BinTestOperator {
 	switch val {
-	case "-a":
-		return syntax.AndTest
-	case "-o":
-		return syntax.OrTest
 	case "==", "=":
 		return syntax.TsMatch
 	case "!=":
 		return syntax.TsNoMatch
+	case "<":
+		return syntax.TsBefore
+	case ">":
+		return syntax.TsAfter
 	case "-nt":
 		return syntax.TsNewer
 	case "-ot":
@@ -203,5 +287,17 @@ func testBinaryOp(val string) syntax.BinTestOperator {
 		return syntax.TsGtr
 	default:
 		return illegalTok
+	}
+}
+
+// testBinaryOp is like syntax's, but with -a and -o, and without =~.
+func testBinaryOp(val string) syntax.BinTestOperator {
+	switch val {
+	case "-a":
+		return syntax.AndTest
+	case "-o":
+		return syntax.OrTest
+	default:
+		return testExprBinaryOp(val)
 	}
 }


### PR DESCRIPTION
## Summary
- fix ambiguous classic `test` / `[` parsing in both the runtime builtin and mvdan interp paths
- remove the stale `oils/blog2.test.sh` xfail and narrow `oils/bool-parse.test.sh` to the remaining `[[ ) ]]` parser-diagnostic case
- add regression coverage for repeated `-a`, parenthesized operand forms, and trailing-word parsing cases

## Verification
- go test ./internal/builtins ./third_party/mvdan-sh/interp
- GBASH_RUN_CONFORMANCE=1 go test ./internal/conformance -run '^TestConformance$/^bash$/^oils$/^(blog2|bool-parse)\.test\.sh$' -count=1 -timeout=5m -v
- make lint
