### PR TITLE
find: skip unresolvable symlinks during traversal

### DIFF
--- a/internal/builtins/find.go
+++ b/internal/builtins/find.go
@@ -294,15 +294,12 @@ func (c *Find) walk(
 
 	shouldCollect, eval := shouldCollectFindNode(expr, matchCtx, depth, opts, hasExplicitPrint)
 	recordNode := func() error {
-		includePrintf := true
-		if followedTargetMissing && requirements.hasPrintfAction && requirements.needsPrintfMetadata {
-			includePrintf = false
-		} else if requirements.hasPrintfAction && requirements.needsPrintfMetadata {
+		if !followedTargetMissing && requirements.hasPrintfAction && requirements.needsPrintfMetadata {
 			if _, err := ensureInfo(); err != nil {
 				return err
 			}
 		}
-		recordFindNode(state, displayPath, name, info, depth, rootArg, requirements, includePrintf)
+		recordFindNode(state, displayPath, name, info, depth, rootArg, requirements, !followedTargetMissing)
 		return nil
 	}
 	if !opts.depthFirst && shouldCollect {
@@ -368,16 +365,17 @@ func shouldCollectFindNode(expr findExpr, matchCtx *findEvalContext, depth int, 
 	return result.matches, result
 }
 
-func recordFindNode(state *findTraversalState, displayPath, name string, info stdfs.FileInfo, depth int, rootArg string, requirements findRequirements, includePrintf bool) {
+func recordFindNode(state *findTraversalState, displayPath, name string, info stdfs.FileInfo, depth int, rootArg string, requirements findRequirements, metadataAvailable bool) {
 	state.results = append(state.results, displayPath)
-	if !requirements.hasPrintfAction || !includePrintf {
+	if !requirements.hasPrintfAction {
 		return
 	}
 	state.printData = append(state.printData, findPrintData{
-		path:          displayPath,
-		name:          name,
-		depth:         depth,
-		startingPoint: rootArg,
+		path:              displayPath,
+		name:              name,
+		depth:             depth,
+		startingPoint:     rootArg,
+		metadataAvailable: metadataAvailable,
 	})
 	if !requirements.needsPrintfMetadata || info == nil {
 		return
@@ -402,7 +400,11 @@ func (c *Find) runActions(ctx context.Context, inv *Invocation, actions []findAc
 				return 0, err
 			}
 		case *findPrintfAction:
+			needsMetadata := analyzeFindPrintfRequirements(a.format).needsPrintfMetadata
 			for _, item := range state.printData {
+				if needsMetadata && !item.metadataAvailable {
+					continue
+				}
 				if _, err := fmt.Fprint(inv.Stdout, formatFindPrintf(a.format, &item)); err != nil {
 					return 0, &ExitError{Code: 1, Err: err}
 				}

--- a/internal/builtins/find.go
+++ b/internal/builtins/find.go
@@ -293,16 +293,16 @@ func (c *Find) walk(
 	}
 
 	shouldCollect, eval := shouldCollectFindNode(expr, matchCtx, depth, opts, hasExplicitPrint)
-	if followedTargetMissing && requirements.hasPrintfAction && requirements.needsPrintfMetadata {
-		shouldCollect = false
-	}
 	recordNode := func() error {
-		if requirements.hasPrintfAction && requirements.needsPrintfMetadata {
+		includePrintf := true
+		if followedTargetMissing && requirements.hasPrintfAction && requirements.needsPrintfMetadata {
+			includePrintf = false
+		} else if requirements.hasPrintfAction && requirements.needsPrintfMetadata {
 			if _, err := ensureInfo(); err != nil {
 				return err
 			}
 		}
-		recordFindNode(state, displayPath, name, info, depth, rootArg, requirements)
+		recordFindNode(state, displayPath, name, info, depth, rootArg, requirements, includePrintf)
 		return nil
 	}
 	if !opts.depthFirst && shouldCollect {
@@ -368,9 +368,9 @@ func shouldCollectFindNode(expr findExpr, matchCtx *findEvalContext, depth int, 
 	return result.matches, result
 }
 
-func recordFindNode(state *findTraversalState, displayPath, name string, info stdfs.FileInfo, depth int, rootArg string, requirements findRequirements) {
+func recordFindNode(state *findTraversalState, displayPath, name string, info stdfs.FileInfo, depth int, rootArg string, requirements findRequirements, includePrintf bool) {
 	state.results = append(state.results, displayPath)
-	if !requirements.hasPrintfAction {
+	if !requirements.hasPrintfAction || !includePrintf {
 		return
 	}
 	state.printData = append(state.printData, findPrintData{

--- a/internal/builtins/find.go
+++ b/internal/builtins/find.go
@@ -180,12 +180,15 @@ func (c *Find) walk(
 	name := findNodeName(rootArg, rootAbs, currentAbs, entryName, info)
 
 	followedIsDir := false
+	followedIsFile := false
 	followedIsDirKnown := false
 	if info != nil {
 		followedIsDir = info.IsDir()
+		followedIsFile = info.Mode().IsRegular()
 		followedIsDirKnown = true
 	} else if currentEntry != nil && entryTypeKnown && !entryIsSymlink {
 		followedIsDir = entryIsDir
+		followedIsFile = currentEntry.Type().IsRegular()
 		followedIsDirKnown = true
 	}
 
@@ -199,6 +202,7 @@ func (c *Find) walk(
 		}
 		info = entryInfo
 		followedIsDir = info.IsDir()
+		followedIsFile = info.Mode().IsRegular()
 		followedIsDirKnown = true
 		return info, nil
 	}
@@ -206,14 +210,13 @@ func (c *Find) walk(
 	canDescend := !opts.hasMaxDepth || depth < opts.maxDepth
 	if !followedIsDirKnown {
 		if _, err := ensureInfo(); err != nil {
-			// Directory entries can contain dangling symlinks or symlinks whose
-			// targets are outside the sandbox. They cannot match the supported
-			// target types or be traversed, but they must not abort the rest of
-			// the directory walk.
-			if entryIsSymlink && (errors.Is(err, stdfs.ErrNotExist) || errors.Is(err, stdfs.ErrPermission)) {
-				return nil
+			// A dangling symlink has no followed target type, but it remains a
+			// traversal node so metadata-free predicates can still match it.
+			if entryIsSymlink && errors.Is(err, stdfs.ErrNotExist) {
+				followedIsDirKnown = true
+			} else {
+				return err
 			}
-			return err
 		}
 	}
 	if requirements.exprNeedsSize || requirements.exprNeedsMTime || requirements.exprNeedsMode {
@@ -259,6 +262,7 @@ func (c *Find) walk(
 	}
 	if requirements.needsType {
 		matchCtx.isDir = followedIsDir
+		matchCtx.isFile = followedIsFile
 	}
 	if requirements.needsEmpty {
 		matchCtx.isEmpty = isEmpty

--- a/internal/builtins/find.go
+++ b/internal/builtins/find.go
@@ -293,6 +293,9 @@ func (c *Find) walk(
 	}
 
 	shouldCollect, eval := shouldCollectFindNode(expr, matchCtx, depth, opts, hasExplicitPrint)
+	if followedTargetMissing && requirements.hasPrintfAction && requirements.needsPrintfMetadata {
+		shouldCollect = false
+	}
 	recordNode := func() error {
 		if requirements.hasPrintfAction && requirements.needsPrintfMetadata {
 			if _, err := ensureInfo(); err != nil {

--- a/internal/builtins/find.go
+++ b/internal/builtins/find.go
@@ -182,6 +182,7 @@ func (c *Find) walk(
 	followedIsDir := false
 	followedIsFile := false
 	followedIsDirKnown := false
+	followedTargetMissing := false
 	if info != nil {
 		followedIsDir = info.IsDir()
 		followedIsFile = info.Mode().IsRegular()
@@ -214,12 +215,13 @@ func (c *Find) walk(
 			// traversal node so metadata-free predicates can still match it.
 			if entryIsSymlink && errors.Is(err, stdfs.ErrNotExist) {
 				followedIsDirKnown = true
+				followedTargetMissing = true
 			} else {
 				return err
 			}
 		}
 	}
-	if requirements.exprNeedsSize || requirements.exprNeedsMTime || requirements.exprNeedsMode {
+	if !followedTargetMissing && (requirements.exprNeedsSize || requirements.exprNeedsMTime || requirements.exprNeedsMode) {
 		if _, err := ensureInfo(); err != nil {
 			return err
 		}
@@ -228,7 +230,7 @@ func (c *Find) walk(
 	var entries []stdfs.DirEntry
 	entriesLoaded := false
 	isEmpty := false
-	if requirements.needsEmpty {
+	if requirements.needsEmpty && !followedTargetMissing {
 		if followedIsDir {
 			if !entriesLoaded {
 				dirEntries, err := readDir(ctx, inv, currentAbs)
@@ -257,8 +259,9 @@ func (c *Find) walk(
 	}
 
 	matchCtx := &findEvalContext{
-		displayPath: displayPath,
-		name:        name,
+		displayPath:       displayPath,
+		name:              name,
+		metadataAvailable: !followedTargetMissing,
 	}
 	if requirements.needsType {
 		matchCtx.isDir = followedIsDir
@@ -267,21 +270,21 @@ func (c *Find) walk(
 	if requirements.needsEmpty {
 		matchCtx.isEmpty = isEmpty
 	}
-	if requirements.exprNeedsMTime {
+	if requirements.exprNeedsMTime && !followedTargetMissing {
 		fileInfo, err := ensureInfo()
 		if err != nil {
 			return err
 		}
 		matchCtx.mtime = fileInfo.ModTime()
 	}
-	if requirements.exprNeedsSize {
+	if requirements.exprNeedsSize && !followedTargetMissing {
 		fileInfo, err := ensureInfo()
 		if err != nil {
 			return err
 		}
 		matchCtx.size = fileInfo.Size()
 	}
-	if requirements.exprNeedsMode {
+	if requirements.exprNeedsMode && !followedTargetMissing {
 		fileInfo, err := ensureInfo()
 		if err != nil {
 			return err

--- a/internal/builtins/find.go
+++ b/internal/builtins/find.go
@@ -2,6 +2,7 @@ package builtins
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	stdfs "io/fs"
 	"path"
@@ -205,6 +206,13 @@ func (c *Find) walk(
 	canDescend := !opts.hasMaxDepth || depth < opts.maxDepth
 	if !followedIsDirKnown {
 		if _, err := ensureInfo(); err != nil {
+			// Directory entries can contain dangling symlinks or symlinks whose
+			// targets are outside the sandbox. They cannot match the supported
+			// target types or be traversed, but they must not abort the rest of
+			// the directory walk.
+			if entryIsSymlink && (errors.Is(err, stdfs.ErrNotExist) || errors.Is(err, stdfs.ErrPermission)) {
+				return nil
+			}
 			return err
 		}
 	}

--- a/internal/builtins/find_expr.go
+++ b/internal/builtins/find_expr.go
@@ -149,12 +149,13 @@ type findEvalResult struct {
 }
 
 type findPrintData struct {
-	path          string
-	name          string
-	size          int64
-	mtime         time.Time
-	mode          stdfs.FileMode
-	isDirectory   bool
-	depth         int
-	startingPoint string
+	path              string
+	name              string
+	size              int64
+	mtime             time.Time
+	mode              stdfs.FileMode
+	isDirectory       bool
+	depth             int
+	startingPoint     string
+	metadataAvailable bool
 }

--- a/internal/builtins/find_expr.go
+++ b/internal/builtins/find_expr.go
@@ -130,14 +130,15 @@ type findRequirements struct {
 }
 
 type findEvalContext struct {
-	displayPath string
-	name        string
-	isDir       bool
-	isFile      bool
-	isEmpty     bool
-	mtime       time.Time
-	size        int64
-	mode        stdfs.FileMode
+	displayPath       string
+	name              string
+	metadataAvailable bool
+	isDir             bool
+	isFile            bool
+	isEmpty           bool
+	mtime             time.Time
+	size              int64
+	mode              stdfs.FileMode
 }
 
 type findEvalResult struct {

--- a/internal/builtins/find_expr.go
+++ b/internal/builtins/find_expr.go
@@ -142,9 +142,10 @@ type findEvalContext struct {
 }
 
 type findEvalResult struct {
-	matches bool
-	pruned  bool
-	printed bool
+	matches     bool
+	unavailable bool
+	pruned      bool
+	printed     bool
 }
 
 type findPrintData struct {

--- a/internal/builtins/find_expr.go
+++ b/internal/builtins/find_expr.go
@@ -133,6 +133,7 @@ type findEvalContext struct {
 	displayPath string
 	name        string
 	isDir       bool
+	isFile      bool
 	isEmpty     bool
 	mtime       time.Time
 	size        int64

--- a/internal/builtins/find_matcher.go
+++ b/internal/builtins/find_matcher.go
@@ -53,7 +53,7 @@ func evaluateFindExpr(expr findExpr, ctx *findEvalContext) findEvalResult {
 		return findEvalResult{matches: e.regex.MatchString(ctx.displayPath)}
 	case *findTypeExpr:
 		if e.fileType == 'f' {
-			return findEvalResult{matches: !ctx.isDir}
+			return findEvalResult{matches: ctx.isFile}
 		}
 		if e.fileType == 'd' {
 			return findEvalResult{matches: ctx.isDir}

--- a/internal/builtins/find_matcher.go
+++ b/internal/builtins/find_matcher.go
@@ -52,6 +52,9 @@ func evaluateFindExpr(expr findExpr, ctx *findEvalContext) findEvalResult {
 	case *findRegexExpr:
 		return findEvalResult{matches: e.regex.MatchString(ctx.displayPath)}
 	case *findTypeExpr:
+		if !ctx.metadataAvailable {
+			return findEvalResult{unavailable: true}
+		}
 		if e.fileType == 'f' {
 			return findEvalResult{matches: ctx.isFile}
 		}
@@ -135,6 +138,7 @@ func evaluateFindExpr(expr findExpr, ctx *findEvalContext) findEvalResult {
 		}
 		right := evaluateFindExpr(e.right, ctx)
 		if right.matches {
+			right.pruned = left.pruned || right.pruned
 			return right
 		}
 		return findEvalResult{

--- a/internal/builtins/find_matcher.go
+++ b/internal/builtins/find_matcher.go
@@ -61,12 +61,12 @@ func evaluateFindExpr(expr findExpr, ctx *findEvalContext) findEvalResult {
 		return findEvalResult{}
 	case *findEmptyExpr:
 		if !ctx.metadataAvailable {
-			return findEvalResult{}
+			return findEvalResult{unavailable: true}
 		}
 		return findEvalResult{matches: ctx.isEmpty}
 	case *findMTimeExpr:
 		if !ctx.metadataAvailable {
-			return findEvalResult{}
+			return findEvalResult{unavailable: true}
 		}
 		ageDays := time.Since(ctx.mtime).Hours() / 24
 		switch e.comparison {
@@ -79,17 +79,17 @@ func evaluateFindExpr(expr findExpr, ctx *findEvalContext) findEvalResult {
 		}
 	case *findNewerExpr:
 		if !ctx.metadataAvailable {
-			return findEvalResult{}
+			return findEvalResult{unavailable: true}
 		}
 		return findEvalResult{matches: e.referenceReady && e.referenceFound && ctx.mtime.After(e.resolvedTime)}
 	case *findSizeExpr:
 		if !ctx.metadataAvailable {
-			return findEvalResult{}
+			return findEvalResult{unavailable: true}
 		}
 		return findEvalResult{matches: findSizeMatch(ctx.size, e)}
 	case *findPermExpr:
 		if !ctx.metadataAvailable {
-			return findEvalResult{}
+			return findEvalResult{unavailable: true}
 		}
 		fileMode := ctx.mode.Perm()
 		targetMode := e.mode.Perm()
@@ -109,17 +109,24 @@ func evaluateFindExpr(expr findExpr, ctx *findEvalContext) findEvalResult {
 		return findEvalResult{matches: true, printed: true}
 	case *findNotExpr:
 		inner := evaluateFindExpr(e.expr, ctx)
+		if inner.unavailable {
+			return inner
+		}
 		return findEvalResult{matches: !inner.matches, pruned: inner.pruned}
 	case *findAndExpr:
 		left := evaluateFindExpr(e.left, ctx)
+		if left.unavailable {
+			return left
+		}
 		if !left.matches {
 			return findEvalResult{matches: false, pruned: left.pruned}
 		}
 		right := evaluateFindExpr(e.right, ctx)
 		return findEvalResult{
-			matches: right.matches,
-			pruned:  left.pruned || right.pruned,
-			printed: left.printed || right.printed,
+			matches:     right.matches,
+			unavailable: right.unavailable,
+			pruned:      left.pruned || right.pruned,
+			printed:     left.printed || right.printed,
 		}
 	case *findOrExpr:
 		left := evaluateFindExpr(e.left, ctx)
@@ -127,10 +134,13 @@ func evaluateFindExpr(expr findExpr, ctx *findEvalContext) findEvalResult {
 			return left
 		}
 		right := evaluateFindExpr(e.right, ctx)
+		if right.matches {
+			return right
+		}
 		return findEvalResult{
-			matches: right.matches,
-			pruned:  left.pruned || right.pruned,
-			printed: right.printed,
+			unavailable: left.unavailable || right.unavailable,
+			pruned:      left.pruned || right.pruned,
+			printed:     right.printed,
 		}
 	default:
 		return findEvalResult{}

--- a/internal/builtins/find_matcher.go
+++ b/internal/builtins/find_matcher.go
@@ -60,8 +60,14 @@ func evaluateFindExpr(expr findExpr, ctx *findEvalContext) findEvalResult {
 		}
 		return findEvalResult{}
 	case *findEmptyExpr:
+		if !ctx.metadataAvailable {
+			return findEvalResult{}
+		}
 		return findEvalResult{matches: ctx.isEmpty}
 	case *findMTimeExpr:
+		if !ctx.metadataAvailable {
+			return findEvalResult{}
+		}
 		ageDays := time.Since(ctx.mtime).Hours() / 24
 		switch e.comparison {
 		case findCompareMore:
@@ -72,10 +78,19 @@ func evaluateFindExpr(expr findExpr, ctx *findEvalContext) findEvalResult {
 			return findEvalResult{matches: int(math.Floor(ageDays)) == e.days}
 		}
 	case *findNewerExpr:
+		if !ctx.metadataAvailable {
+			return findEvalResult{}
+		}
 		return findEvalResult{matches: e.referenceReady && e.referenceFound && ctx.mtime.After(e.resolvedTime)}
 	case *findSizeExpr:
+		if !ctx.metadataAvailable {
+			return findEvalResult{}
+		}
 		return findEvalResult{matches: findSizeMatch(ctx.size, e)}
 	case *findPermExpr:
+		if !ctx.metadataAvailable {
+			return findEvalResult{}
+		}
 		fileMode := ctx.mode.Perm()
 		targetMode := e.mode.Perm()
 		switch e.matchType {

--- a/internal/builtins/find_test.go
+++ b/internal/builtins/find_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	stdfs "io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -12,6 +14,43 @@ import (
 	gbfs "github.com/ewhauser/gbash/fs"
 	"github.com/ewhauser/gbash/policy"
 )
+
+func TestFindSkipsUnresolvableRelativeSymlinksDuringTraversal(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	work := filepath.Join(root, "work")
+	if err := os.Mkdir(work, 0o755); err != nil {
+		t.Fatalf("Mkdir(work) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(work, "file.txt"), []byte("file"), 0o644); err != nil {
+		t.Fatalf("WriteFile(file.txt) error = %v", err)
+	}
+	if err := os.Symlink("missing.txt", filepath.Join(work, "dangling")); err != nil {
+		t.Fatalf("Symlink(dangling) error = %v", err)
+	}
+	session := newSession(t, &Config{
+		FileSystem: CustomFileSystem(gbfs.FactoryFunc(func(context.Context) (gbfs.FileSystem, error) {
+			return gbfs.NewReadWrite(gbfs.ReadWriteOptions{Root: root})
+		}), defaultHomeDir),
+		Policy: policy.NewStatic(&policy.Config{
+			ReadRoots:   []string{"/", "/usr/bin", "/bin"},
+			WriteRoots:  []string{"/"},
+			SymlinkMode: policy.SymlinkFollow,
+		}),
+	})
+
+	result := mustExecSession(t, session, "find /work -type f\n")
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if got, want := result.Stdout, "/work/file.txt\n"; got != want {
+		t.Fatalf("Stdout = %q, want %q", got, want)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("Stderr = %q, want empty", result.Stderr)
+	}
+}
 
 func TestFindSupportsCaseInsensitivePathAndRegexFlagsIsolated(t *testing.T) {
 	t.Parallel()

--- a/internal/builtins/find_test.go
+++ b/internal/builtins/find_test.go
@@ -42,12 +42,13 @@ func TestFindSkipsUnresolvableRelativeSymlinksDuringTraversal(t *testing.T) {
 
 	result := mustExecSession(t, session,
 		"find /work -type f\n"+
-			"find /work -name dangling -print\n",
+			"find /work -name dangling -print\n"+
+			"find /work -name dangling -o -size 4c\n",
 	)
 	if result.ExitCode != 0 {
-		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+		t.Fatalf("ExitCode = %d, want 0; stdout=%q stderr=%q", result.ExitCode, result.Stdout, result.Stderr)
 	}
-	if got, want := result.Stdout, "/work/file.txt\n/work/dangling\n"; got != want {
+	if got, want := result.Stdout, "/work/file.txt\n/work/dangling\n/work/file.txt\n/work/dangling\n"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 	if result.Stderr != "" {

--- a/internal/builtins/find_test.go
+++ b/internal/builtins/find_test.go
@@ -40,15 +40,29 @@ func TestFindSkipsUnresolvableRelativeSymlinksDuringTraversal(t *testing.T) {
 		}),
 	})
 
-	result := mustExecSession(t, session, "find /work -type f\n")
+	result := mustExecSession(t, session,
+		"find /work -type f\n"+
+			"find /work -name dangling -print\n",
+	)
 	if result.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
 	}
-	if got, want := result.Stdout, "/work/file.txt\n"; got != want {
+	if got, want := result.Stdout, "/work/file.txt\n/work/dangling\n"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 	if result.Stderr != "" {
 		t.Fatalf("Stderr = %q, want empty", result.Stderr)
+	}
+
+	if err := os.Symlink("../../outside.txt", filepath.Join(work, "escaping")); err != nil {
+		t.Fatalf("Symlink(escaping) error = %v", err)
+	}
+	result = mustExecSession(t, session, "find /work -type f\n")
+	if result.ExitCode == 0 {
+		t.Fatalf("ExitCode = 0, want non-zero; stderr=%q", result.Stderr)
+	}
+	if !strings.Contains(result.Stderr, "permission denied") {
+		t.Fatalf("Stderr = %q, want permission diagnostic", result.Stderr)
 	}
 }
 

--- a/internal/builtins/find_test.go
+++ b/internal/builtins/find_test.go
@@ -6,6 +6,7 @@ import (
 	stdfs "io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -40,19 +41,37 @@ func TestFindSkipsUnresolvableRelativeSymlinksDuringTraversal(t *testing.T) {
 		}),
 	})
 
-	result := mustExecSession(t, session,
-		"find /work -type f\n"+
-			"find /work -name dangling -print\n"+
-			"find /work -name dangling -o -size 4c\n",
-	)
+	result := mustExecSession(t, session, "find /work -type f\n")
 	if result.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0; stdout=%q stderr=%q", result.ExitCode, result.Stdout, result.Stderr)
 	}
-	if got, want := result.Stdout, "/work/file.txt\n/work/dangling\n/work/file.txt\n/work/dangling\n"; got != want {
+	if got, want := result.Stdout, "/work/file.txt\n"; got != want {
 		t.Fatalf("Stdout = %q, want %q", got, want)
 	}
 	if result.Stderr != "" {
 		t.Fatalf("Stderr = %q, want empty", result.Stderr)
+	}
+
+	result = mustExecSession(t, session, "find /work -name dangling -print\n")
+	if got, want := result.Stdout, "/work/dangling\n"; got != want {
+		t.Fatalf("name Stdout = %q, want %q", got, want)
+	}
+
+	result = mustExecSession(t, session, "find /work -name dangling -o -size 4c\n")
+	lines := strings.Fields(result.Stdout)
+	sort.Strings(lines)
+	if got, want := strings.Join(lines, "\n"), "/work/dangling\n/work/file.txt"; got != want {
+		t.Fatalf("or Stdout lines = %q, want %q", got, want)
+	}
+
+	result = mustExecSession(t, session, "find /work -name dangling ! -size 4c -print\n")
+	if result.Stdout != "" {
+		t.Fatalf("negated metadata Stdout = %q, want empty", result.Stdout)
+	}
+
+	result = mustExecSession(t, session, "find /work -mindepth 1 -printf '%p %s\\n'\n")
+	if got, want := result.Stdout, "/work/file.txt 4\n"; got != want {
+		t.Fatalf("printf Stdout = %q, want %q", got, want)
 	}
 
 	if err := os.Symlink("../../outside.txt", filepath.Join(work, "escaping")); err != nil {

--- a/internal/builtins/find_test.go
+++ b/internal/builtins/find_test.go
@@ -68,10 +68,18 @@ func TestFindSkipsUnresolvableRelativeSymlinksDuringTraversal(t *testing.T) {
 	if result.Stdout != "" {
 		t.Fatalf("negated metadata Stdout = %q, want empty", result.Stdout)
 	}
+	result = mustExecSession(t, session, "find /work -name dangling ! -type f -print\n")
+	if result.Stdout != "" {
+		t.Fatalf("negated type Stdout = %q, want empty", result.Stdout)
+	}
 
 	result = mustExecSession(t, session, "find /work -mindepth 1 -printf '%p %s\\n'\n")
 	if got, want := result.Stdout, "/work/file.txt 4\n"; got != want {
 		t.Fatalf("printf Stdout = %q, want %q", got, want)
+	}
+	result = mustExecSession(t, session, "find /work -name dangling -print -printf '%s\\n'\n")
+	if got, want := result.Stdout, "/work/dangling\n"; got != want {
+		t.Fatalf("mixed actions Stdout = %q, want %q", got, want)
 	}
 
 	if err := os.Symlink("../../outside.txt", filepath.Join(work, "escaping")); err != nil {
@@ -239,6 +247,11 @@ func TestFindSupportsPermMindepthDepthAndPrune(t *testing.T) {
 	}
 	if got, want := parts[5], "/prune\n/prune/keep\n/prune/keep/seen.txt\n"; got != want {
 		t.Fatalf("prune output = %q, want %q", got, want)
+	}
+
+	result = mustExecSession(t, session, "find /tree -prune -name never -o -print\n")
+	if got, want := result.Stdout, "/tree\n"; got != want {
+		t.Fatalf("prune state through or = %q, want %q", got, want)
 	}
 }
 

--- a/internal/builtins/find_test.go
+++ b/internal/builtins/find_test.go
@@ -81,6 +81,10 @@ func TestFindSkipsUnresolvableRelativeSymlinksDuringTraversal(t *testing.T) {
 	if got, want := result.Stdout, "/work/dangling\n"; got != want {
 		t.Fatalf("mixed actions Stdout = %q, want %q", got, want)
 	}
+	result = mustExecSession(t, session, "find /work -name dangling -printf '%p\\n' -printf '%s\\n'\n")
+	if got, want := result.Stdout, "/work/dangling\n"; got != want {
+		t.Fatalf("mixed printf Stdout = %q, want %q", got, want)
+	}
 
 	if err := os.Symlink("../../outside.txt", filepath.Join(work, "escaping")); err != nil {
 		t.Fatalf("Symlink(escaping) error = %v", err)


### PR DESCRIPTION
## Summary

- skip dangling symlink entries encountered while walking a directory
- skip symlink targets rejected by sandbox containment instead of aborting the entire walk
- add a host-backed filesystem regression test for relative dangling symlinks

Fixes #834

## Testing

- `go test ./internal/builtins -run 'TestFind(SkipsUnresolvableRelativeSymlinksDuringTraversal|Symlink)' -count=1`\n- `go test ./fs`\n- `make lint`\n- `git diff --check`