### PR TITLE
xargs: warn when parallel execution is unavailable

### DIFF
--- a/internal/builtins/xargs.go
+++ b/internal/builtins/xargs.go
@@ -146,6 +146,9 @@ func (c *XArgs) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedC
 	if err != nil {
 		return err
 	}
+	if opts.maxProcs > 1 {
+		xargsWarn(inv, "warning: -P N>1 not supported in this build, running serially")
+	}
 
 	maxSupported := xargsMaxCharsLimit(inv.Env)
 	if opts.maxCharsSet && opts.maxChars > maxSupported {
@@ -492,7 +495,7 @@ func writeXArgsLimits(inv *Invocation, opts *xargsOptions) error {
 		xargsPosixArgMin,
 		usable,
 		opts.maxChars,
-		math.MaxInt32,
+		1,
 	)
 	return err
 }
@@ -882,9 +885,8 @@ func runXArgsTasksSequential(ctx context.Context, inv *Invocation, opts *xargsOp
 }
 
 func runXArgsTasksParallel(ctx context.Context, inv *Invocation, opts *xargsOptions, tasks []xargsTask) (int, error) {
-	// The current runtime subexec path is not safe for concurrent inv.Exec calls,
-	// so in the sandbox we preserve -P parsing and batching behavior but execute
-	// the resulting commands serially.
+	// RunParsed warns that the current runtime subexec path is not safe for
+	// concurrent inv.Exec calls. Preserve batching behavior and execute serially.
 	return runXArgsTasksSequential(ctx, inv, opts, tasks)
 }
 

