### PR TITLE
cli: add --dump-ast AST output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ gbash -c 'echo hello' --json
 
 The JSON payload includes `stdout`, `stderr`, `exitCode`, truncation flags, timing metadata, and trace metadata when the wrapper enables tracing on the underlying runtime.
 
+For parser and tooling workflows, you can dump the parsed shell AST without executing the script:
+
+```bash
+gbash --dump-ast -c 'echo hello'
+```
+
+`--dump-ast` writes pretty-printed typed JSON for the parsed `shell/syntax` tree. Add `--detect` to choose the parser variant from a leading shebang first, then a positional file extension for file-backed inputs, and otherwise fall back to `bash`.
+
 For long-lived agent or editor integrations, the same shared CLI frontend can serve a JSON-RPC protocol instead of executing one script:
 
 ```bash

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # gbash
 
 Status: Draft v0.1
-Last updated: 2026-03-30
+Last updated: 2026-04-04
 
 ## 1. Purpose
 
@@ -178,6 +178,8 @@ The normal CLI entrypoint also accepts filesystem selection flags before the she
 - `gbash --inherit-env <vars> ...` copies the named host environment variables into the runtime base environment without otherwise widening the default environment surface; the value is a comma-separated list of shell variable names
 - `gbash --copy-script ...` stages the positional host regular file into the sandbox before execution instead of requiring it to already exist in the sandbox namespace
 - `gbash --json ...` emits one JSON object for a non-interactive execution with `stdout`, `stderr`, `exitCode`, truncation flags, timing metadata, and optional trace metadata when tracing is enabled
+- `gbash --dump-ast ...` parses the selected non-interactive input and writes the typed JSON `shell/syntax` AST to stdout without executing the script
+- `gbash --dump-ast --detect ...` chooses the AST parser variant from a leading shebang first, then a positional file extension for file-backed inputs, and otherwise falls back to `bash`; `--detect` is not a standalone reporting mode
 - `gbash --server --socket <path>` serves a long-lived JSON-RPC protocol over a Unix domain socket instead of executing a script
 - `gbash --server --listen <host:port>` serves the same protocol over an explicit loopback TCP listener instead of executing a script
 - `gbash --session-ttl <duration>` controls how long idle server sessions survive without active work

--- a/cli/ast_dump.go
+++ b/cli/ast_dump.go
@@ -1,0 +1,263 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	stdfs "io/fs"
+	"math"
+	"strings"
+
+	"github.com/ewhauser/gbash/commands"
+	gbfs "github.com/ewhauser/gbash/fs"
+	"github.com/ewhauser/gbash/internal/builtins"
+	"github.com/ewhauser/gbash/internal/commandutil"
+	"github.com/ewhauser/gbash/internal/shell/fileutil"
+	"github.com/ewhauser/gbash/shell/syntax"
+	"github.com/ewhauser/gbash/shell/syntax/typedjson"
+	"github.com/ewhauser/gbash/shellvariant"
+)
+
+type astDumpSource struct {
+	script     string
+	sourceName string
+	detectPath string
+}
+
+func runBashInvocationAST(ctx context.Context, cfg Config, parsed *builtins.BashInvocation, runtimeOpts *runtimeOptions, stdin io.Reader, stdout io.Writer) (int, error) {
+	if parsed == nil {
+		parsed = &builtins.BashInvocation{Name: cfg.Name, Source: builtins.BashSourceStdin}
+	}
+
+	source, exitCode, err := loadASTDumpSource(ctx, cfg, parsed, runtimeOpts, stdin)
+	if err != nil {
+		return exitCode, err
+	}
+
+	variant := astDumpShellVariant(parsed, source.script, source.detectPath, runtimeOpts != nil && runtimeOpts.detect)
+	program, err := syntax.NewParser(syntax.Variant(variant.SyntaxLang())).Parse(strings.NewReader(source.script), source.sourceName)
+	if err != nil {
+		var parseErr syntax.ParseError
+		if errors.As(err, &parseErr) {
+			return 2, errors.New(formatVariantParseError(&parseErr, variant))
+		}
+		var langErr syntax.LangError
+		if errors.As(err, &langErr) {
+			return 2, errors.New(langErr.Error())
+		}
+		return 1, fmt.Errorf("parse script: %w", err)
+	}
+
+	if err := (typedjson.EncodeOptions{Indent: "  "}).Encode(writerOrDiscard(stdout), program); err != nil {
+		return 1, fmt.Errorf("encode AST: %w", err)
+	}
+	return 0, nil
+}
+
+func loadASTDumpSource(ctx context.Context, cfg Config, parsed *builtins.BashInvocation, runtimeOpts *runtimeOptions, stdin io.Reader) (astDumpSource, int, error) {
+	if parsed == nil {
+		parsed = &builtins.BashInvocation{Name: cfg.Name, Source: builtins.BashSourceStdin}
+	}
+
+	switch parsed.Source {
+	case builtins.BashSourceFile:
+		return loadASTDumpFileSource(ctx, cfg, parsed, runtimeOpts)
+	default:
+		script, _, exitCode, err := loadBashInvocationScript(parsed, stdin)
+		if err != nil {
+			return astDumpSource{}, exitCode, err
+		}
+		if parsed.Source == builtins.BashSourceCommandString && strings.HasPrefix(script, "\n") {
+			script = script[1:]
+		}
+		return astDumpSource{
+			script:     script,
+			sourceName: astDumpSourceName(parsed),
+		}, 0, nil
+	}
+}
+
+func loadASTDumpFileSource(ctx context.Context, cfg Config, parsed *builtins.BashInvocation, runtimeOpts *runtimeOptions) (astDumpSource, int, error) {
+	if runtimeOpts == nil {
+		runtimeOpts = &runtimeOptions{}
+	}
+
+	//nolint:contextcheck // gbash.New does not accept context; runtime use remains scoped to this ctx-bound CLI invocation.
+	rt, err := newRuntime(cfg, runtimeOpts)
+	if err != nil {
+		return astDumpSource{}, 1, fmt.Errorf("init runtime: %w", err)
+	}
+	session, err := rt.NewSession(ctx)
+	if err != nil {
+		return astDumpSource{}, 1, fmt.Errorf("new session: %w", err)
+	}
+	if exitCode, err := prepareBashInvocationScriptPath(ctx, session, parsed, runtimeOpts); err != nil {
+		return astDumpSource{}, exitCode, err
+	}
+
+	script, err := readASTDumpSessionScript(ctx, session.FileSystem(), session.Limits().MaxFileBytes, runtimeOpts.defaultWorkingDir(), parsed.ScriptPath)
+	if err != nil {
+		return astDumpSource{}, astDumpErrorExitCode(err), err
+	}
+	return astDumpSource{
+		script:     script,
+		sourceName: astDumpSourceName(parsed),
+		detectPath: parsed.ScriptPath,
+	}, 0, nil
+}
+
+func readASTDumpSessionScript(ctx context.Context, fsys gbfs.FileSystem, maxFileBytes int64, workDir, scriptPath string) (string, error) {
+	if fsys == nil {
+		return "", errors.New("session filesystem unavailable")
+	}
+
+	source, err := fsys.Open(ctx, gbfs.Resolve(workDir, scriptPath))
+	if err != nil {
+		return "", astDumpScriptLoadError(scriptPath, err)
+	}
+	defer func() { _ = source.Close() }()
+
+	data, err := readASTDumpScriptData(ctx, source, scriptPath, maxFileBytes)
+	if err != nil {
+		return "", err
+	}
+	if err := builtins.ValidateShellScriptFileData(scriptPath, data); err != nil {
+		return "", &commands.ExitError{Code: 126, Err: err}
+	}
+	return string(data), nil
+}
+
+func readASTDumpScriptData(ctx context.Context, source io.Reader, sourcePath string, maxFileBytes int64) ([]byte, error) {
+	reader := commandutil.ReaderWithContext(ctx, source)
+	if maxFileBytes <= 0 || maxFileBytes == math.MaxInt64 {
+		data, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, fmt.Errorf("read script %s: %w", sourcePath, err)
+		}
+		return data, nil
+	}
+
+	data, err := io.ReadAll(io.LimitReader(reader, maxFileBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read script %s: %w", sourcePath, err)
+	}
+	if int64(len(data)) > maxFileBytes {
+		return nil, fmt.Errorf("%s: %w", sourcePath, commands.Diagnosticf("input exceeds maximum file size of %d bytes", maxFileBytes))
+	}
+	return data, nil
+}
+
+func astDumpSourceName(parsed *builtins.BashInvocation) string {
+	if parsed == nil {
+		return "stdin"
+	}
+	switch {
+	case strings.TrimSpace(parsed.ScriptPath) != "":
+		return parsed.ScriptPath
+	case strings.TrimSpace(parsed.ExecutionName) != "":
+		return parsed.ExecutionName
+	default:
+		return "stdin"
+	}
+}
+
+func astDumpShellVariant(parsed *builtins.BashInvocation, script, detectPath string, detect bool) shellvariant.ShellVariant {
+	if detect {
+		if variant := detectedShellVariant(script, detectPath); variant.Resolved() {
+			return variant
+		}
+		return shellvariant.Bash
+	}
+	if parsed != nil {
+		if variant := parsed.DefaultShellVariant(); variant.Resolved() {
+			return variant
+		}
+	}
+	return shellvariant.Bash
+}
+
+func detectedShellVariant(script, scriptPath string) shellvariant.ShellVariant {
+	if variant := shellvariant.FromInterpreter(fileutil.Shebang([]byte(script))); variant.Resolved() {
+		return variant
+	}
+	if scriptPath != "" {
+		if variant := shellvariant.FromPath(scriptPath); variant.Resolved() {
+			return variant
+		}
+	}
+	return shellvariant.Bash
+}
+
+func formatVariantParseError(err *syntax.ParseError, variant shellvariant.ShellVariant) string {
+	if err == nil {
+		return ""
+	}
+	if variant.UsesBashDiagnostics() {
+		return err.BashError()
+	}
+	return err.Error()
+}
+
+func astDumpErrorExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if code, ok := commands.ExitCode(err); ok {
+		return code
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return 124
+	}
+	if errors.Is(err, context.Canceled) {
+		return 130
+	}
+	return 1
+}
+
+func astDumpScriptLoadError(scriptPath string, err error) error {
+	if astDumpScriptLoadIsNotExist(err) {
+		return &commands.ExitError{
+			Code: 127,
+			Err:  fmt.Errorf("%s: No such file or directory", scriptPath),
+		}
+	}
+
+	code := 1
+	if exitCode, ok := commands.ExitCode(err); ok {
+		code = exitCode
+	}
+	return &commands.ExitError{
+		Code: code,
+		Err:  fmt.Errorf("%s: %s", scriptPath, astDumpScriptLoadErrorText(err)),
+	}
+}
+
+func astDumpScriptLoadErrorText(err error) string {
+	switch {
+	case astDumpScriptLoadIsNotExist(err):
+		return "No such file or directory"
+	case astDumpScriptLoadIsDirectory(err):
+		return "Is a directory"
+	default:
+		return err.Error()
+	}
+}
+
+func astDumpScriptLoadIsNotExist(err error) bool {
+	return err != nil &&
+		(errors.Is(err, stdfs.ErrNotExist) ||
+			strings.Contains(strings.ToLower(err.Error()), "no such file or directory") ||
+			strings.Contains(strings.ToLower(err.Error()), "file does not exist"))
+}
+
+func astDumpScriptLoadIsDirectory(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pathErr *stdfs.PathError
+	if errors.As(err, &pathErr) && errors.Is(pathErr.Err, stdfs.ErrInvalid) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "is a directory")
+}

--- a/cli/run.go
+++ b/cli/run.go
@@ -68,6 +68,12 @@ func run(ctx context.Context, cfg Config, args []string, stdin io.Reader, stdout
 		_, _ = io.WriteString(stdout, versionText(cfg))
 		return 0, nil
 	}
+	if runtimeOpts.detect && !runtimeOpts.dumpAST {
+		if runtimeOpts.json {
+			return writeCLIJSONError(stdout, cfg.Name, 2, fmt.Errorf("--detect requires --dump-ast"))
+		}
+		return 2, fmt.Errorf("--detect requires --dump-ast")
+	}
 	if runtimeOpts.server {
 		if runtimeOpts.json {
 			return writeCLIJSONError(stdout, cfg.Name, 2, fmt.Errorf("--server and --json are mutually exclusive"))
@@ -87,6 +93,20 @@ func run(ctx context.Context, cfg Config, args []string, stdin io.Reader, stdout
 				return 2, err
 			}
 		}
+	}
+	if runtimeOpts.dumpAST {
+		if runtimeOpts.json {
+			return writeCLIJSONError(stdout, cfg.Name, 2, fmt.Errorf("--dump-ast and --json are mutually exclusive"))
+		}
+		if runtimeOpts.server {
+			return 2, fmt.Errorf("--dump-ast and --server are mutually exclusive")
+		}
+		if parsed.Source == builtins.BashSourceStdin && (parsed.Interactive || stdinTTY) {
+			return 2, fmt.Errorf("--dump-ast is only supported for non-interactive executions")
+		}
+		stdin = wrapInheritedStdin(stdin, &runtimeOpts)
+		stdout = wrapInheritedStdout(stdout, &runtimeOpts)
+		return runBashInvocationAST(ctx, cfg, parsed, &runtimeOpts, stdin, stdout)
 	}
 	if runtimeOpts.json && parsed.Source == builtins.BashSourceStdin && (parsed.Interactive || stdinTTY) {
 		if jsonErr := writeJSONExecutionResult(stdout, buildJSONExecutionResult(2, nil, formatCLIError(cfg.Name, fmt.Errorf("--json is only supported for non-interactive executions")))); jsonErr != nil {

--- a/cli/runtime_options.go
+++ b/cli/runtime_options.go
@@ -25,6 +25,8 @@ type runtimeOptions struct {
 	cwd             string
 	maxFileBytes    int64
 	json            bool
+	dumpAST         bool
+	detect          bool
 	server          bool
 	socket          string
 	listen          string
@@ -105,6 +107,10 @@ func parseRuntimeOptions(args []string) (runtimeOptions, []string, error) {
 			opts.maxFileBytes = value
 		case arg == "--json":
 			opts.json = true
+		case arg == "--dump-ast":
+			opts.dumpAST = true
+		case arg == "--detect":
+			opts.detect = true
 		case arg == "--server":
 			opts.server = true
 		case arg == "--socket":
@@ -235,6 +241,23 @@ func appendUniqueStrings(dst []string, values ...string) []string {
 		out = append(out, value)
 	}
 	return out
+}
+
+func (opts *runtimeOptions) defaultWorkingDir() string {
+	if opts == nil {
+		return gbash.InMemoryFileSystem().WorkingDir
+	}
+	if cwdValue := strings.TrimSpace(opts.cwd); cwdValue != "" {
+		return normalizeSandboxPath(cwdValue)
+	}
+	switch {
+	case strings.TrimSpace(opts.root) != "":
+		return gbash.DefaultWorkspaceMountPoint
+	case strings.TrimSpace(opts.readWriteRoot) != "":
+		return "/"
+	default:
+		return gbash.InMemoryFileSystem().WorkingDir
+	}
 }
 
 func (opts *runtimeOptions) gbashOptions() ([]gbash.Option, error) {
@@ -590,6 +613,8 @@ func renderHelp(w io.Writer, name string) error {
 		"  --max-file-bytes N    override the sandbox file-size/read-size limit in bytes\n"+
 		"\nCLI output options:\n"+
 		"  --json                emit one JSON result object for a non-interactive execution\n"+
+		"  --dump-ast            parse the selected input and print typed-json AST output only\n"+
+		"  --detect              auto-detect the parser variant for --dump-ast from shebang or file extension\n"+
 		"\nCLI server options:\n"+
 		"  --server                run the shared gbash JSON-RPC server instead of executing a script\n"+
 		"  --socket PATH           listen on PATH for Unix domain socket clients\n"+

--- a/cmd/gbash/cli_test.go
+++ b/cmd/gbash/cli_test.go
@@ -114,7 +114,7 @@ func TestRunCLIHelpRendersFilesystemFlags(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("exitCode = %d, want 0", exitCode)
 	}
-	for _, want := range []string{"CLI filesystem options:", "--root DIR", "--cwd DIR", "--readwrite-root DIR", "--copy-script", "--max-file-bytes N", "CLI output options:", "--json"} {
+	for _, want := range []string{"CLI filesystem options:", "--root DIR", "--cwd DIR", "--readwrite-root DIR", "--copy-script", "--max-file-bytes N", "CLI output options:", "--json", "--dump-ast", "--detect"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want help to contain %q", stdout.String(), want)
 		}
@@ -124,6 +124,260 @@ func TestRunCLIHelpRendersFilesystemFlags(t *testing.T) {
 	}
 	if got := stderr.String(); got != "" {
 		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
+func TestRunCLIDumpASTCommandString(t *testing.T) {
+	t.Parallel()
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), []string{"--dump-ast", "-c", "echo hi\n"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+	mustParseASTRootType(t, stdout.String())
+}
+
+func TestRunCLIDumpASTStdin(t *testing.T) {
+	t.Parallel()
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), []string{"--dump-ast"}, strings.NewReader("echo hi\n"), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+	mustParseASTRootType(t, stdout.String())
+}
+
+func TestRunCLIDumpASTReadsRootMountedScript(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.sh"), []byte("echo from-file\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(main.sh) error = %v", err)
+	}
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), []string{"--root", root, "--dump-ast", "main.sh"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+	mustParseASTRootType(t, stdout.String())
+}
+
+func TestRunCLIDumpASTCopyScriptStagesHostFile(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(t.TempDir(), "copy-script.sh")
+	if err := os.WriteFile(scriptPath, []byte("echo staged\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(copy-script.sh) error = %v", err)
+	}
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), []string{"--copy-script", "--dump-ast", scriptPath}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+	mustParseASTRootType(t, stdout.String())
+}
+
+func TestRunCLIDumpASTParseErrorsReturnExit2(t *testing.T) {
+	t.Parallel()
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), []string{"--dump-ast", "-c", "echo <\n"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err == nil {
+		t.Fatal("runCLI() error = nil, want parse failure")
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d, want 2", exitCode)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+	if !strings.Contains(err.Error(), "line 1") {
+		t.Fatalf("error = %v, want parse diagnostic", err)
+	}
+}
+
+func TestRunCLIDumpASTRejectsJSONOutputEnvelope(t *testing.T) {
+	t.Parallel()
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), []string{"--dump-ast", "--json", "-c", "echo hi\n"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d, want 2; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+
+	payload := mustParseCLIJSONResult(t, stdout.String())
+	if !strings.Contains(payload.Stderr, "--dump-ast and --json are mutually exclusive") {
+		t.Fatalf("stderr = %q, want dump-ast/json rejection", payload.Stderr)
+	}
+}
+
+func TestRunCLIDumpASTRejectsServerMode(t *testing.T) {
+	t.Parallel()
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), []string{"--dump-ast", "--server", "--socket", filepath.Join(t.TempDir(), "gbash.sock")}, strings.NewReader(""), &stdout, &stderr, false)
+	if err == nil {
+		t.Fatal("runCLI() error = nil, want server conflict")
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d, want 2", exitCode)
+	}
+	if !strings.Contains(err.Error(), "--dump-ast and --server are mutually exclusive") {
+		t.Fatalf("error = %v, want dump-ast/server conflict", err)
+	}
+}
+
+func TestRunCLIDumpASTRejectsInteractiveInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		args     []string
+		stdinTTY bool
+	}{
+		{name: "stdin tty", args: []string{"--dump-ast"}, stdinTTY: true},
+		{name: "interactive flag", args: []string{"--dump-ast", "-i"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var stdout strings.Builder
+			var stderr strings.Builder
+
+			exitCode, err := runCLI(context.Background(), tc.args, strings.NewReader(""), &stdout, &stderr, tc.stdinTTY)
+			if err == nil {
+				t.Fatal("runCLI() error = nil, want interactive rejection")
+			}
+			if exitCode != 2 {
+				t.Fatalf("exitCode = %d, want 2", exitCode)
+			}
+			if !strings.Contains(err.Error(), "non-interactive") {
+				t.Fatalf("error = %v, want non-interactive rejection", err)
+			}
+		})
+	}
+}
+
+func TestRunCLIDetectRequiresDumpAST(t *testing.T) {
+	t.Parallel()
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), []string{"--detect", "-c", "echo hi\n"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err == nil {
+		t.Fatal("runCLI() error = nil, want detect rejection")
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d, want 2", exitCode)
+	}
+	if !strings.Contains(err.Error(), "--detect requires --dump-ast") {
+		t.Fatalf("error = %v, want detect rejection", err)
+	}
+}
+
+func TestRunCLIDumpASTDetectUsesShebangVariant(t *testing.T) {
+	t.Parallel()
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), []string{"--dump-ast", "--detect", "-c", "#!/bin/zsh\necho ${(q)foo}\n"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+	mustParseASTRootType(t, stdout.String())
+}
+
+func TestRunCLIDumpASTDetectUsesPathExtensionForFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.zsh"), []byte("echo ${(q)foo}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(main.zsh) error = %v", err)
+	}
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), []string{"--root", root, "--dump-ast", "--detect", "main.zsh"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+	mustParseASTRootType(t, stdout.String())
+}
+
+func TestRunCLIDumpASTDetectFallsBackToBashWithoutSourceHints(t *testing.T) {
+	t.Parallel()
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), []string{"--dump-ast", "--detect", "-c", "echo ${(q)foo}\n"}, strings.NewReader(""), &stdout, &stderr, false)
+	if err == nil {
+		t.Fatal("runCLI() error = nil, want bash parse failure")
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d, want 2", exitCode)
+	}
+	if !strings.Contains(err.Error(), "tried parsing as bash") {
+		t.Fatalf("error = %v, want bash-variant parse diagnostic", err)
 	}
 }
 
@@ -621,6 +875,18 @@ func mustParseCLIJSONResult(t *testing.T, raw string) cliJSONResult {
 		t.Fatalf("Unmarshal(JSON output) error = %v; raw=%q", err, raw)
 	}
 	return out
+}
+
+func mustParseASTRootType(t *testing.T, raw string) {
+	t.Helper()
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("Unmarshal(AST output) error = %v; raw=%q", err, raw)
+	}
+	if got, want := out["Type"], "File"; got != want {
+		t.Fatalf("AST root Type = %v, want %q; raw=%q", got, want, raw)
+	}
 }
 
 func reserveLoopbackTCPAddress(t *testing.T) string {

--- a/contrib/extras/cmd/gbash-extras/main_test.go
+++ b/contrib/extras/cmd/gbash-extras/main_test.go
@@ -144,6 +144,31 @@ func TestCLIDoesNotRegisterNodeJSByDefault(t *testing.T) {
 	}
 }
 
+func TestCLISupportsASTDumpMode(t *testing.T) {
+	t.Parallel()
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	exitCode, err := runCLI(context.Background(), []string{"--dump-ast", "-c", "echo extras\n"}, strings.NewReader(""), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runCLI() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d, want 0; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout.String()), &payload); err != nil {
+		t.Fatalf("Unmarshal(AST output) error = %v; raw=%q", err, stdout.String())
+	}
+	if got, want := payload["Type"], "File"; got != want {
+		t.Fatalf("AST root Type = %v, want %q; raw=%q", got, want, stdout.String())
+	}
+}
+
 func TestCLIServerServesStableExtrasRegistry(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- add `--dump-ast` to print the parsed shell AST as pretty-printed typed JSON without executing
- add `--detect` as a `--dump-ast` modifier that chooses the parser variant from shebang first, then file extension, else bash
- cover the new shared CLI mode in `gbash` and `gbash-extras`, and document it in the README and SPEC

## Validation
- `go test ./cli ./cmd/gbash ./contrib/extras/cmd/gbash-extras`
- `make lint`