### PR TITLE
conformance: fix break/continue error message to match bash

### DIFF
--- a/internal/conformance/manifest.json
+++ b/internal/conformance/manifest.json
@@ -318,10 +318,6 @@
           "mode": "skip",
           "reason": "gbash helper scripts cannot read arbitrary file descriptors without shell features that are not implemented yet"
         },
-        "oils/if_.test.sh": {
-          "mode": "xfail",
-          "reason": "known gbash divergence from bash semantics in this upstream spec file"
-        },
         "oils/interactive.test.sh": {
           "mode": "skip",
           "reason": "requires an interactive shell or tty behavior"

--- a/internal/conformance/runner.go
+++ b/internal/conformance/runner.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ewhauser/gbash"
 )
 
-var bashLinePrefixPattern = regexp.MustCompile(`(?m)^(?:[^:\n]+/)?bash: line \d+: `)
+var bashLinePrefixPattern = regexp.MustCompile(`(?m)^(?:[^:\n]+/)?\w+: line \d+: `)
 
 func resolvedSuiteConfig(cfg *SuiteConfig) SuiteConfig {
 	resolved := *cfg

--- a/third_party/mvdan-sh/interp/builtin.go
+++ b/third_party/mvdan-sh/interp/builtin.go
@@ -265,7 +265,7 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 		}
 	case "break", "continue":
 		if !r.inLoop {
-			return failf(0, "%s is only useful in a loop\n", name)
+			return failf(0, "%s: only meaningful in a `for', `while', or `until' loop\n", name)
 		}
 		enclosing := &r.breakEnclosing
 		if name == "continue" {

--- a/third_party/mvdan-sh/interp/interp_test.go
+++ b/third_party/mvdan-sh/interp/interp_test.go
@@ -247,8 +247,8 @@ var runTests = []runTest{
 	{"exit; echo foo", ""},
 	{"exit 0; echo foo", ""},
 	{"printf", "usage: printf format [arguments]\nexit status 2 #JUSTERR"},
-	{"break", "break is only useful in a loop\n #JUSTERR"},
-	{"continue", "continue is only useful in a loop\n #JUSTERR"},
+	{"break", "break: only meaningful in a `for', `while', or `until' loop\n #JUSTERR"},
+	{"continue", "continue: only meaningful in a `for', `while', or `until' loop\n #JUSTERR"},
 	{"cd a b", "usage: cd [dir]\nexit status 2 #JUSTERR"},
 	{"shift a", "shift: a: numeric argument required\nexit status 2 #JUSTERR"},
 	{


### PR DESCRIPTION
## Summary
- Match bash's exact error wording for `break`/`continue` outside a loop: `break: only meaningful in a 'for', 'while', or 'until' loop`
- Broaden the conformance stderr normalization regex to strip any `<word>: line N:` prefix (not just `bash:`), handling the `environment: line N:` prefix bash emits in BASH_ENV and similar contexts
- Remove the `oils/if_.test.sh` xfail since all its cases now pass

## Test plan
- [x] `make conformance-test` passes (full suite)
- [x] `go test ./third_party/mvdan-sh/interp/...` passes
- [x] `oils/if_.test.sh` conformance cases all pass without xfail