### PR TITLE
ci: harden workflows and add security policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - run: go mod download
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
 
       - run: make test
 
@@ -51,7 +51,7 @@ jobs:
 
       - run: go mod download
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
 
       - run: make bats-test
 
@@ -66,7 +66,7 @@ jobs:
 
       - run: go mod download
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
 
       - run: make conformance-test
 
@@ -81,6 +81,6 @@ jobs:
 
       - run: go mod download
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
 
       - run: make contrib-conformance-test

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -5,11 +5,7 @@ on:
     - cron: "0 7 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: compat-pages
@@ -18,6 +14,11 @@ concurrency:
 jobs:
   compat:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+      pages: write
+      id-token: write
     outputs:
       exit_code: ${{ steps.run-compat.outputs.exit_code }}
       publishable: ${{ steps.publish-state.outputs.publishable }}
@@ -266,6 +267,9 @@ jobs:
     if: always() && needs.compat.outputs.deployable == 'true'
     needs: compat
     runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
     concurrency:
       group: github-pages
       cancel-in-progress: false

--- a/.github/workflows/fuzz-full.yml
+++ b/.github/workflows/fuzz-full.yml
@@ -5,14 +5,15 @@ on:
     - cron: "0 7 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   fuzz-full:
     name: Fuzz Full (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -69,6 +70,9 @@ jobs:
   fuzz-contrib:
     name: Fuzz Contrib (${{ matrix.name }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
 
       - name: Build package
         run: nix build .#${{ inputs.package }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -3,10 +3,7 @@ name: Prepare Release
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: {}
 
 concurrency:
   group: prepare-release
@@ -15,6 +12,10 @@ concurrency:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/publish-custom-gcl.yml
+++ b/.github/workflows/publish-custom-gcl.yml
@@ -8,8 +8,7 @@ on:
       - .custom-gcl.yml
       - tools/regexponce-gclplugin/**/*.go
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   build:
@@ -23,6 +22,8 @@ jobs:
             goos: darwin
             goarch: arm64
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -46,6 +47,8 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       should_publish: ${{ steps.context.outputs.should_publish }}
       version: ${{ steps.context.outputs.version }}
@@ -52,7 +53,7 @@ jobs:
           elif [[ "${EVENT_NAME}" == "push" ]]; then
             # Look up the merged PR associated with this push commit.
             pr_json=$(gh api "repos/${REPOSITORY}/commits/${COMMIT_SHA}/pulls" \
-              --jq '[.[] | select(.merged_at != null and .base.ref == "main")] | .[0] // empty' || true)
+              --jq '[.[] | select(.merged_at != null and .base.ref == "main")] | .[0] // empty')
 
             if [[ -n "${pr_json}" ]]; then
               pr_head_repo=$(echo "${pr_json}" | jq -r '.head.repo.full_name')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,8 @@
 name: Publish Release
 
 on:
-  pull_request_target:
-    types:
-      - closed
-    branches:
-      - main
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       version:
@@ -18,18 +15,17 @@ on:
         default: main
         type: string
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
-  group: publish-release-${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.pull_request.head.ref }}
+  group: publish-release-${{ github.event_name == 'workflow_dispatch' && inputs.version || github.sha }}
   cancel-in-progress: false
 
 jobs:
   resolve:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       should_publish: ${{ steps.context.outputs.should_publish }}
       version: ${{ steps.context.outputs.version }}
@@ -41,13 +37,8 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_REF: ${{ inputs.ref }}
           REPOSITORY: ${{ github.repository }}
-          PR_MERGED: ${{ github.event.pull_request.merged }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          COMMIT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           should_publish=false
@@ -58,16 +49,26 @@ jobs:
             should_publish=true
             version="${INPUT_VERSION}"
             ref="${INPUT_REF:-main}"
-          elif [[ "${PR_MERGED}" == "true" ]] \
-            && [[ "${PR_BASE_REF}" == "main" ]] \
-            && [[ "${PR_HEAD_REPO}" == "${REPOSITORY}" ]] \
-            && [[ "${PR_HEAD_REF}" == release/v* ]] \
-            && [[ ",${PR_LABELS}," == *",release,"* ]] \
-            && [[ "${PR_AUTHOR}" == "github-actions[bot]" ]] \
-            && [[ -n "${PR_MERGE_SHA}" ]]; then
-            should_publish=true
-            version="${PR_HEAD_REF#release/}"
-            ref="${PR_MERGE_SHA}"
+          elif [[ "${EVENT_NAME}" == "push" ]]; then
+            # Look up the merged PR associated with this push commit.
+            pr_json=$(gh api "repos/${REPOSITORY}/commits/${COMMIT_SHA}/pulls" \
+              --jq '[.[] | select(.merged_at != null and .base.ref == "main")] | .[0] // empty' || true)
+
+            if [[ -n "${pr_json}" ]]; then
+              pr_head_repo=$(echo "${pr_json}" | jq -r '.head.repo.full_name')
+              pr_head_ref=$(echo "${pr_json}" | jq -r '.head.ref')
+              pr_labels=$(echo "${pr_json}" | jq -r '[.labels[].name] | join(",")')
+              pr_author=$(echo "${pr_json}" | jq -r '.user.login')
+
+              if [[ "${pr_head_repo}" == "${REPOSITORY}" ]] \
+                && [[ "${pr_head_ref}" == release/v* ]] \
+                && [[ ",${pr_labels}," == *",release,"* ]] \
+                && [[ "${pr_author}" == "github-actions[bot]" ]]; then
+                should_publish=true
+                version="${pr_head_ref#release/}"
+                ref="${COMMIT_SHA}"
+              fi
+            fi
           fi
 
           if [[ "${should_publish}" == "true" ]] && [[ ! "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -85,6 +86,10 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     outputs:
       pages_deployable: ${{ steps.pages_state.outputs.deployable }}
     steps:
@@ -97,13 +102,16 @@ jobs:
       - name: Fetch tags
         run: git fetch --force --tags origin
 
+      # Caching is intentionally disabled during releases to prevent cache
+      # poisoning from compromising shipped artifacts.
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
+          cache: false
 
       - run: go mod download
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
@@ -111,7 +119,6 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          cache: pnpm
           node-version: "20"
 
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
@@ -310,6 +317,9 @@ jobs:
       - publish
     if: needs.resolve.outputs.should_publish == 'true' && needs.publish.outputs.pages_deployable == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     concurrency:
       group: github-pages
       cancel-in-progress: false

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -4,6 +4,9 @@
     "security:only-security-updates",
     "helpers:pinGitHubActionDigests"
   ],
+  // Avoid adopting compromised packages by waiting for a cooldown period
+  // after each release before updating.
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "description": "Internal Go modules are released together from this repository.",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in gbash, please report it through
+[GitHub's private vulnerability reporting](https://github.com/ewhauser/gbash/security/advisories/new).
+
+**Do not open a public issue for security vulnerabilities.**
+
+Please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Any relevant logs or output
+- The version of gbash affected
+
+You should receive an initial response within 72 hours. Once the issue is
+confirmed, a fix will be developed and released as soon as practical, with
+credit to the reporter unless they prefer to remain anonymous.
+
+## Supported Versions
+
+Security fixes are applied to the latest release only.


### PR DESCRIPTION
## Summary

Applies open-source security best practices from [Astral's recommendations](https://astral.sh/blog/open-source-security-at-astral):

- **Pin `cachix/install-nix-action` to SHA** — was the only action using a mutable tag instead of a commit digest
- **Replace `pull_request_target` with `push` trigger** in `release.yml` — eliminates a dangerous trigger class; the resolve job now uses the GitHub API (`commits/{sha}/pulls`) to look up the merged PR and validates the same 4 gates (repo match, `release/v*` branch, `release` label, `github-actions[bot]` author)
- **Scope permissions per-job** — sets `permissions: {}` at workflow level in `release.yml`, `compat.yml`, `fuzz-full.yml`, `publish-custom-gcl.yml`, and `prepare-release.yml`; each job declares only what it needs
- **Disable caching during releases** — prevents cache poisoning from compromising shipped artifacts (`cache: false` on setup-go, removed pnpm cache)
- **Add 3-day dependency update cooldown** — `minimumReleaseAge` in Renovate config avoids adopting freshly-published compromised packages
- **Add `SECURITY.md`** — vulnerability disclosure policy pointing to GitHub private advisory reporting

## Test plan

- [ ] Verify CI passes on this PR (the `push` trigger change to `release.yml` won't fire since this targets `main` and the resolve job exits early for non-release commits)
- [ ] Confirm `actionlint` reports no new issues (pre-existing shellcheck style warnings only)
- [ ] After merge, verify the next `make release` cycle still triggers the publish workflow correctly via the `push`-to-main path