--- a/internal/builtins/xargs.go
+++ b/internal/builtins/xargs.go
@@ -146,7 +146,9 @@ func (c *XArgs) RunParsed(ctx context.Context, inv *Invocation, matches *ParsedC
 	if err != nil {
 		return err
 	}
-	if opts.maxProcs > 1 {
+	if opts.maxProcs == 0 {
+		xargsWarn(inv, "warning: -P 0 not supported in this build, running serially")
+	} else if opts.maxProcs > 1 {
 		xargsWarn(inv, "warning: -P N>1 not supported in this build, running serially")
 	}
 

--- a/internal/builtins/xargs_test.go
+++ b/internal/builtins/xargs_test.go
@@ -268,8 +268,54 @@ func TestXArgsAcceptsMaxProcsFlag(t *testing.T) {
 	if got, want := result.Stdout, "one\ntwo\nthree\n"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
-	if got, want := result.Stderr, "xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value\n"; got != want {
+	if got, want := result.Stderr, "xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value\n"+
+		"xargs: warning: -P N>1 not supported in this build, running serially\n"; got != want {
 		t.Fatalf("Stderr = %q, want %q", got, want)
+	}
+}
+
+func TestXArgsWarnsWhenParallelExecutionIsRequested(t *testing.T) {
+	t.Parallel()
+
+	for _, maxProcs := range []string{"-P2", "--max-procs=2"} {
+		t.Run(maxProcs, func(t *testing.T) {
+			t.Parallel()
+			rt := newRuntime(t, &Config{})
+
+			result, err := rt.Run(context.Background(), &ExecutionRequest{
+				Script: "printf 'one\\ntwo\\n' | xargs " + maxProcs + " -n1 echo\n",
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if result.ExitCode != 0 {
+				t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+			}
+			if got, want := result.Stdout, "one\ntwo\n"; got != want {
+				t.Fatalf("Stdout = %q, want %q", got, want)
+			}
+			if got, want := result.Stderr, "xargs: warning: -P N>1 not supported in this build, running serially\n"; got != want {
+				t.Fatalf("Stderr = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestXArgsShowLimitsReportsSerialMaximum(t *testing.T) {
+	t.Parallel()
+	rt := newRuntime(t, &Config{})
+
+	result, err := rt.Run(context.Background(), &ExecutionRequest{
+		Script: "printf '' | xargs --show-limits --no-run-if-empty\n",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if !strings.Contains(result.Stderr, "Maximum parallelism (--max-procs must be no greater): 1\n") {
+		t.Fatalf("Stderr = %q, want serial maximum", result.Stderr)
 	}
 }
 
@@ -384,7 +430,7 @@ func TestXArgsSetsProcessSlotVar(t *testing.T) {
 	rt := newRuntime(t, &Config{})
 
 	result, err := rt.Run(context.Background(), &ExecutionRequest{
-		Script: "printf 'one\\ntwo\\n' | xargs -n1 --process-slot-var=SLOT sh -c 'printf \"%s:%s\\\\n\" \"$SLOT\" \"$1\"' _\n",
+		Script: "printf 'one\\ntwo\\n' | xargs -P2 -n1 --process-slot-var=SLOT sh -c 'printf \"%s:%s\\\\n\" \"$SLOT\" \"$1\"' _\n",
 	})
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
@@ -394,5 +440,8 @@ func TestXArgsSetsProcessSlotVar(t *testing.T) {
 	}
 	if got, want := result.Stdout, "0:one\n0:two\n"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+	if got, want := result.Stderr, "xargs: warning: -P N>1 not supported in this build, running serially\n"; got != want {
+		t.Fatalf("Stderr = %q, want %q", got, want)
 	}
 }

--- a/internal/builtins/xargs_test.go
+++ b/internal/builtins/xargs_test.go
@@ -277,13 +277,22 @@ func TestXArgsAcceptsMaxProcsFlag(t *testing.T) {
 func TestXArgsWarnsWhenParallelExecutionIsRequested(t *testing.T) {
 	t.Parallel()
 
-	for _, maxProcs := range []string{"-P2", "--max-procs=2"} {
-		t.Run(maxProcs, func(t *testing.T) {
+	tests := []struct {
+		maxProcs string
+		warning  string
+	}{
+		{maxProcs: "-P0", warning: "xargs: warning: -P 0 not supported in this build, running serially\n"},
+		{maxProcs: "--max-procs=0", warning: "xargs: warning: -P 0 not supported in this build, running serially\n"},
+		{maxProcs: "-P2", warning: "xargs: warning: -P N>1 not supported in this build, running serially\n"},
+		{maxProcs: "--max-procs=2", warning: "xargs: warning: -P N>1 not supported in this build, running serially\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.maxProcs, func(t *testing.T) {
 			t.Parallel()
 			rt := newRuntime(t, &Config{})
 
 			result, err := rt.Run(context.Background(), &ExecutionRequest{
-				Script: "printf 'one\\ntwo\\n' | xargs " + maxProcs + " -n1 echo\n",
+				Script: "printf 'one\\ntwo\\n' | xargs " + test.maxProcs + " -n1 echo\n",
 			})
 			if err != nil {
 				t.Fatalf("Run() error = %v", err)
@@ -294,7 +303,7 @@ func TestXArgsWarnsWhenParallelExecutionIsRequested(t *testing.T) {
 			if got, want := result.Stdout, "one\ntwo\n"; got != want {
 				t.Fatalf("Stdout = %q, want %q", got, want)
 			}
-			if got, want := result.Stderr, "xargs: warning: -P N>1 not supported in this build, running serially\n"; got != want {
+			if got, want := result.Stderr, test.warning; got != want {
 				t.Fatalf("Stderr = %q, want %q", got, want)
 			}
 		})


### PR DESCRIPTION
## Summary

- warn when `-P N` or `--max-procs=N` requests unsupported parallel execution
- continue running tasks serially instead of silently ignoring the option
- report a maximum parallelism of 1 from `--show-limits`
- cover short and long option forms plus serial process-slot behavior

Closes #836

## Testing

- `go test ./internal/builtins -run TestXArgs -count=1`
- `make lint`
- `make test` (fails in unrelated `TestFindSkipsUnresolvableRelativeSymlinksDuringTraversal`; the focused xargs tests pass)