### PR TITLE
Harden sandbox escape boundaries

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -731,6 +731,7 @@ Important properties:
 - the runtime may reserve a small synthetic namespace such as `/dev/null`, `/dev/urandom`, and `/dev/zero` above any backend so shell-visible device behavior stays consistent across in-memory and host-backed filesystems
 - host-backed filesystems must still satisfy policy checks and must never imply host command execution
 - a read-write host-backed filesystem may be enabled explicitly for external test harnesses or advanced embedding, but it is not the default runtime backend
+- host-backed filesystem mutations that create entries, including named pipes, must perform the final host operation relative to a resolved sandbox-confined directory handle rather than reusing a post-check absolute host path
 - shell redirects and command file access share the same filesystem view
 - symlink support is optional and must default to the safer behavior when policy is ambiguous
 - for backends without symlink creation/traversal support, `Lstat` behaves like `Stat`, `Readlink` fails for non-symlinks, and `Realpath` resolves only existing virtual paths
@@ -815,7 +816,7 @@ The policy package should be able to answer three questions:
 2. may this builtin run?
 3. may this path be read or written?
 
-Network policy for the current runtime is enforced by the dedicated `network/` layer rather than by generic shell evaluation. Commands never receive host `http.Client` access directly; they only receive the runtime-owned sandboxed `network.Client`.
+Network policy for the current runtime is enforced by the dedicated `network/` layer rather than by generic shell evaluation. Commands never receive host `http.Client` access directly; they only receive the runtime-owned sandboxed `network.Client`. The default sandboxed HTTP client must not inherit host proxy environment variables, and private-range blocking must be enforced during the actual dial using the same resolver surface used by the preflight URL check.
 
 Path-policy enforcement rule for the current runtime:
 

--- a/fs/mkfifo_at_darwin.go
+++ b/fs/mkfifo_at_darwin.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package fs
+
+import (
+	stdfs "io/fs"
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+func mkfifoAt(parent *os.File, base string, perm stdfs.FileMode) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	if err := unix.PthreadFchdir(int(parent.Fd())); err != nil {
+		return err
+	}
+	defer func() { _ = unix.PthreadFchdir(-1) }()
+
+	return unix.Mkfifo(base, uint32(perm.Perm()))
+}

--- a/fs/mkfifo_at_freebsd.go
+++ b/fs/mkfifo_at_freebsd.go
@@ -1,0 +1,14 @@
+//go:build freebsd
+
+package fs
+
+import (
+	stdfs "io/fs"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func mkfifoAt(parent *os.File, base string, perm stdfs.FileMode) error {
+	return unix.Mknodat(int(parent.Fd()), base, uint32(perm.Perm())|unix.S_IFIFO, 0)
+}

--- a/fs/mkfifo_at_mkfifoat.go
+++ b/fs/mkfifo_at_mkfifoat.go
@@ -1,0 +1,14 @@
+//go:build linux || netbsd || openbsd || solaris || zos
+
+package fs
+
+import (
+	stdfs "io/fs"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func mkfifoAt(parent *os.File, base string, perm stdfs.FileMode) error {
+	return unix.Mkfifoat(int(parent.Fd()), base, uint32(perm.Perm()))
+}

--- a/fs/mkfifo_at_mknodat.go
+++ b/fs/mkfifo_at_mknodat.go
@@ -1,0 +1,14 @@
+//go:build aix || dragonfly
+
+package fs
+
+import (
+	stdfs "io/fs"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func mkfifoAt(parent *os.File, base string, perm stdfs.FileMode) error {
+	return unix.Mknodat(int(parent.Fd()), base, uint32(perm.Perm())|unix.S_IFIFO, 0)
+}

--- a/fs/readwrite_posix.go
+++ b/fs/readwrite_posix.go
@@ -334,15 +334,22 @@ func (h *ReadWriteFS) MkdirAll(_ context.Context, name string, perm stdfs.FileMo
 
 func (h *ReadWriteFS) Mkfifo(_ context.Context, name string, perm stdfs.FileMode) error {
 	abs := h.resolve(name)
-	target, err := h.resolveLeaf(abs)
+	root, resolved, err := openResolvedRoot(h.root, h.canonicalRoot, strings.TrimPrefix(abs, "/"), false, true)
 	if err != nil {
 		return h.pathError("mkfifo", abs, err)
 	}
+	defer func() { _ = root.Close() }()
+
+	parent, base, err := openResolvedParentFile(root, resolved.rel)
+	if err != nil {
+		return h.pathError("mkfifo", abs, err)
+	}
+	defer func() { _ = parent.Close() }()
 
 	if perm == 0 {
 		perm = 0o666
 	}
-	if err := syscall.Mkfifo(target, uint32(perm.Perm())); err != nil {
+	if err := mkfifoAt(parent, base, perm); err != nil {
 		return h.pathError("mkfifo", abs, err)
 	}
 	return nil
@@ -498,50 +505,6 @@ func (h *ReadWriteFS) moveOwnership(oldTarget, newTarget string) {
 }
 func (h *ReadWriteFS) resolve(name string) string {
 	return Resolve(h.Getwd(), name)
-}
-
-func (h *ReadWriteFS) resolveLeaf(abs string) (string, error) {
-	abs = Clean(abs)
-	if abs == "/" {
-		return h.canonicalRoot, nil
-	}
-
-	lexical := h.lexicalPath(abs)
-	parent := filepath.Dir(lexical)
-	missingParts := make([]string, 0, 4)
-	for {
-		canonicalParent, err := filepath.EvalSymlinks(parent)
-		if err == nil {
-			canonicalParent = filepath.Clean(canonicalParent)
-			if !withinHostRoot(canonicalParent, h.canonicalRoot) {
-				return "", stdfs.ErrPermission
-			}
-			target := canonicalParent
-			for i := len(missingParts) - 1; i >= 0; i-- {
-				target = filepath.Join(target, missingParts[i])
-			}
-			return filepath.Join(target, filepath.Base(lexical)), nil
-		}
-		if !os.IsNotExist(err) {
-			return "", err
-		}
-		if filepath.Clean(parent) == h.root {
-			if !withinHostRoot(h.canonicalRoot, h.canonicalRoot) {
-				return "", stdfs.ErrPermission
-			}
-			target := h.canonicalRoot
-			for i := len(missingParts) - 1; i >= 0; i-- {
-				target = filepath.Join(target, missingParts[i])
-			}
-			return filepath.Join(target, filepath.Base(lexical)), nil
-		}
-		missingParts = append(missingParts, filepath.Base(parent))
-		next := filepath.Dir(parent)
-		if next == parent {
-			return "", err
-		}
-		parent = next
-	}
 }
 
 func (h *ReadWriteFS) lexicalPath(abs string) string {

--- a/fs/readwrite_posix_test.go
+++ b/fs/readwrite_posix_test.go
@@ -114,6 +114,39 @@ func TestReadWriteFSMkdirAllCreatesNestedMissingParents(t *testing.T) {
 	}
 }
 
+func TestReadWriteFSMkfifoCreatesNamedPipe(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	fsys, err := NewReadWrite(ReadWriteOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewReadWrite() error = %v", err)
+	}
+
+	if err := fsys.MkdirAll(context.Background(), "/pipes", 0o755); err != nil {
+		t.Fatalf("MkdirAll(/pipes) error = %v", err)
+	}
+	if err := fsys.Mkfifo(context.Background(), "/pipes/events", 0o600); err != nil {
+		t.Fatalf("Mkfifo(/pipes/events) error = %v", err)
+	}
+
+	info, err := fsys.Lstat(context.Background(), "/pipes/events")
+	if err != nil {
+		t.Fatalf("Lstat(/pipes/events) error = %v", err)
+	}
+	if info.Mode()&stdfs.ModeNamedPipe == 0 {
+		t.Fatalf("Lstat(/pipes/events).Mode() = %v, want named pipe", info.Mode())
+	}
+
+	hostInfo, err := os.Lstat(filepath.Join(root, "pipes", "events"))
+	if err != nil {
+		t.Fatalf("os.Lstat(host pipe) error = %v", err)
+	}
+	if hostInfo.Mode()&stdfs.ModeNamedPipe == 0 {
+		t.Fatalf("os.Lstat(host pipe).Mode() = %v, want named pipe", hostInfo.Mode())
+	}
+}
+
 func TestReadWriteFSStatPreservesRawSysStat(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -331,6 +364,32 @@ func TestReadWriteFSDeniesWriteThroughSymlinkedParent(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(outsideRoot, "pwned.txt")); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("Stat(outside pwned.txt) error = %v, want not exist", statErr)
+	}
+}
+
+func TestReadWriteFSDeniesMkfifoThroughSymlinkedParent(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	outsideRoot := t.TempDir()
+
+	if err := os.Symlink(outsideRoot, filepath.Join(root, "escape")); err != nil {
+		t.Fatalf("Symlink(escape) error = %v", err)
+	}
+
+	fsys, err := NewReadWrite(ReadWriteOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewReadWrite() error = %v", err)
+	}
+
+	err = fsys.Mkfifo(context.Background(), "/escape/events", 0o600)
+	if err == nil {
+		t.Fatal("Mkfifo(/escape/events) error = nil, want permission")
+	}
+	if !errors.Is(err, stdfs.ErrPermission) {
+		t.Fatalf("Mkfifo(/escape/events) error = %v, want permission", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outsideRoot, "events")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("Stat(outside events) error = %v, want not exist", statErr)
 	}
 }
 

--- a/network/network.go
+++ b/network/network.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 )
@@ -179,12 +180,7 @@ func New(cfg *Config, opts ...Option) (*HTTPClient, error) {
 	}
 
 	client := &HTTPClient{
-		cfg: resolved,
-		doer: &http.Client{
-			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		},
+		cfg:      resolved,
 		resolver: net.DefaultResolver,
 	}
 	for _, opt := range opts {
@@ -192,7 +188,87 @@ func New(cfg *Config, opts ...Option) (*HTTPClient, error) {
 			opt(client)
 		}
 	}
+	if client.doer == nil {
+		client.doer = client.defaultDoer()
+	}
 	return client, nil
+}
+
+func (c *HTTPClient) defaultDoer() HTTPDoer {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                 nil,
+			DialContext:           c.dialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func (c *HTTPClient) dialContext(ctx context.Context, networkName, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+
+	ips, err := c.resolveDialIPs(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if c.cfg.denyPrivateRanges {
+		if slices.ContainsFunc(ips, isPrivateIP) {
+			return nil, &AccessDeniedError{URL: host, Reason: "host resolves to private or loopback IP"}
+		}
+	}
+
+	dialer := net.Dialer{KeepAlive: 30 * time.Second}
+	var lastErr error
+	for _, ip := range ips {
+		conn, err := dialer.DialContext(ctx, networkName, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+}
+
+func (c *HTTPClient) resolveDialIPs(ctx context.Context, host string) ([]net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return []net.IP{ip}, nil
+	}
+
+	addresses, err := c.lookupIPAddrs(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	ips := make([]net.IP, 0, len(addresses))
+	for _, address := range addresses {
+		if address.IP != nil {
+			ips = append(ips, address.IP)
+		}
+	}
+	if len(ips) == 0 {
+		return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+	}
+	return ips, nil
+}
+
+func (c *HTTPClient) lookupIPAddrs(ctx context.Context, host string) ([]net.IPAddr, error) {
+	resolver := c.resolver
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	return resolver.LookupIPAddr(ctx, host)
 }
 
 func resolveConfig(cfg *Config) (resolvedConfig, error) {
@@ -384,7 +460,7 @@ func (c *HTTPClient) checkPrivateHost(ctx context.Context, parsed *url.URL) erro
 		return nil
 	}
 
-	addresses, err := c.resolver.LookupIPAddr(ctx, host)
+	addresses, err := c.lookupIPAddrs(ctx, host)
 	if err != nil {
 		var dnsErr *net.DNSError
 		if errors.As(err, &dnsErr) && (dnsErr.IsNotFound || dnsErr.Err == "no such host") {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -7,7 +7,9 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -15,6 +17,23 @@ type resolverFunc func(context.Context, string) ([]net.IPAddr, error)
 
 func (fn resolverFunc) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
 	return fn(ctx, host)
+}
+
+type sequenceResolver struct {
+	mu        sync.Mutex
+	responses [][]net.IPAddr
+}
+
+func (r *sequenceResolver) LookupIPAddr(context.Context, string) ([]net.IPAddr, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.responses) == 0 {
+		return nil, &net.DNSError{Err: "no such host", IsNotFound: true}
+	}
+	response := r.responses[0]
+	r.responses = r.responses[1:]
+	return response, nil
 }
 
 type staticHTTPDoer struct{}
@@ -233,5 +252,83 @@ func TestClientBlocksPrivateRangesAfterDNSResolution(t *testing.T) {
 	_, err = client.Do(context.Background(), &Request{URL: "https://api.example.com/path"})
 	if !IsDenied(err) {
 		t.Fatalf("Do() error = %v, want denied error", err)
+	}
+}
+
+func TestClientBlocksPrivateRangesDuringDial(t *testing.T) {
+	t.Parallel()
+	client, err := New(&Config{
+		AllowedURLPrefixes: []string{"http://api.example.test:80"},
+		DenyPrivateRanges:  true,
+	}, WithResolver(&sequenceResolver{
+		responses: [][]net.IPAddr{
+			{{IP: net.ParseIP("93.184.216.34")}},
+			{{IP: net.ParseIP("127.0.0.1")}},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	_, err = client.Do(context.Background(), &Request{URL: "http://api.example.test:80/path"})
+	if !IsDenied(err) {
+		t.Fatalf("Do() error = %v, want denied error", err)
+	}
+}
+
+func TestClientIgnoresHostProxyEnvironment(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("backend"))
+	}))
+	defer backend.Close()
+
+	var mu sync.Mutex
+	proxyHit := false
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		proxyHit = true
+		mu.Unlock()
+		http.Error(w, "proxy", http.StatusBadGateway)
+	}))
+	defer proxy.Close()
+
+	t.Setenv("HTTP_PROXY", proxy.URL)
+	t.Setenv("http_proxy", proxy.URL)
+	t.Setenv("HTTPS_PROXY", proxy.URL)
+	t.Setenv("NO_PROXY", "")
+
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("Parse(%q) error = %v", backend.URL, err)
+	}
+	_, port, err := net.SplitHostPort(backendURL.Host)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q) error = %v", backendURL.Host, err)
+	}
+	allowedHost := net.JoinHostPort("allowed.example.test", port)
+
+	client, err := New(&Config{
+		AllowedURLPrefixes: []string{"http://" + allowedHost},
+		DenyPrivateRanges:  false,
+	}, WithResolver(resolverFunc(func(context.Context, string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, nil
+	})))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	resp, err := client.Do(context.Background(), &Request{URL: "http://" + allowedHost + "/via-default-transport"})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if got, want := string(resp.Body), "backend"; got != want {
+		t.Fatalf("Body = %q, want %q", got, want)
+	}
+
+	mu.Lock()
+	hit := proxyHit
+	mu.Unlock()
+	if hit {
+		t.Fatal("proxy server was used, want direct sandbox-controlled dial")
 	}
 }


### PR DESCRIPTION
## Summary

- close a host-path TOCTOU window in `ReadWriteFS.Mkfifo` by creating FIFOs relative to a resolved sandbox-confined parent directory handle
- install a sandbox-owned default HTTP transport that ignores host proxy environment variables and enforces private-range checks during the actual dial
- add regression coverage for the FIFO containment and network transport boundary cases
- update `SPEC.md` to document the hardened filesystem and network guarantees

## Security notes

This came out of a focused sandbox escape review. The filesystem issue was limited to explicit read-write host-backed filesystem mode, where `Mkfifo` used a checked absolute host path for the final host operation. The network issue affected enabled sandbox networking by letting Go's default transport consult ambient proxy configuration and perform its own dial-time resolution after preflight checks.

Scan artifacts from the local review are under `/tmp/codex-security-scans/gbash/79318321aa89_20260502T215553Z/`.

## Verification

- `go test ./fs ./network`
- `make test`
- `make lint`
- `git diff --check`
- cross-compiled the `./fs` test binary for linux, freebsd, netbsd, openbsd, dragonfly, solaris, and aix helper coverage
